### PR TITLE
[simd]: Fix signature check for v128 lane instructions

### DIFF
--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -770,14 +770,14 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 				V128_LOAD_64_ZERO => checkLoad(opcode, 3, ValueType.V128);
 				V128_LOAD		=> checkLoad(opcode, 4, ValueType.V128);
 				V128_STORE		=> checkStore(opcode, 4, ValueType.V128);
-				V128_LOAD_8_LANE	=> { checkLaneLoad(opcode, 0); checkLane(15); }
-				V128_STORE_8_LANE	=> { checkLaneStore(opcode, 0); checkLane(15); }
-				V128_LOAD_16_LANE	=> { checkLaneLoad(opcode, 1); checkLane(7); }
-				V128_STORE_16_LANE	=> { checkLaneStore(opcode, 1); checkLane(7); }
-				V128_LOAD_32_LANE	=> { checkLaneLoad(opcode, 2); checkLane(3); }
-				V128_STORE_32_LANE	=> { checkLaneStore(opcode, 2); checkLane(3); }
-				V128_LOAD_64_LANE	=> { checkLaneLoad(opcode, 3);  checkLane(1); }
-				V128_STORE_64_LANE	=> { checkLaneStore(opcode, 3);  checkLane(1); }
+				V128_LOAD_8_LANE	=> { checkLaneLoad(opcode, 0); checkLaneAndSig(opcode, 15); }
+				V128_STORE_8_LANE	=> { checkLaneStore(opcode, 0); checkLaneAndSig(opcode, 15); }
+				V128_LOAD_16_LANE	=> { checkLaneLoad(opcode, 1); checkLaneAndSig(opcode, 7); }
+				V128_STORE_16_LANE	=> { checkLaneStore(opcode, 1); checkLaneAndSig(opcode, 7); }
+				V128_LOAD_32_LANE	=> { checkLaneLoad(opcode, 2); checkLaneAndSig(opcode, 3); }
+				V128_STORE_32_LANE	=> { checkLaneStore(opcode, 2); checkLaneAndSig(opcode, 3); }
+				V128_LOAD_64_LANE	=> { checkLaneLoad(opcode, 3);  checkLaneAndSig(opcode, 1); }
+				V128_STORE_64_LANE	=> { checkLaneStore(opcode, 3);  checkLaneAndSig(opcode, 1); }
 				V128_CONST => {
 					codeptr.skipN(16);
 					push(ValueType.V128);
@@ -785,18 +785,18 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 				I8X16_SHUFFLE => codeptr.skipN(16);
 				I8X16_EXTRACTLANE_S,
 				I8X16_EXTRACTLANE_U,
-				I8X16_REPLACELANE => checkLane(15);
+				I8X16_REPLACELANE => checkLaneAndSig(opcode, 15);
 				I16X8_EXTRACTLANE_S,
 				I16X8_EXTRACTLANE_U,
-				I16X8_REPLACELANE => checkLane(7);
+				I16X8_REPLACELANE => checkLaneAndSig(opcode, 7);
 				I32X4_EXTRACTLANE,
 				I32X4_REPLACELANE,
 				F32X4_EXTRACTLANE,
-				F32X4_REPLACELANE => checkLane(3);
+				F32X4_REPLACELANE => checkLaneAndSig(opcode, 3);
 				I64X2_EXTRACTLANE,
 				I64X2_REPLACELANE,
 				F64X2_EXTRACTLANE,
-				F64X2_REPLACELANE => checkLane(3);
+				F64X2_REPLACELANE => checkLaneAndSig(opcode, 3);
 				INVALID => {
 					codeptr.at(opcode_pos);
 					err_atpc().InvalidOpcode(codeptr.read1(), codeptr.read_uleb32());
@@ -882,9 +882,10 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 		}
 		return indexType;
 	}
-	def checkLane(max: u32) {
+	def checkLaneAndSig(opcode: Opcode, max: u32) {
 		var lane = codeptr.read1();
 		if (lane > max) err_atpc().IllegalLane(max, lane);
+		checkSignature(opcode.sig);
 	}
 	def traceOpcode() {
 		OUT.put2("  %x(+%d): ", opcode_pos, opcode_pos - ctlxfer.start_pos);


### PR DESCRIPTION
- Added a call to checkSignature() in checkLane() so that all v128 instructions that check the lane index will now be correctly validated.
- Will factor out v128_extract_lane in the interpreter and finish implementing the rest instructions in future PRs.