### PR TITLE
[monitors] Convert ProbeFrame to DynamicLoc and change probe signature

### DIFF
--- a/src/engine/Execute.v3
+++ b/src/engine/Execute.v3
@@ -69,19 +69,21 @@ component Execute {
 		Trace.OUT.put2("callHost(\"%q\": %q)", hf.render, hf.sig.render).outln();
 	}
 	// Fires probes on the global interpreter loop
-	def fireProbes(func: WasmFunction, pc: int, frame: TargetFrame) -> AbruptReturn {
-		var r = Execute.probes.fire(func, pc, frame);
+	def fireProbes(dynamicLoc: DynamicLoc) -> AbruptReturn {
+		var r = Execute.probes.fire(dynamicLoc);
 		return resume(r);
 	}
 	// Fires probes on a specific instruction
-	def fireProbesAt(func: WasmFunction, pc: int, frame: TargetFrame) -> AbruptReturn {
+	def fireProbesAt(dynamicLoc: DynamicLoc) -> AbruptReturn {
+		var func = dynamicLoc.func;
+		var pc = dynamicLoc.pc;
 		var probes = func.instance.module.probes;
 		if (probes == null) return null;
 		var map = probes[func.decl.func_index];
 		if (map == null) return null;
 		var list = map[pc];
 		if (list == null) return null;
-		var r = list.fire(func, pc, frame);
+		var r = list.fire(dynamicLoc);
 		if (list.elem == null) map[pc] = null;
 		return resume(r);
 	}

--- a/src/engine/Probe.v3
+++ b/src/engine/Probe.v3
@@ -5,10 +5,10 @@
 // instruction is executed.
 class Probe {
 	// Called when reaching a probe (e.g. before executing an instruction).
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption { return Resumption.Continue; }
+	def fire(dynamicLoc: DynamicLoc) -> Resumption { return Resumption.Continue; }
 }
 
-type ProbeFrame(func: WasmFunction, pc: int, frame: TargetFrame) #unboxed { }
+type DynamicLoc(func: WasmFunction, pc: int, frame: TargetFrame) #unboxed { }
 
 // An object which provides access to the state of an executing frame.
 // A {FrameAccessor} is a stateful object that is materialized lazily by calling {TargetFrame.getAccessor()}
@@ -28,7 +28,8 @@ class FrameAccessor {
 	// Returns the call depth of this frame within its segment, with the bottom frame being #0.
 	def depth() -> int;
 	// Get the caller frame. If none, then {Frame.func} will be {null}.
-	def caller() -> ProbeFrame;
+	// TODO: Convert to CallerFrame that supports host function locations too.
+	def caller() -> DynamicLoc;
 	// Get the number of local variables in this frame.
 	def numLocals() -> int;
 	// Get the value of local variable {i}.
@@ -89,12 +90,12 @@ class ProbeList {
 	}
 	// Fire all probes in this list. Defers reentrant changes until after the last probe
 	// has fired. If any probe traps, rather than continuing, the last trap is returned.
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		var prev = defer; // handle reentrant fire()
 		defer = true;
 		var result: Resumption = Resumption.Continue;
 		for (e = elem; e != null; e = e.next) {
-			var r = e.probe.fire(func, pc, frame);
+			var r = e.probe.fire(dynamicLoc);
 			if (r != Resumption.Continue) result = r;
 		}
 		defer = prev;
@@ -120,7 +121,7 @@ class ProbeElem(probe: Probe) {
 }
 // Utility class to implement timeouts.
 class TimeoutProbe(var count: int) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		if (--count <= 0) return Resumption.Trap(TrapReason.TIMEOUT, true);
 		return Resumption.Continue;
 	}
@@ -128,14 +129,14 @@ class TimeoutProbe(var count: int) extends Probe {
 // Utility class to count calls to {fire()}.
 class CountProbe extends Probe {
 	var count = 0;
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		count++;
 		return Resumption.Continue;
 	}
 }
 // Utility class to implement a callback upon {fire()} without needing to extend {Probe}.
 class ClosureProbe<P, R>(f: P -> R, param: P) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		f(param);
 		return Resumption.Continue;
 	}
@@ -146,12 +147,14 @@ class TraceProbe extends Probe {
 	def tracer = InstrTracer.new();
 	def codeptr = DataReader.new([]);
 
-	def fire(func: WasmFunction, offset: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var func = dynamicLoc.func;
+		var offset = dynamicLoc.pc;
 		codeptr.reset(func.decl.cur_bytecode, offset, func.decl.cur_bytecode.length);
 		var module = if(func.instance != null, func.instance.module);
 		var out = Trace.OUT;
 		var len = out.length;
-		var accessor = frame.getFrameAccessor();
+		var accessor = dynamicLoc.frame.getFrameAccessor();
 		out.pad(' ', len + 2 * accessor.depth());
 		out.putc('+').putd(offset).puts(": ");
 

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -24,14 +24,14 @@ component V3Interpreter {
 		// Keep executing bytecodes while there is a top frame
 		while (call_stack.top > prev_top) {
 			if (E.probes != null) {
-				var ret = E.fireProbes(frame.func, frame.pc, TargetFrame(frame));
+				var ret = E.fireProbes(DynamicLoc(frame.func, frame.pc, TargetFrame(frame)));
 				if (ret != null) return finish(ret);
 			}
 			var pc = codeptr.pos;
 			var b = codeptr.peek1();
 			var opcode: Opcode;
 			if (b == InternalOpcode.PROBE.code) {
-				var ret = Execute.fireProbesAt(frame.func, pc, TargetFrame(frame));
+				var ret = Execute.fireProbesAt(DynamicLoc(frame.func, pc, TargetFrame(frame)));
 				if (ret != null) return finish(ret);
 				opcode = codeptr.read_orig_opcode(frame.func.decl.orig_bytecode[pc]);
 			} else {
@@ -1358,10 +1358,17 @@ class V3FrameAccessor(frame: V3Frame) extends FrameAccessor {
 		return 0; // TODO: not found. error?
 	}
 	// Get the caller frame. If none, then {Frame.func} will be {null}.
-	def caller() -> ProbeFrame {
+	def caller() -> DynamicLoc {
 		checkNotUnwound();
-		if (cached_caller == null) ; // TODO
-		return ProbeFrame(cached_caller.func, cached_caller.pc, TargetFrame(cached_caller));
+		if (cached_caller == null) {
+			var depth = depth();
+			if (depth == 0) {
+				return DynamicLoc(null, 0, TargetFrame(null));
+			} else {
+				cached_caller = V3Interpreter.call_stack.elems[depth - 1];
+			}
+		}
+		return DynamicLoc(cached_caller.func, cached_caller.pc, TargetFrame(cached_caller));
 	}
 	// Get the number of local variables in this frame.
 	def numLocals() -> int {

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -227,13 +227,13 @@ component X86_64Runtime {
 	}
 	def runtime_PROBE_loop(func: WasmFunction, pc: int) -> AbruptReturn {
 		var frame = TargetFrame(CiRuntime.callerSp());
-		var ret = Execute.fireProbes(func, pc, frame);
+		var ret = Execute.fireProbes(DynamicLoc(func, pc, frame));
 		if (Trap.?(ret)) return prependFrames(Trap.!(ret), null, CiRuntime.callerSp());
 		return ret;
 	}
 	def runtime_PROBE_instr(func: WasmFunction, pc: int) -> AbruptReturn {
 		var frame = TargetFrame(CiRuntime.callerSp());
-		var ret = Execute.fireProbesAt(func, pc, frame);
+		var ret = Execute.fireProbesAt(DynamicLoc(func, pc, frame));
 		if (Trap.?(ret)) return prependFrames(Trap.!(ret), null, CiRuntime.callerSp());
 		return ret;
 	}
@@ -427,13 +427,13 @@ class X86_64BaseFrameAccessor(sp: Pointer) extends FrameAccessor {
 		return 0;
 	}
 	// Get the caller frame. If none, then {Frame.func} will be {null}.
-	def caller() -> ProbeFrame {
+	def caller() -> DynamicLoc {
 		checkNotUnwound();
 		var callerSp = sp + IVarConfig.frame.size + Pointer.SIZE;
 		var frame = TargetFrame(callerSp);
 		var accessor = frame.getFrameAccessor();
-		if (accessor == null) return ProbeFrame(null, -1, frame);
-		return ProbeFrame(accessor.func(), accessor.pc(), frame);
+		if (accessor == null) return DynamicLoc(null, -1, frame);
+		return DynamicLoc(accessor.func(), accessor.pc(), frame);
 	}
 	// Get the number of local variables in this frame.
 	def numLocals() -> int {

--- a/src/monitors/BranchMonitor.v3
+++ b/src/monitors/BranchMonitor.v3
@@ -81,8 +81,8 @@ class BranchMonitor extends Monitor {
 }
 
 class BranchMonitorProbe(taken: Array<u64>) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		var accessor = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var accessor = dynamicLoc.frame.getFrameAccessor();
 		var condition = accessor.getOperand(0);
 		var taken = Values.v_i(condition) != 0;
 		var index = if(taken, 1, 0);
@@ -91,8 +91,8 @@ class BranchMonitorProbe(taken: Array<u64>) extends Probe {
 	}
 }
 class BranchMonitorBranchTableProbe(taken: Array<u64>) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		var accessor = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var accessor = dynamicLoc.frame.getFrameAccessor();
 		var numBranches = taken.length;
 		var condition = accessor.getOperand(0);
 		var takenBranch = Values.v_i(condition);

--- a/src/monitors/CallsMonitor.v3
+++ b/src/monitors/CallsMonitor.v3
@@ -30,16 +30,16 @@ class CallsMonitor extends Monitor {
 	}
 }
 class CallsMonitorEnterProbe(m: CallsMonitor) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		for (i < m.depth) Trace.OUT.puts("  ");
 		m.depth++;
-		func.render(Trace.OUT);
+		dynamicLoc.func.render(Trace.OUT);
 		Trace.OUT.outln();
 		return Resumption.Continue;
 	}
 }
 class CallsMonitorExitProbe(m: CallsMonitor) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		m.depth--;
 		return Resumption.Continue;
 	}

--- a/src/monitors/CoverageMonitor.v3
+++ b/src/monitors/CoverageMonitor.v3
@@ -42,9 +42,9 @@ class CoverageMonitor extends Monitor {
 	}
 }
 class CoverageMonitorProbe(module: Module, func: FuncDecl, monitor: CoverageMonitor, start: int) extends Probe {
-	def fire(func: WasmFunction, offset: int, frame: TargetFrame) -> Resumption {
-		monitor.executed[offset + start] = true;
-		module.removeProbeAt(func.decl.func_index, offset, this);
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		monitor.executed[dynamicLoc.pc + start] = true;
+		module.removeProbeAt(dynamicLoc.func.decl.func_index, dynamicLoc.pc, this);
 		return Resumption.Continue;
 	}
 }

--- a/src/monitors/LoopMonitor.v3
+++ b/src/monitors/LoopMonitor.v3
@@ -66,7 +66,7 @@ class LoopMonitor extends Monitor {
 	}
 }
 class LoopMonitorCounter(m: LoopMonitor, entry: int) extends Probe {
-	def fire(func: WasmFunction, offset: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		m.counts[entry] = 1u + m.counts[entry];
 		return Resumption.Continue;
 	}

--- a/src/monitors/ProfileMonitor.v3
+++ b/src/monitors/ProfileMonitor.v3
@@ -152,13 +152,13 @@ class ProfileMonitor extends Monitor {
 	}
 }
 class ProfileMonitorEnterProbe(m: ProfileMonitor) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		m.tree.enterFunc(func);
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		m.tree.enterFunc(dynamicLoc.func);
 		return Resumption.Continue;
 	}
 }
 class ProfileMonitorExitProbe(m: ProfileMonitor) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		m.tree.exitFunc();
 		return Resumption.Continue;
 	}

