### PR TITLE
[simd]: Implement v128 swizzle

### DIFF
--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2435,13 +2435,13 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		}
 		bindHandler(Opcode.I16X8_EXTADDPAIRWISE_I8X16_S); {
 			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-			masm.emit_i16x8_extadd_pairwise_i8x16_s(r_xmm0, r_tmp0, r_xmm1, r_xmm2);
+			masm.emit_i16x8_extadd_pairwise_i8x16_s(r_xmm0, r_tmp0, r_xmm1);
 			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 			endHandler();
 		}
 		bindHandler(Opcode.I16X8_EXTADDPAIRWISE_I8X16_U); {
 			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-			masm.emit_i16x8_extadd_pairwise_i8x16_u(r_xmm0, r_tmp0, r_xmm1, r_xmm2);
+			masm.emit_i16x8_extadd_pairwise_i8x16_u(r_xmm0, r_tmp0, r_xmm1);
 			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 			endHandler();
 		}
@@ -2652,7 +2652,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		]) {
 			bindHandler(t.0);
 			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-			t.1(r_xmm0, r_tmp0, r_xmm1, r_xmm2);
+			t.1(r_xmm0, r_tmp0, r_xmm1);
 			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 			endHandler();
 		}
@@ -2739,7 +2739,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		}
 		bindHandler(Opcode.I8X16_SWIZZLE); {
 			load_v128_xmm0_xmm1();
-			masm.emit_i8x16_swizzle(r_xmm0, r_xmm1, r_tmp0, r_xmm2, r_xmm3);
+			masm.emit_i8x16_swizzle(r_xmm0, r_xmm1, r_tmp0, r_xmm2);
 			asm.movdqu_m_s(vsph[-2].value, r_xmm0);
 			decrementVsp();
 			endHandler();

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2380,7 +2380,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			endHandler();
 		}
 		for (t in [
-			// V128 lane-wise arithmetic
+			// V128 lane-wise general binary operations
 			(Opcode.I8X16_ADD, asm.paddb_s_s),
 			(Opcode.I16X8_ADD, asm.paddw_s_s),
 			(Opcode.I32X4_ADD, asm.paddd_s_s),
@@ -2736,6 +2736,13 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			asm.q.sub_r_i(idx, SIMD_128_SIZE); // idx -= 16
 			asm.q.lea(val_addr, rhs);
 			asm.jmp_rel_near(LOOP_EPI);
+		}
+		bindHandler(Opcode.I8X16_SWIZZLE); {
+			load_v128_xmm0_xmm1();
+			masm.emit_i8x16_swizzle(r_xmm0, r_xmm1, r_tmp0, r_xmm2, r_xmm3);
+			asm.movdqu_m_s(vsph[-2].value, r_xmm0);
+			decrementVsp();
+			endHandler();
 		}
 		{	// V128 lane extraction
 			genExtractLane(Opcode.I8X16_EXTRACTLANE_U, BpTypeCode.I32.code, 1, asm.movb_r_m, asm.movb_m_r, false);

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -739,15 +739,12 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def mask_i8x16_splat_0x01: (long, long) = (0x0101010101010101, 0x0101010101010101);
 	def mask_i8x16_swizzle: (long, long) = (0x7070707070707070, 0x7070707070707070);
 	// Load a mask into an Xmm register s
-	def load_v128_mask(dst: X86_64Xmmr, mask: (long, long), tmp: X86_64Gpr, xtmp: X86_64Xmmr) {
+	def load_v128_mask(dst: X86_64Xmmr, mask: (long, long), tmp: X86_64Gpr) {
 		// move 64 bit wide general purpose register into an xmm's lower half
 		asm.movq_r_l(tmp, mask.0);
-		asm.movq_s_r(dst, tmp);
+		asm.pinsrq_s_r_i(dst, tmp, 0);
 		asm.movq_r_l(tmp, mask.1);
-		asm.movq_s_r(xtmp, tmp);
-		// interleave low-order quadword from xmm1 and xmm2 into xmm1 register
-		asm.punpcklqdq_s_s(dst, xtmp);
-		// todo: use pinsert to avoid the need for xtmp
+		asm.pinsrq_s_r_i(dst, tmp, 1);
 	}
 	def emit_v128_orps(dst: X86_64Xmmr, src: X86_64Xmmr) {
 		asm.orps_s_s(dst, src);
@@ -758,20 +755,20 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def emit_v128_andps(dst: X86_64Xmmr, src: X86_64Xmmr) {
 		asm.andps_s_s(dst, src);
 	}
-	def emit_v128_negps(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_v128_float_neg_constant, tmp, xtmp);
+	def emit_v128_negps(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_v128_float_neg_constant, tmp);
 		emit_v128_xorps(dst, mask);
 	}
-	def emit_v128_negpd(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_v128_double_neg_constant, tmp, xtmp);
+	def emit_v128_negpd(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_v128_double_neg_constant, tmp);
 		emit_v128_xorps(dst, mask);
 	}
-	def emit_v128_absps(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_v128_float_absolute_constant, tmp, xtmp);
+	def emit_v128_absps(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_v128_float_absolute_constant, tmp);
 		emit_v128_andps(dst, mask);
 	}
-	def emit_v128_abspd(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_v128_double_absolute_constant, tmp, xtmp);
+	def emit_v128_abspd(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_v128_double_absolute_constant, tmp);
 		emit_v128_andps(dst, mask);
 	}
 	def emit_v128_zero(s: X86_64Xmmr) {
@@ -833,8 +830,8 @@ class X86_64MacroAssembler extends MacroAssembler {
 	}
 	def emit_i8x16_popcnt(dst: X86_64Xmmr, tmp1: X86_64Gpr, xtmp1: X86_64Xmmr, xtmp2: X86_64Xmmr, mask: X86_64Xmmr) {
 		// load masks
-		load_v128_mask(xtmp1, mask_i8x16_splat_0x0f, tmp1, xtmp2);
-		load_v128_mask(mask, mask_i8x16_popcnt, tmp1, xtmp2);
+		load_v128_mask(xtmp1, mask_i8x16_splat_0x0f, tmp1);
+		load_v128_mask(mask, mask_i8x16_popcnt, tmp1);
 		asm.movaps_s_s(xtmp2, xtmp1);
 		// prepare temp variables
 		asm.andps_s_s(xtmp1, dst);
@@ -899,10 +896,10 @@ class X86_64MacroAssembler extends MacroAssembler {
 		asm.psrlq_i(dst, 13);
 		asm.andnpd_s_s(dst, scratch);
 	}
-	def emit_f64x2_convert_low_i32x4_u(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_f64x2_convert_low_i32x4_u_int, tmp, xtmp);
+	def emit_f64x2_convert_low_i32x4_u(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_f64x2_convert_low_i32x4_u_int, tmp);
 		asm.unpcklps_s_s(dst, mask);
-		load_v128_mask(mask, mask_double_2_power_52, tmp, xtmp);
+		load_v128_mask(mask, mask_double_2_power_52, tmp);
 		asm.subpd_s_s(dst, mask);
 	}
 	def emit_i16x8_s_convert_i8x16_high(dst: X86_64Xmmr) {
@@ -929,13 +926,13 @@ class X86_64MacroAssembler extends MacroAssembler {
 		asm.xorps_s_s(scratch, scratch);
 		asm.punpckhdq_s_s(dst, scratch);
 	}
-	def emit_i16x8_extadd_pairwise_i8x16_s(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_i8x16_splat_0x01, tmp, xtmp);
+	def emit_i16x8_extadd_pairwise_i8x16_s(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_i8x16_splat_0x01, tmp);
 		asm.pmaddubsw_s_s(mask, dst);
 		asm.movaps_s_s(dst, mask);
 	}
-	def emit_i16x8_extadd_pairwise_i8x16_u(dst: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_i8x16_splat_0x01, tmp, xtmp);
+	def emit_i16x8_extadd_pairwise_i8x16_u(dst: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_i8x16_splat_0x01, tmp);
 		asm.pmaddubsw_s_s(dst, mask);
 	}
 	def emit_i8x16_splat(dst: X86_64Xmmr, src: X86_64Gpr, scratch: X86_64Xmmr) {
@@ -964,8 +961,8 @@ class X86_64MacroAssembler extends MacroAssembler {
 		asm.movq_s_r(scratch, src);
 		asm.movddup_s_s(dst, scratch);
 	}
-	def emit_i8x16_swizzle(dst: X86_64Xmmr, src: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
-		load_v128_mask(mask, mask_i8x16_swizzle, tmp, xtmp);
+	def emit_i8x16_swizzle(dst: X86_64Xmmr, src: X86_64Xmmr, tmp: X86_64Gpr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_i8x16_swizzle, tmp);
 		asm.paddusb_s_s(mask, src);
 		asm.pshufb_s_s(dst, mask);
 	}

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -737,6 +737,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def mask_f64x2_convert_low_i32x4_u_int: (long, long) = (0x4330000043300000, 0x4330000043300000);
 	def mask_double_2_power_52: (long, long) = (0x4330000000000000, 0x4330000000000000);
 	def mask_i8x16_splat_0x01: (long, long) = (0x0101010101010101, 0x0101010101010101);
+	def mask_i8x16_swizzle: (long, long) = (0x7070707070707070, 0x7070707070707070);
 	// Load a mask into an Xmm register s
 	def load_v128_mask(dst: X86_64Xmmr, mask: (long, long), tmp: X86_64Gpr, xtmp: X86_64Xmmr) {
 		// move 64 bit wide general purpose register into an xmm's lower half
@@ -962,6 +963,11 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def emit_f64x2_splat(dst: X86_64Xmmr, src: X86_64Gpr, scratch: X86_64Xmmr) {
 		asm.movq_s_r(scratch, src);
 		asm.movddup_s_s(dst, scratch);
+	}
+	def emit_i8x16_swizzle(dst: X86_64Xmmr, src: X86_64Xmmr, tmp: X86_64Gpr, xtmp: X86_64Xmmr, mask: X86_64Xmmr) {
+		load_v128_mask(mask, mask_i8x16_swizzle, tmp, xtmp);
+		asm.paddusb_s_s(mask, src);
+		asm.pshufb_s_s(dst, mask);
 	}
 	def getLabel(m: MasmLabel) -> X86_64Label {
 		return X86_64MasmLabel.!(m).label;

--- a/test/regress/simd/v128_swizzle.bin.wast
+++ b/test/regress/simd/v128_swizzle.bin.wast
@@ -1,0 +1,204 @@
+(module binary
+  "\00\61\73\6d\01\00\00\00\01\87\80\80\80\00\01\60"
+  "\02\7b\7b\01\7b\03\82\80\80\80\00\01\00\07\91\80"
+  "\80\80\00\01\0d\76\38\78\31\36\5f\73\77\69\7a\7a"
+  "\6c\65\00\00\0a\8e\80\80\80\00\01\88\80\80\80\00"
+  "\00\20\00\20\01\fd\0e\0b"
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x1312_1110 0x1716_1514 0x1b1a_1918 0x1f1e_1d1c)
+    (v128.const i32x4 0x302_0100 0x706_0504 0xb0a_0908 0xf0e_0d0c)
+  )
+  (v128.const i8x16
+    0x10
+    0x11
+    0x12
+    0x13
+    0x14
+    0x15
+    0x16
+    0x17
+    0x18
+    0x19
+    0x1a
+    0x1b
+    0x1c
+    0x1d
+    0x1e
+    0x1f
+  )
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0xf3f2_f1f0 0xf7f6_f5f4 0xfbfa_f9f8 0xfffe_fdfc)
+    (v128.const i32x4 0xfbfa_f9f8 0xfffe_fdfc 0x1312_1110 0x1716_1514)
+  )
+  (v128.const i8x16
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+    0x0
+  )
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6766_6564 0x6b6a_6968 0x6f6e_6d6c 0x7372_7170)
+    (v128.const i32x4 0xc0d_0e0f 0x809_0a0b 0x405_0607 0x1_0203)
+  )
+  (v128.const i8x16
+    0x73
+    0x72
+    0x71
+    0x70
+    0x6f
+    0x6e
+    0x6d
+    0x6c
+    0x6b
+    0x6a
+    0x69
+    0x68
+    0x67
+    0x66
+    0x65
+    0x64
+  )
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6766_6564 0x6b6a_6968 0x6f6e_6d6c 0x7372_7170)
+    (v128.const i32x4 0x2fe_01ff 0x4fc_03fd 0x6fa_05fb 0x8f8_07f9)
+  )
+  (v128.const i8x16
+    0x0
+    0x65
+    0x0
+    0x66
+    0x0
+    0x67
+    0x0
+    0x68
+    0x0
+    0x69
+    0x0
+    0x6a
+    0x0
+    0x6b
+    0x0
+    0x6c
+  )
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6766_6564 0x6b6a_6968 0x6f6e_6d6c 0x7372_7170)
+    (v128.const i32x4 0x110a_1009 0x130c_120b 0x150e_140d 0x1710_160f)
+  )
+  (v128.const i8x16
+    0x6d
+    0x0
+    0x6e
+    0x0
+    0x6f
+    0x0
+    0x70
+    0x0
+    0x71
+    0x0
+    0x72
+    0x0
+    0x73
+    0x0
+    0x0
+    0x0
+  )
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6766_6564 0x6b6a_6968 0x6f6e_6d6c 0x7372_7170)
+    (v128.const i32x4 0x110a_1009 0x130c_120b 0x150e_140d 0x1710_160f)
+  )
+  (v128.const i8x16
+    0x6d
+    0x0
+    0x6e
+    0x0
+    0x6f
+    0x0
+    0x70
+    0x0
+    0x71
+    0x0
+    0x72
+    0x0
+    0x73
+    0x0
+    0x0
+    0x0
+  )
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6667_6465 0x6a6b_6869 0x6e6f_6c6d 0x7273_7071)
+    (v128.const i32x4 0x302_0100 0x706_0504 0xb0a_0908 0xf0e_0d0c)
+  )
+  (v128.const i16x8 0x6465 0x6667 0x6869 0x6a6b 0x6c6d 0x6e6f 0x7071 0x7273)
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6465_6667 0x6869_6a6b 0x6c6d_6e6f 0x7071_7273)
+    (v128.const i32x4 0xc0d_0e0f 0x809_0a0b 0x405_0607 0x1_0203)
+  )
+  (v128.const i32x4 0x7372_7170 0x6f6e_6d6c 0x6b6a_6968 0x6766_6564)
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x7fc0_0000 0xffc0_0000 0x7f80_0000 0xff80_0000)
+    (v128.const i32x4 0x302_0100 0x706_0504 0xb0a_0908 0xf0e_0d0c)
+  )
+  (v128.const i32x4 0x7fc0_0000 0xffc0_0000 0x7f80_0000 0xff80_0000)
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x6766_6564 0x6b6a_6968 0x6f6e_6d5c 0x7372_7170)
+    (v128.const i32x4 0x0 0x8000_0000 0x7f80_0000 0xff80_0000)
+  )
+  (v128.const i32x4 0x6464_6464 0x64_6464 0x6464 0x6464)
+)
+(assert_return
+  (invoke "v8x16_swizzle"
+    (v128.const i32x4 0x4996_02d2 0x1234_5678 0x4996_02d2 0x1234_5678)
+    (v128.const i32x4 0x302_0100 0x706_0504 0xb0a_0908 0xf0e_0d0c)
+  )
+  (v128.const i32x4 0x4996_02d2 0x1234_5678 0x4996_02d2 0x1234_5678)
+)
+(assert_invalid
+  (module binary
+    "\00\61\73\6d\01\00\00\00\01\85\80\80\80\00\01\60"
+    "\00\01\7b\03\82\80\80\80\00\01\00\0a\9e\80\80\80"
+    "\00\01\98\80\80\80\00\00\41\01\fd\0c\0f\0e\0d\0c"
+    "\0b\0a\09\08\07\06\05\04\03\02\01\00\fd\0e\0b"
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module binary
+    "\00\61\73\6d\01\00\00\00\01\85\80\80\80\00\01\60"
+    "\00\01\7b\03\82\80\80\80\00\01\00\0a\9e\80\80\80"
+    "\00\01\98\80\80\80\00\00\fd\0c\0f\0e\0d\0c\0b\0a"
+    "\09\08\07\06\05\04\03\02\01\00\41\02\fd\0e\0b"
+  )
+  "type mismatch"
+)

