### PR TITLE
[monitors] Use ModuleMonitor in Branch/Calls/ProfileMonitor

### DIFF
--- a/src/monitors/BranchMonitor.v3
+++ b/src/monitors/BranchMonitor.v3
@@ -28,7 +28,7 @@ class BranchMonitorState(mm: ModuleMonitor) extends BytecodeVisitor {
 
 		mm.beforeInstrExec(f, bi.pc, if(isBrTable, branchTableCallback, branchCallback)(_, entry.taken));
 	}
-	def report() {
+	def onFinish(i: Instance) {
 		var prev: FuncDecl;
 		for (i < entries.length) {
 			var e = entries[i];
@@ -78,9 +78,7 @@ class BranchMonitor extends Monitor {
 		visitor.bi = it;
 
 		mm.forEachFunc(MonitorUtil.isNotImport, monitorFunc(_, visitor));
-	}
-	def onFinish(i: Instance) {
-		for (j < visitors.length) visitors[j].report();
+		mm.afterFinish(visitor.onFinish);
 	}
 
 	private def monitorFunc(func: FuncDecl, visitor: BranchMonitorState) {

--- a/src/monitors/BranchMonitor.v3
+++ b/src/monitors/BranchMonitor.v3
@@ -7,7 +7,7 @@ class BmEntry(func: FuncDecl, pc: int, op: Opcode, numTargets: int) {
 	def taken = Array<u64>.new(numTargets);
 }
 
-class BranchMonitorState(module: Module) extends BytecodeVisitor {
+class BranchMonitorState(mm: ModuleMonitor) extends BytecodeVisitor {
 	def entries = Vector<BmEntry>.new();
 	var bi: BytecodeIterator;
 
@@ -26,8 +26,7 @@ class BranchMonitorState(module: Module) extends BytecodeVisitor {
 		var entry = BmEntry.new(f, bi.pc, opcode, numTargets);
 		entries.put(entry);
 
-		var probe = if(isBrTable, BranchMonitorBranchTableProbe.new(entry.taken), BranchMonitorProbe.new(entry.taken));
-		module.insertProbeAt(f.func_index, bi.pc, probe);
+		mm.beforeInstrExec(f, bi.pc, if(isBrTable, branchTableCallback, branchCallback)(_, entry.taken));
 	}
 	def report() {
 		var prev: FuncDecl;
@@ -35,7 +34,7 @@ class BranchMonitorState(module: Module) extends BytecodeVisitor {
 			var e = entries[i];
 			if (e.func != prev) {
 				prev = e.func;
-				Trace.OUT.put1("func %q:", prev.render(module.names, _)).outln();
+				Trace.OUT.put1("func %q:", prev.render(mm.module.names, _)).outln();
 			}
 			Trace.OUT.put1("  +%d ", e.pc);
 			Opcodes.render(Trace.OUT, e.op.code);
@@ -50,56 +49,45 @@ class BranchMonitorState(module: Module) extends BytecodeVisitor {
 			Trace.OUT.outln();
 		}
 	}
+
+	private def branchCallback(dynamicLoc: DynamicLoc, taken: Array<u64>) -> Resumption {
+		var accessor = dynamicLoc.frame.getFrameAccessor();
+		var condition = accessor.getOperand(0);
+		var branchTaken = Values.v_i(condition) != 0;
+		taken[if(branchTaken, 1, 0)] += 1;
+		return Resumption.Continue;
+	}
+	private def branchTableCallback(dynamicLoc: DynamicLoc, taken: Array<u64>) -> Resumption {
+		var accessor = dynamicLoc.frame.getFrameAccessor();
+		var condition = accessor.getOperand(0);
+		var branchTaken = Values.v_i(condition);
+		if (branchTaken >= taken.length) branchTaken = taken.length - 1;
+		taken[branchTaken] += 1;
+		return Resumption.Continue;
+	}
 }
 
 class BranchMonitor extends Monitor {
 	def visitors = Vector<BranchMonitorState>.new();
+	def it = BytecodeIterator.new();
 
 	def onParse(module: Module) {
-		def visitor = BranchMonitorState.new(module);
+		var mm = ModuleMonitor.new(module);
+		def visitor = BranchMonitorState.new(mm);
 		visitors.put(visitor);
-
-		var it = BytecodeIterator.new();
 		visitor.bi = it;
 
-		for (i < module.functions.length) {
-			var f = module.functions[i];
-			if (f.imp != null) continue;
-			
-			var bi = it.reset(f);
-			while (bi.more()) {
-				bi.dispatch(visitor);
-				bi.next();
-			}
-		}
+		mm.forEachFunc(MonitorUtil.isNotImport, monitorFunc(_, visitor));
 	}
 	def onFinish(i: Instance) {
-		for (j < visitors.length) {
-			visitors[j].report();
-		}
+		for (j < visitors.length) visitors[j].report();
 	}
-}
 
-class BranchMonitorProbe(taken: Array<u64>) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		var accessor = dynamicLoc.frame.getFrameAccessor();
-		var condition = accessor.getOperand(0);
-		var taken = Values.v_i(condition) != 0;
-		var index = if(taken, 1, 0);
-		this.taken[index] += 1;
-		return Resumption.Continue;
-	}
-}
-class BranchMonitorBranchTableProbe(taken: Array<u64>) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		var accessor = dynamicLoc.frame.getFrameAccessor();
-		var numBranches = taken.length;
-		var condition = accessor.getOperand(0);
-		var takenBranch = Values.v_i(condition);
-		if (takenBranch >= numBranches) {
-			takenBranch = numBranches - 1;
+	private def monitorFunc(func: FuncDecl, visitor: BranchMonitorState) {
+		var bi = it.reset(func);
+		while (bi.more()) {
+			bi.dispatch(visitor);
+			bi.next();
 		}
-		this.taken[takenBranch] += 1;
-		return Resumption.Continue;
 	}
 }

--- a/src/monitors/CallsMonitor.v3
+++ b/src/monitors/CallsMonitor.v3
@@ -13,34 +13,24 @@ class CallsMonitor extends Monitor {
 		return null;
 	}
 	def onParse(module: Module) {
-		for (i < module.functions.length) {
-			var f = module.functions[i];
-			if (filter != null && !filter.matches(module, f)) continue;
-			if (f.imp != null) continue; // skip imported functions
-			var callProbe = CallsMonitorEnterProbe.new(this);
-			var retProbe = CallsMonitorExitProbe.new(this);
+		var mm = ModuleMonitor.new(module);
+		mm.forEachFunc(isFuncMonitored, mm.beforeFuncExecAndReturn(_, callFn, retFn));
+	}
 
-			module.insertProbeAtFuncEnterExit(i, callProbe, retProbe);
-		}
+	private def isFuncMonitored(module: Module, func: FuncDecl) -> bool {
+		if (filter != null && !filter.matches(module, func)) return false;
+		if (MonitorUtil.isImport(module, func)) return false;
+		return true;
 	}
-	def onExit(code: int) {
-		onFinish(null);
-	}
-	def onFinish(i: Instance) {
-	}
-}
-class CallsMonitorEnterProbe(m: CallsMonitor) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		for (i < m.depth) Trace.OUT.puts("  ");
-		m.depth++;
+	private def callFn(dynamicLoc: DynamicLoc) -> Resumption {
+		for (i < depth) Trace.OUT.puts("  ");
+		depth++;
 		dynamicLoc.func.render(Trace.OUT);
 		Trace.OUT.outln();
 		return Resumption.Continue;
 	}
-}
-class CallsMonitorExitProbe(m: CallsMonitor) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		m.depth--;
+	private def retFn(dynamicLoc: DynamicLoc) -> Resumption {
+		depth--;
 		return Resumption.Continue;
 	}
 }

--- a/src/monitors/CallsMonitor.v3
+++ b/src/monitors/CallsMonitor.v3
@@ -14,7 +14,7 @@ class CallsMonitor extends Monitor {
 	}
 	def onParse(module: Module) {
 		var mm = ModuleMonitor.new(module);
-		mm.forEachFunc(isFuncMonitored, mm.beforeFuncExecAndReturn(_, callFn, retFn));
+		mm.forEachFunc(isFuncMonitored, mm.beforeFuncExecAndReturn(_, beforeFuncExec, beforeFuncReturn));
 	}
 
 	private def isFuncMonitored(module: Module, func: FuncDecl) -> bool {
@@ -22,14 +22,14 @@ class CallsMonitor extends Monitor {
 		if (MonitorUtil.isImport(module, func)) return false;
 		return true;
 	}
-	private def callFn(dynamicLoc: DynamicLoc) -> Resumption {
+	private def beforeFuncExec(dynamicLoc: DynamicLoc) -> Resumption {
 		for (i < depth) Trace.OUT.puts("  ");
 		depth++;
 		dynamicLoc.func.render(Trace.OUT);
 		Trace.OUT.outln();
 		return Resumption.Continue;
 	}
-	private def retFn(dynamicLoc: DynamicLoc) -> Resumption {
+	private def beforeFuncReturn(dynamicLoc: DynamicLoc) -> Resumption {
 		depth--;
 		return Resumption.Continue;
 	}

--- a/src/monitors/LoopMonitor.v3
+++ b/src/monitors/LoopMonitor.v3
@@ -1,4 +1,4 @@
-// Copyright 2022 Ben L. Titzer. All rights reserved.
+// Copyright 2023 Wizard Authors. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
 // Implements a simple monitor that counts the number of iterations of each loop.
@@ -9,48 +9,11 @@ class LmEntry(module: Module, func: FuncDecl, depth: int, pc: int) {
 class LoopMonitor extends Monitor {
 	def entries = Vector<LmEntry>.new();
 	def counts = Vector<u64>.new();
+	def it = BytecodeIterator.new();
 
 	def onParse(m: Module) {
-		var it = BytecodeIterator.new();
-
-		for (i < m.functions.length) {
-			var f = m.functions[i];
-			if (f.imp != null) continue; // skip imported functions
-
-			var loopDepth = 0;
-			var controlStack = ArrayStack<(Opcode, LmEntry)>.new();
-
-			for (bi = it.reset(f); bi.more(); bi.next()) {
-				var op = bi.current();
-				match (op) {
-					BLOCK, IF => controlStack.push((op, null));
-					LOOP => {
-						var probe = LoopMonitorCounter.new(this, entries.length);
-						m.insertProbeAt(f.func_index, bi.pc, probe);
-						var lmEntry = LmEntry.new(m, f, loopDepth, bi.pc);
-						entries.put(lmEntry);
-						controlStack.push((op, lmEntry));
-						counts.put(0);
-						loopDepth++;
-					}
-					// TODO: try and exception bytecodes 
-					END => {
-						if ((bi.pc + 1) < f.cur_bytecode.length) {
-							var topControl = controlStack.pop();
-							if (topControl.0 == Opcode.LOOP) {
-								loopDepth--;
-								topControl.1.endPc = bi.pc;
-							}
-						}
-					}
-					_ => ;
-				}
-
-			}
-		}
-	}
-	def onExit(code: int) {
-		onFinish(null);
+		var mm = ModuleMonitor.new(m);
+		mm.forEachFunc(MonitorUtil.isNotImport, monitorFunc(mm, _));
 	}
 	def onFinish(i: Instance) {
 		var prev: FuncDecl;
@@ -64,10 +27,40 @@ class LoopMonitor extends Monitor {
 			Trace.OUT.put3("  +%d ... +%d loop: %d", e.pc, e.endPc, counts[j]).outln();
 		}
 	}
-}
-class LoopMonitorCounter(m: LoopMonitor, entry: int) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		m.counts[entry]++;
+
+	private def monitorFunc(mm: ModuleMonitor, func: FuncDecl) {
+		var loopDepth = 0;
+		var controlStack = ArrayStack<(Opcode, LmEntry)>.new();
+
+		for (bi = it.reset(func); bi.more(); bi.next()) {
+			var op = bi.current();
+			match (op) {
+				BLOCK, IF => controlStack.push((op, null));
+				LOOP => {
+					var callback = loopHit(_, entries.length);
+					mm.beforeInstrExec(func, bi.pc, callback);
+					var lmEntry = LmEntry.new(mm.module, func, loopDepth, bi.pc);
+					entries.put(lmEntry);
+					controlStack.push((op, lmEntry));
+					counts.put(0);
+					loopDepth++;
+				}
+				// TODO: try and exception bytecodes 
+				END => {
+					if ((bi.pc + 1) < func.cur_bytecode.length) {
+						var topControl = controlStack.pop();
+						if (topControl.0 == Opcode.LOOP) {
+							loopDepth--;
+							topControl.1.endPc = bi.pc;
+						}
+					}
+				}
+				_ => ;
+			}
+		}
+	}
+	private def loopHit(dynamicLoc: DynamicLoc, entry: int) -> Resumption {
+		counts[entry] = 1u + counts[entry];
 		return Resumption.Continue;
 	}
 }

--- a/src/monitors/ModuleMonitor.v3
+++ b/src/monitors/ModuleMonitor.v3
@@ -4,7 +4,13 @@
 // The ModuleMonitor interface implements an API for inserting callbacks for various events that
 // occur during execution. Events are detected and instrumented using the lower-level probe API
 // offered by the engine.
-class ModuleMonitor(module: Module) {
+class ModuleMonitor(module: Module) extends Monitor {
+	def finishCallbacks = Vector<(Instance -> void)>.new();
+
+	new() {
+		MonitorOptions.insertMonitor(this);
+	}
+
 	// Attach callback {f} to be called before {func} is executed.
 	def beforeFuncExec(func: FuncDecl, f: DynamicLoc -> Resumption) {
 		if (func.imp != null) return;
@@ -96,6 +102,12 @@ class ModuleMonitor(module: Module) {
 	// Attach callback {f} to before every memory grow.
 	def beforeMemGrow(f: (DynamicLoc, Memory, u32) -> Resumption) {
 		beforeMemOp(null, null, f);
+	}
+	def afterFinish(f: (Instance) -> void) {
+		finishCallbacks.put(f);
+	}
+	def onFinish(i: Instance) {
+		for (j < finishCallbacks.length) finishCallbacks[j](i);
 	}
 
 	// Helpers

--- a/src/monitors/ModuleMonitor.v3
+++ b/src/monitors/ModuleMonitor.v3
@@ -16,7 +16,7 @@ class ModuleMonitor(module: Module) {
 		beforeFuncExecAndReturn(func, null, f);
 	}
 	// Attach callbacks that are called when a func is executed or returns
-	def beforeFuncExecAndReturn(func: FuncDecl, callFn: DynamicLoc -> Resumption, retFn: DynamicLoc -> Resumption) {
+	def beforeFuncExecAndReturn(func: FuncDecl, beforeExec: DynamicLoc -> Resumption, beforeRet: DynamicLoc -> Resumption) {
 		var it = BytecodeIterator.new();
 		var bi = it.reset(func);
 
@@ -25,9 +25,9 @@ class ModuleMonitor(module: Module) {
 		if (bi.current() == Opcode.LOOP) {
 			startsWithLoop = true;
 			frameAccessors = ListStack<FrameAccessor>.new();
-			module.insertProbeAt(func.func_index, bi.pc, FuncWithLoopEnterProbe.new(frameAccessors, callFn));
-		} else if (callFn != null) {
-			module.insertProbeAt(func.func_index, bi.pc, CallbackProbe.new(callFn));
+			module.insertProbeAt(func.func_index, bi.pc, FuncWithLoopEnterProbe.new(frameAccessors, beforeExec));
+		} else if (beforeExec != null) {
+			module.insertProbeAt(func.func_index, bi.pc, CallbackProbe.new(beforeExec));
 		}
 
 		for (bi = it.reset(func); bi.more(); bi.next()) {
@@ -39,9 +39,9 @@ class ModuleMonitor(module: Module) {
 			}
 
 			if (startsWithLoop) {
-				module.insertProbeAt(func.func_index, bi.pc, FuncWithLoopExitProbe.new(frameAccessors, retFn));
-			} else if (retFn != null) {
-				module.insertProbeAt(func.func_index, bi.pc, CallbackProbe.new(retFn));
+				module.insertProbeAt(func.func_index, bi.pc, FuncWithLoopExitProbe.new(frameAccessors, beforeRet));
+			} else if (beforeRet != null) {
+				module.insertProbeAt(func.func_index, bi.pc, CallbackProbe.new(beforeRet));
 			}
 		}
 	}

--- a/src/monitors/MonitorOptions.v3
+++ b/src/monitors/MonitorOptions.v3
@@ -3,7 +3,7 @@
 
 // Parses and updates monitor options based on arguments.
 component MonitorOptions {
-	private var monitors: List<Monitor>;
+	private var monitors = Vector<Monitor>.new();
 
 	// Parse a command-line argument, configuring and updating monitors. Return {true}
 	// if the argument was matched and parsed successfully.
@@ -36,11 +36,14 @@ component MonitorOptions {
 		var m = MonitorRegistry.lookupName(name);
 		if (m != null) {
 			if (args != null) m.configure(args);
-			monitors = List.new(m, monitors);
+			monitors.put(m);
 		}
 	}
+	def insertMonitor(m: Monitor) {
+		monitors.put(m);
+	}
 	// Get the monitors, if any, configured by the above.
-	def getMonitors() -> List<Monitor> {
+	def getMonitors() -> Vector<Monitor> {
 		return monitors;
 	}
 }

--- a/src/monitors/ProfileMonitor.v3
+++ b/src/monitors/ProfileMonitor.v3
@@ -132,15 +132,8 @@ class ProfileMonitor extends Monitor {
 		}
 	}
 	def onParse(module: Module) {
-		for (i < module.functions.length) {
-			var f = module.functions[i];
-			if (f.imp != null) continue; // skip imported functions
-			if (filter != null && !filter.matches(module, f)) continue;
-			var enterProbe = ProfileMonitorEnterProbe.new(this);
-			var exitProbe = ProfileMonitorExitProbe.new(this);
-
-			module.insertProbeAtFuncEnterExit(i, enterProbe, exitProbe);
-		}
+		var mm = ModuleMonitor.new(module);
+		mm.forEachFunc(isFuncMonitored, mm.beforeFuncExecAndReturn(_, enterFunc, exitFunc));
 		tree = ProfileTree.new();
 	}
 	def onExit(code: int) {
@@ -150,16 +143,18 @@ class ProfileMonitor extends Monitor {
 	def onFinish(i: Instance) {
 		tree.rootNode.render(Trace.OUT, 0, 0, maxDepth);
 	}
-}
-class ProfileMonitorEnterProbe(m: ProfileMonitor) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		m.tree.enterFunc(dynamicLoc.func);
+
+	private def isFuncMonitored(module: Module, func: FuncDecl) -> bool {
+		if (filter != null && !filter.matches(module, func)) return false;
+		if (MonitorUtil.isImport(module, func)) return false;
+		return true;
+	}
+	private def enterFunc(dynamicLoc: DynamicLoc) -> Resumption {
+		tree.enterFunc(dynamicLoc.func);
 		return Resumption.Continue;
 	}
-}
-class ProfileMonitorExitProbe(m: ProfileMonitor) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		m.tree.exitFunc();
+	private def exitFunc(dynamicLoc: DynamicLoc) -> Resumption {
+		tree.exitFunc();
 		return Resumption.Continue;
 	}
 }

--- a/src/wizeng.main.v3
+++ b/src/wizeng.main.v3
@@ -56,7 +56,7 @@ def main(args: Array<string>) -> int {
 
 	// Parse the binary module
 	var monitors = MonitorOptions.getMonitors();
-	if (monitors != null) Execute.tiering.onMonitorsStart();
+	if (monitors.length > 0) Execute.tiering.onMonitorsStart();
 	var result = engine.loadWasmFile(path);
 	var module: Module;
 	match (result) {
@@ -71,7 +71,7 @@ def main(args: Array<string>) -> int {
 			.exit(3);
 	}
 	// Call monitors for parsed module
-	for (l = monitors; l != null; l = l.tail) l.head.onParse(module);
+	for (i < monitors.length) monitors[i].onParse(module);
 	var err = ErrorGen.new(path);
 	if (monitors != null) Execute.tiering.onMonitorsFinish(module, err);
 
@@ -108,7 +108,7 @@ def main(args: Array<string>) -> int {
 		.exit(6);
 
 	// Call monitors on finish
-	for (l = monitors; l != null; l = l.tail) l.head.onInstantiate(instance);
+	for (i < monitors.length) monitors[i].onInstantiate(instance);
 
 	// Try to find the main entrypoint.
 	var entry: (Function, Array<Value>);
@@ -133,7 +133,7 @@ def main(args: Array<string>) -> int {
 	if (module.start_function >= 0) {
 		var start = instance.functions[module.start_function];
 		Execute.exit_code = 0;
-		for (l = monitors; l != null; l = l.tail) l.head.onStart(start);
+		for (i < monitors.length) monitors[i].onStart(start);
 		var r = Metrics.start_time_us.run(Execute.call, (start, Values.NONE));
 		match (r) {
 			Throw(thrown) => return exitTrap(monitors, instance, thrown);
@@ -143,7 +143,7 @@ def main(args: Array<string>) -> int {
 
 	// Execute the main entrypoint.
 	Execute.exit_code = 0;
-	for (l = monitors; l != null; l = l.tail) l.head.onMain(entry.0, entry.1);
+	for (i < monitors.length) monitors[i].onMain(entry.0, entry.1);
 	var r = Metrics.main_time_us.run(Execute.call, (entry.0, entry.1));
 	match (r) {
 		Value(vals) => {
@@ -167,14 +167,14 @@ def main(args: Array<string>) -> int {
 		}
 	}
 	// Call monitors on finish
-	for (l = monitors; l != null; l = l.tail) l.head.onFinish(instance);
+	for (i < monitors.length) monitors[i].onFinish(instance);
 	Metrics.report();
 	return Execute.exit_code;
 }
-def exitTrap(monitors: List<Monitor>, instance: Instance, thrown: Throwable) -> int {
+def exitTrap(monitors: Vector<Monitor>, instance: Instance, thrown: Throwable) -> int {
 	if (Trap.?(thrown) && Trap.!(thrown).reason == TrapReason.EXIT) {
 		// Call monitors on exit
-		for (l = monitors; l != null; l = l.tail) l.head.onExit(Execute.exit_code);
+		for (i < monitors.length) monitors[i].onExit(Execute.exit_code);
 		Metrics.report();
 		return Execute.exit_code;
 	} else {
@@ -201,7 +201,7 @@ def exitTrap(monitors: List<Monitor>, instance: Instance, thrown: Throwable) -> 
 		thrown.render(e);
 		e.ln();
 		// Call monitors on finish
-		for (l = monitors; l != null; l = l.tail) l.head.onFinish(instance);
+		for (i < monitors.length) monitors[i].onFinish(instance);
 		Metrics.report();
 		return e.exit(10);
 	}

--- a/test/wizeng/calls3.wasm.out
+++ b/test/wizeng/calls3.wasm.out
@@ -1,4 +1,4 @@
 func "main":
-  +19 br_if: [1, 1004]
-func "main":
   +8 ... +21 loop: 1005
+func "main":
+  +19 br_if: [1, 1004]


### PR DESCRIPTION
Changes the old monitors to use the new `ModuleMonitor` interface.