--- a/src/util/FuncMonitorUtil.v3
+++ b/src/util/FuncMonitorUtil.v3
@@ -1,20 +1,20 @@
 private class FuncWithLoopEnterProbe(probe: Probe, frameAccessors: ListStack<FrameAccessor>) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		var curAccessor = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var curAccessor = dynamicLoc.frame.getFrameAccessor();
 		if (!frameAccessors.empty() && curAccessor == frameAccessors.peek())
 			return Resumption.Continue;
 		frameAccessors.push(curAccessor);
 		if (probe != null)
-			return probe.fire(func, pc, frame);
+			return probe.fire(dynamicLoc);
 		return Resumption.Continue;
 	}
 }
 
 private class FuncWithLoopExitProbe(probe: Probe, frameAccessors: ListStack<FrameAccessor>) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		frameAccessors.pop();
 		if (probe != null)
-			return probe.fire(func, pc, frame);
+			return probe.fire(dynamicLoc);
 		return Resumption.Continue;
 	}
 }

--- a/src/weerun.main.v3
+++ b/src/weerun.main.v3
@@ -132,7 +132,9 @@ class TraceProbe extends Probe {
 	def tracer = InstrTracer.new();
 	def d = DataReader.new([]);
 
-	def fire(func: WasmFunction, offset: int) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var func = dynamicLoc.func;
+		var offset = dynamicLoc.offset;
 		d.reset(func.decl.code.orig, offset, func.decl.code.orig.length);
 		var module = if(func.instance != null, func.instance.module);
 		var out = Trace.OUT;

--- a/test/unittest/DebugTest.v3
+++ b/test/unittest/DebugTest.v3
@@ -12,8 +12,8 @@ def X = [
 ];
 
 class DebugBreak(t: DebugTester) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		t.breaks.put(func, pc);
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		t.breaks.put(dynamicLoc.func, dynamicLoc.pc);
 		return Resumption.Continue;
 	}
 }