--- a/test/regress/simd/v128_swizzle.wast
+++ b/test/regress/simd/v128_swizzle.wast
@@ -1,0 +1,59 @@
+(module
+;;   Swizzle and shuffle
+  (func (export "v8x16_swizzle") (param v128 v128) (result v128)
+    (i8x16.swizzle (local.get 0) (local.get 1)))
+)
+
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i8x16 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31)
+  (v128.const i8x16  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15))
+  (v128.const i8x16 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i8x16 -16 -15 -14 -13 -12 -11 -10 -9 -8 -7 -6 -5 -4 -3 -2 -1)
+  (v128.const i8x16  -8  -7  -6  -5  -4  -3  -2 -1 16 17 18 19 20 21 22 23))
+  (v128.const i8x16   0   0   0   0   0   0   0  0  0  0  0  0  0  0  0  0))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i8x16 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115)
+  (v128.const i8x16  15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0))
+  (v128.const i8x16 115 114 113 112 111 110 109 108 107 106 105 104 103 102 101 100))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i8x16 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115)
+  (v128.const i8x16  -1   1  -2   2  -3   3  -4   4  -5   5  -6   6  -7   7  -8   8))
+  (v128.const i8x16   0 101   0 102   0 103   0 104   0 105   0 106   0 107   0 108))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i8x16 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115)
+  (v128.const i8x16   9  16  10  17  11  18  12  19  13  20  14  21  15  22  16  23))
+  (v128.const i8x16 109   0 110   0 111   0 112   0 113   0 114   0 115   0   0   0))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i8x16 0x64 0x65 0x66 0x67 0x68 0x69 0x6a 0x6b 0x6c 0x6d 0x6e 0x6f 0x70 0x71 0x72 0x73)
+  (v128.const i8x16    9   16   10   17  11    18   12   19  13    20   14   21   15   22   16   23))
+  (v128.const i8x16 0x6d    0 0x6e    0 0x6f    0 0x70    0 0x71    0 0x72    0 0x73    0    0    0))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i16x8 0x6465 0x6667 0x6869 0x6a6b 0x6c6d 0x6e6f 0x7071 0x7273)
+  (v128.const i8x16 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15))
+  (v128.const i16x8 0x6465 0x6667 0x6869 0x6a6b 0x6c6d 0x6e6f 0x7071 0x7273))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i32x4 0x64656667 0x68696a6b 0x6c6d6e6f 0x70717273)
+  (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0))
+  (v128.const i32x4 0x73727170 0x6f6e6d6c 0x6b6a6968 0x67666564))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const f32x4 nan -nan inf -inf)
+  (v128.const i8x16 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15))
+  (v128.const i32x4 0x7fc00000 0xffc00000 0x7f800000 0xff800000))
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i32x4 0x67666564 0x6b6a6968 0x6f6e6d5c 0x73727170)
+  (v128.const f32x4 0.0 -0.0 inf -inf))
+  (v128.const i32x4 0x64646464 0x00646464 0x00006464 0x00006464))
+
+
+;; More literals
+(assert_return (invoke "v8x16_swizzle"
+  (v128.const i32x4 1_234_567_890 0x1234_5678 01_234_567_890 0x0_1234_5678)
+  (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15))
+  (v128.const i32x4 0x4996_02d2 0x1234_5678 0x4996_02d2 0x1234_5678))
+
+;;   Invalid types for swizzle and shuffle values
+(assert_invalid (module (func (result v128)
+  (i8x16.swizzle (i32.const 1) (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0)))) "type mismatch")
+(assert_invalid (module (func (result v128)
+  (i8x16.swizzle (v128.const i8x16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0) (i32.const 2)))) "type mismatch")


### PR DESCRIPTION
- Also refactored masm.load_v128_mask to use one fewer xmmr