@@ -78,10 +78,10 @@ def test_timeout0(t: DebugTester) {
 }
 
 class FrameAsserter(t: Tester, expected_func: FuncDecl, expected_pc: int) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		t.asserteq(expected_func, func.decl);
-		t.asserti(expected_pc, pc);
-		var access = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		t.asserteq(expected_func, dynamicLoc.func.decl);
+		t.asserti(expected_pc, dynamicLoc.pc);
+		var access = dynamicLoc.frame.getFrameAccessor();
 		t.asserteq(expected_func, access.func().decl);
 		t.asserti(expected_pc, access.pc());
 		return Resumption.Continue;
@@ -101,8 +101,8 @@ def test_frame0(t: DebugTester) {
 }
 
 class LocalsAsserter(t: Tester, expected_vals: Array<Value>) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		var access = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var access = dynamicLoc.frame.getFrameAccessor();
 		t.asserti(expected_vals.length, access.numLocals());
 		for (i < expected_vals.length) {
 			if (!t.ok) break;
@@ -125,8 +125,8 @@ def test_locals0(t: DebugTester) {
 }
 
 class StackAsserter(t: Tester, expected_vals: Array<Value>) extends Probe {
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		var access = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var access = dynamicLoc.frame.getFrameAccessor();
 		t.asserti(expected_vals.length, access.numOperands());
 		for (i < expected_vals.length) {
 			if (!t.ok) break;

--- a/test/unittest/ProbeTest.v3
+++ b/test/unittest/ProbeTest.v3
@@ -84,12 +84,12 @@ def test_list1(t: ProbeTester) {
 	l.add(p3);
 	t.assert_list([p1, p2, p2, p3], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.assert_count(1, p1);
 	t.assert_count(2, p2);
 	t.assert_list([p1, p2, p3], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.assert_count(2, p1);
 	t.assert_count(3, p2);
 	t.assert_list([p1, p3], l);
@@ -104,18 +104,18 @@ def test_list2(t: ProbeTester) {
 	l.add(p2);
 	t.assert_list([p3, p2, p2], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.assert_count(2, p2);
 	t.assert_list([p3, p2], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.assert_count(3, p2);
 	t.assert_list([p3], l);
 }
 
 class UidProbe(counter: Array<int>) extends Probe {
 	var num = -1;
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		num = counter[0]++;
 		return Resumption.Continue;
 	}
@@ -131,7 +131,7 @@ def test_list3(t: ProbeTester) {
 	l.add(p3);
 	t.assert_list([p1, p2, p3], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.t.asserteq(1001, p1.num);
 	t.t.asserteq(1002, p2.num);
 	t.t.asserteq(1003, p3.num);
@@ -139,7 +139,7 @@ def test_list3(t: ProbeTester) {
 	l.remove(p2);
 	t.assert_list([p1, p3], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.t.asserteq(1004, p1.num);
 	t.t.asserteq(1002, p2.num);
 	t.t.asserteq(1005, p3.num);
@@ -147,7 +147,7 @@ def test_list3(t: ProbeTester) {
 	l.add(p2);
 	t.assert_list([p1, p3, p2], l);
 
-	l.fire(null, 0, frame);
+	l.fire(DynamicLoc(null, 0, frame));
 	t.t.asserteq(1006, p1.num);
 	t.t.asserteq(1008, p2.num);
 	t.t.asserteq(1007, p3.num);
@@ -271,16 +271,16 @@ def test_unwound0(t: ProbeTester) {
 
 class DepthProbe extends Probe {
 	var depth = -1000;
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		depth = frame.getFrameAccessor().depth();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		depth = dynamicLoc.frame.getFrameAccessor().depth();
 		return Resumption.Continue;
 	}
 }
 
 class AccessorCapture extends Probe {
 	var accessor: FrameAccessor;
-	def fire(func: WasmFunction, pc: int, frame: TargetFrame) -> Resumption {
-		accessor = frame.getFrameAccessor();
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		accessor = dynamicLoc.frame.getFrameAccessor();
 		return Resumption.Continue;
 	}
 }


### PR DESCRIPTION
Also includes placeholder implementation for `V3Frame.caller()` (before we change the signature of `FrameAccessor.caller()` to support host functions too).