### PR TITLE
Inlining counter probes

### DIFF
--- a/src/engine/Execute.v3
+++ b/src/engine/Execute.v3
@@ -70,6 +70,7 @@ component Execute {
 	}
 	// Fires probes on the global interpreter loop
 	def fireProbes(dynamicLoc: DynamicLoc) -> Throwable {
+		Metrics.probe_fires.val++;
 		var r = Execute.probes.fire(dynamicLoc);
 		return resume(r);
 	}
@@ -81,10 +82,10 @@ component Execute {
 		if (probes == null) return null;
 		var map = probes[func.decl.func_index];
 		if (map == null) return null;
-		var list = map[pc];
-		if (list == null) return null;
-		var r = list.fire(dynamicLoc);
-		if (list.elem == null) map[pc] = null;
+		var probe = map[pc];
+		if (probe == null) return null;
+		Metrics.probe_fires.val++;
+		var r = probe.fire(dynamicLoc);
 		return resume(r);
 	}
 	def resume(r: Resumption) -> Throwable {

--- a/src/engine/Module.v3
+++ b/src/engine/Module.v3
@@ -20,7 +20,7 @@ class Module(filename: string) {
 	def elems = Vector<ElemDecl>.new();
 	def data = Vector<DataDecl>.new();
 	def custom_sections = Vector<CustomSection>.new();
-	var probes: Array<Array<ProbeList>>;
+	var probes: Array<Array<Probe>>;
 
 	var start_function = -1;
 	var explicit_data_count = -1;
@@ -113,9 +113,17 @@ class Module(filename: string) {
 		if (probes == null) probes = Array.new(functions.length);
 		var map = probes[func_id];
 		if (map == null) map = probes[func_id] = Array.new(functions[func_id].orig_bytecode.length);
-		var list = map[offset];
-		if (list == null) map[offset] = list = ProbeList.new();
-		list.add(p);
+		var probe = map[offset];
+		match (probe) {
+			null => map[offset] = p;
+			l: ProbeList => l.add(p);
+			_ => {
+				var list = ProbeList.new();
+				list.add(probe);
+				list.add(p);
+				map[offset] = list;
+			}
+		}
 		functions[func_id].probeAt(offset);
 	}
 	// Insert a probe a specific offset in a specific function.
@@ -123,10 +131,21 @@ class Module(filename: string) {
 		if (probes == null) return;
 		var map = probes[func_id];
 		if (map == null) return;
-		var list = map[offset];
-		if (list == null) return;
-		list.remove(p);
-		if (list.elem == null) functions[func_id].unprobeAt(offset);
+		var probe = map[offset];
+		match (probe) {
+			null => return;
+			l: ProbeList => {
+				l.remove(p);
+				if (l.elem == null) {
+					map[offset] = null;
+					functions[func_id].unprobeAt(offset);
+				}
+			}
+			_ => if (probe == p) {
+				map[offset] = null;
+				functions[func_id].unprobeAt(offset);
+			}
+		}
 	}
 }
 

--- a/src/engine/Module.v3
+++ b/src/engine/Module.v3
@@ -128,18 +128,6 @@ class Module(filename: string) {
 		list.remove(p);
 		if (list.elem == null) functions[func_id].unprobeAt(offset);
 	}
-	// Insert a probe that is fired when a function is called
-	def insertProbeAtFuncEnter(func_id: int, p: Probe) {
-		FuncMonitorUtil.probeOnEnterExitFunc(this, this.functions[func_id], p, null);
-	}
-	// Insert a probe that is fired when a function is exited
-	def insertProbeAtFuncExit(func_id: int, p: Probe) {
-		FuncMonitorUtil.probeOnEnterExitFunc(this, this.functions[func_id], null, p);
-	}
-	// Insert probes that are fired when a function is entered and exited
-	def insertProbeAtFuncEnterExit(func_id: int, enterProbe: Probe, exitProbe: Probe) {
-		FuncMonitorUtil.probeOnEnterExitFunc(this, this.functions[func_id], enterProbe, exitProbe);
-	}
 }
 
 // For imported quantities, the module name, field name, index, and args.

--- a/src/engine/Probe.v3
+++ b/src/engine/Probe.v3
@@ -125,7 +125,7 @@ class ProbeList {
 	}
 }
 // Used internally for singly-linked list management.
-private class ProbeElem(probe: Probe) {
+class ProbeElem(probe: Probe) {
 	var next: ProbeElem;
 }
 // Utility class to implement timeouts.
@@ -137,7 +137,7 @@ class TimeoutProbe(var count: int) extends Probe {
 }
 // Utility class to count calls to {fire()}.
 class CountProbe extends Probe {
-	var count = 0;
+	var count: u64 = 0;
 	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		count++;
 		return Resumption.Continue;

--- a/src/engine/Probe.v3
+++ b/src/engine/Probe.v3
@@ -54,7 +54,7 @@ class FrameAccessor {
 
 // Internal utility to manage a mutable list of probes. Probe lists are designed to support
 // reentrant modifications by deferring changes and then applying them after iteration.
-class ProbeList {
+class ProbeList extends Probe {
 	var elem: ProbeElem;
 	private var last: ProbeElem;
 	var onEnable: void -> void;	// callback when probe list becomes non-empty
@@ -99,6 +99,7 @@ class ProbeList {
 	// Fire all probes in this list. Defers reentrant changes until after the last probe
 	// has fired. If any probe traps, rather than continuing, the last trap is returned.
 	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		Metrics.probe_fires.val--;
 		var prev = defer; // handle reentrant fire()
 		defer = true;
 		var result: Resumption = Resumption.Continue;
@@ -194,6 +195,18 @@ class TraceProbe extends Probe {
 			}
 		}
 		out.outln();
+		return Resumption.Continue;
+	}
+}
+
+class OperandProbe extends Probe { }
+class OperandProbe_i_v extends OperandProbe {
+	def fire_i(i: u32) {}
+
+	def fire(dynamicLoc: DynamicLoc) -> Resumption {
+		var accessor = dynamicLoc.frame.getFrameAccessor();
+		var value = accessor.getOperand(0);
+		fire_i(Values.v_u(value));
 		return Resumption.Continue;
 	}
 }

--- a/src/engine/Tuning.v3
+++ b/src/engine/Tuning.v3
@@ -39,4 +39,6 @@ component SpcTuning {
 	var argsInRegs = false;			// XXX: implement
 	var fastIntTierUpThreshold = 10;	// threshold at which int -> SPC tiering occurs
 	var postOsrTierUpThreshold = 1;		// threshold after completing one OSR tierup
+	var shortcutCounterCalls = false;
+	var shortcutSingleOperandCalls = false; // TODO: buggy
 }

--- a/src/engine/compiler/MacroAssembler.v3
+++ b/src/engine/compiler/MacroAssembler.v3
@@ -71,6 +71,8 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 	def getScratchReg(kind: ValueKind) -> Reg {
 		return regConfig.scratch; // TODO: get kind-specific scratch register
 	}
+	def getV3ParamReg(kind: ValueKind, index: int) -> Reg;
+	
 	// Source locations
 	def recordSourceLoc(offset: int) {
 		if (source_loc < 0) return;
@@ -234,7 +236,8 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 	def emit_store_runtime_vsp(vsp: Reg);
 	def emit_load_runtime_vsp(vsp: Reg);
 	def emit_call_runtime_Probe_instr();
-	def emit_call_closure(receiver: Pointer, closure: Pointer);
+	def emit_call_closure_CountProbe(probe: CountProbe);
+	def emit_call_closure_OperandProbe_i_v(probe: OperandProbe_i_v, value_reg: Reg);
 
 	def fatalUnimplemented();
 

--- a/src/engine/compiler/MacroAssembler.v3
+++ b/src/engine/compiler/MacroAssembler.v3
@@ -234,6 +234,7 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 	def emit_store_runtime_vsp(vsp: Reg);
 	def emit_load_runtime_vsp(vsp: Reg);
 	def emit_call_runtime_Probe_instr();
+	def emit_call_closure(receiver: Pointer, closure: Pointer);
 
 	def fatalUnimplemented();
 

--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -280,7 +280,24 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 	}
 	def emitProbe() {
 		if (last_probe == 0) return;
+		var probeList = module.probes[func.func_index][last_probe];
 		last_probe = 0;
+		
+		if (probeList.elem != null && probeList.elem.next == null) {
+			var probe = probeList.elem.probe;
+			match (probe) {
+				x: CountProbe => {
+					var unpacked = CiRuntime.unpackClosure<CountProbe, DynamicLoc, Resumption>(x.fire);
+					var closurePtr = unpacked.0;
+					var probePtr = Pointer.atObject(unpacked.1);
+					state.emitKill(resolver);
+					masm.emit_call_closure(probePtr, closurePtr);
+					emit_reload_regs();
+					return;
+				}
+				_ => ;
+			}
+		}
 		// spill everything
 		state.emitKill(resolver);
 		// compute VSP for potential frame access

--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -280,22 +280,30 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 	}
 	def emitProbe() {
 		if (last_probe == 0) return;
-		var probeList = module.probes[func.func_index][last_probe];
+		var probe = module.probes[func.func_index][last_probe];
 		last_probe = 0;
 		
-		if (probeList.elem != null && probeList.elem.next == null) {
-			var probe = probeList.elem.probe;
-			match (probe) {
-				x: CountProbe => {
-					var unpacked = CiRuntime.unpackClosure<CountProbe, DynamicLoc, Resumption>(x.fire);
-					var closurePtr = unpacked.0;
-					var probePtr = Pointer.atObject(unpacked.1);
-					state.emitKill(resolver);
-					masm.emit_call_closure(probePtr, closurePtr);
-					emit_reload_regs();
-					return;
-				}
-				_ => ;
+		match (probe) {
+			null => ;
+			x: CountProbe => if (SpcTuning.shortcutCounterCalls) {
+				state.emitKill(resolver);
+				emit_compute_vsp(regs.vsp, state.sp);
+				masm.emit_mov_m_r(ValueKind.REF, frame.vsp_slot, regs.vsp);
+				masm.emit_store_runtime_vsp(regs.vsp);
+				masm.emit_call_closure_CountProbe(x);
+				emit_reload_regs();
+				return;
+			}
+			x: OperandProbe_i_v => if (SpcTuning.shortcutSingleOperandCalls) {
+				state.emitKill(resolver);
+				emit_compute_vsp(regs.vsp, state.sp);
+				masm.emit_mov_m_r(ValueKind.REF, frame.vsp_slot, regs.vsp);
+				masm.emit_store_runtime_vsp(regs.vsp);
+				var value_reg = masm.getV3ParamReg(ValueKind.I32, 1);
+				peekFixedReg(value_reg);
+				masm.emit_call_closure_OperandProbe_i_v(x, value_reg);
+				emit_reload_regs();
+				return;
 			}
 		}
 		// spill everything
@@ -311,6 +319,7 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		// call runtime
 		masm.emit_call_runtime_Probe_instr();
 		emit_reload_regs();
+		
 	}
 	def visit_CRASH_EXEC() {
 		masm.emit_intentional_crash();
@@ -1297,6 +1306,26 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		if (sv.isConst()) masm.emit_mov_r_k(kind, reg, sv.const);
 		else masm.emit_mov_r_s(kind, reg, state.sp);
 		unrefLater(sv.reg, int.!(state.sp));
+		return SpcVal(sv.flags | IN_REG, reg, sv.const);
+	}
+	// Peek the top of the stack and move it into {reg}, spilling any value(s) in {reg} first.
+	def peekFixedReg(reg: Reg) -> SpcVal {
+		// XXX: Factor commonality with popFixedReg
+		var sv = state.peek(), slot = int.!(state.sp - 1);
+		if (sv.reg == reg) {
+			return sv;
+		}
+		spillReg(reg);
+		regAlloc.assign(reg, slot);
+		var kind = sv.kind();
+		if (sv.inReg()) {
+			masm.emit_mov_r_r(reg, sv.reg);
+			regAlloc.unassign(sv.reg, slot);
+		} else if (sv.isConst()) {
+			masm.emit_mov_r_k(kind, reg, sv.const);
+		} else {
+			masm.emit_mov_r_s(kind, reg, state.sp);
+		}
 		return SpcVal(sv.flags | IN_REG, reg, sv.const);
 	}
 	// Pop the top of the stack into {reg}, spilling any value(s) in {reg} first.

--- a/src/engine/x86-64/Tuning.v3
+++ b/src/engine/x86-64/Tuning.v3
@@ -1,0 +1,41 @@
+// Copyright 2022 Ben L. Titzer. All rights reserved.
+// See LICENSE for details of Apache 2.0 license.
+
+// Options that control techniques that primarily impact interpreter performance.
+class X86_64InterpreterTuning {
+	// Interpreter tuning settings; no effect on correctness
+	var threadedDispatch = true;	// inline dispatch at the end of every handler
+	var handlerAlignment = 8;	// align handler code in memory
+	var dispatchEntrySize = 4;	// size of each dispatch table entry
+	var inlineAllLEBs = false;	// always inline LEB slow cases
+
+	// JIT tuning settings; no effect on correctness
+	var trackFloatZeroConst = true;
+	var trackFloat32Const = false; // XXX: enable
+	var directSpcCalls = false;    // XXX: implement
+	var lazySlotZeroing = false;   // XXX: implement
+	var spcArgsInRegs = false;     // XXX: implement
+	var shortcutCounterCalls = true;
+	var shortcutSingleOperandCalls = false; // TODO: buggy
+
+	// Required for trap location reporting
+	var recordCurIpForTraps = true;
+
+	// Required for correct GC tracing; turn off only for performance testing
+	var taggedValues = true;
+
+	// Required for instrumentation; turn off if no instrumentation supported needed
+	var dispatchTableReg = true;
+	var cacheFrameAccessor = true;
+
+	// Required for multi-tier execution; interpreter calls target code entrypoint instead of itself.
+	var multiTierSupport = true;
+
+	// Required for supporting the multi-memory extension.
+	var multiMemorySupport = true;
+
+	// Required for full spec compliance; turn off only for performance testing
+	var useTypeTagTable = true;	// enables support for value types with heap type indices
+	var complexBlockTypes = true;
+	var simdSupport = true;
+}

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -8,6 +8,7 @@ def A(ma: MasmAddr) -> X86_64Addr {
 	return X86_64Addr.new(G(ma.base), null, 1, ma.offset);
 }
 def RT: X86_64Runtime;
+def NO_REG = Reg(0);
 
 class X86_64MasmLabel extends MasmLabel {
 	def label: X86_64Label;
@@ -65,6 +66,13 @@ class X86_64MacroAssembler extends MacroAssembler {
 		// To distinguish an entry for the return address of a call from an entry for a Wasm instruction
 		// following the call, return addresses have a {-1} adjustment.
 		recordSourceLoc(asm.pos() - 1);
+	}
+	def getV3ParamReg(kind: ValueKind, index: int) -> Reg {
+		match (kind) {
+			I32, I64, REF => return X86_64MasmRegs.PARAM_GPRS[index];
+			_ => unimplemented();
+		}
+		return NO_REG;
 	}
 
 	def emit_intentional_crash() {
@@ -669,6 +677,20 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def emit_call_closure(receiver: Pointer, closure: Pointer) {
 		asm.movd_r_i(Target.V3_PARAM_GPRS[0], int.view(u32.!(receiver - Pointer.NULL)));
 		asm.movd_r_i(scratch, int.view(u32.!(closure - Pointer.NULL))); // XXX: make direct call to runtime if within 2GB
+		asm.icall_r(scratch);
+		recordRetSourceLoc();
+	}
+	def emit_call_closure_CountProbe(probe: CountProbe) {
+		var ptr = Pointer.atObject(probe);
+		var fieldPtr = Pointer.atField(probe.count);
+		asm.inc_m(X86_64Addr.new(null, null, 1, int.!(fieldPtr - Pointer.NULL)));
+	}
+	def emit_call_closure_OperandProbe_i_v(probe: OperandProbe_i_v, value_reg: Reg) {
+		var ptr = CiRuntime.unpackClosure<OperandProbe_i_v, u32, void>(probe.fire_i);
+		var closurePtr = ptr.0;
+		var probePtr = Pointer.atObject(ptr.1);
+		asm.movq_r_l(Target.V3_PARAM_GPRS[0], probePtr - Pointer.NULL);
+		asm.movq_r_l(scratch, closurePtr - Pointer.NULL); // XXX: make direct call to runtime if within 2GB
 		asm.icall_r(scratch);
 		recordRetSourceLoc();
 	}

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -666,6 +666,12 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def emit_call_runtime_Probe_instr() {
 		emit_call_runtime(RT.runtime_PROBE_instr);
 	}
+	def emit_call_closure(receiver: Pointer, closure: Pointer) {
+		asm.movd_r_i(Target.V3_PARAM_GPRS[0], int.view(u32.!(receiver - Pointer.NULL)));
+		asm.movd_r_i(scratch, int.view(u32.!(closure - Pointer.NULL))); // XXX: make direct call to runtime if within 2GB
+		asm.icall_r(scratch);
+		recordRetSourceLoc();
+	}
 	private def emit_call_runtime<P, R>(closure: P -> R) {
 		var ptr = CiRuntime.unpackClosure<X86_64Interpreter, P, R>(closure).0;
 		// Do an absolute call into the runtime

--- a/src/engine/x86-64/X86_64MasmRegs.v3
+++ b/src/engine/x86-64/X86_64MasmRegs.v3
@@ -48,6 +48,9 @@ component X86_64MasmRegs {
 	def XMM14 = addXmmr(X86_64Regs.XMM14);
 	def XMM15 = addXmmr(X86_64Regs.XMM15);
 
+	def PARAM_GPRS = [RDI, RSI, RDX, RCX, R8, R9];
+	def RET_GPRS = [RAX, RDX, RCX, RSI];
+
 	def IVAR_FRAME = IVarFrame.new();
 	def SET = buildRegSet();
 	def CONFIG = buildRegConfig();

--- a/src/monitors/HotnessMonitor.v3
+++ b/src/monitors/HotnessMonitor.v3
@@ -47,7 +47,7 @@ private class HotnessData(m: Module) {
 	def spectrum = Palette.spectrum;
 
 	def newProbe(f: FuncDecl, op: Opcode, pc: int) -> LocCounter {
-		var p = LocCounter.new(f, pc, op, 0, 0);
+		var p = LocCounter.new(f, pc, op, 0);
 		counters.put(p);
 		return p;
 	}
@@ -161,7 +161,7 @@ private class HotnessData(m: Module) {
 	}
 }
 
-private class LocCounter(func: FuncDecl, pc: int, op: Opcode, var count: u64, var group: int) extends Probe {
+private class LocCounter(func: FuncDecl, pc: int, op: Opcode, var group: int) extends CountProbe {
 	def compare(that: LocCounter) -> bool {
 		if (this.count > that.count) return true;
 		if (this.count < that.count) return false;
@@ -169,9 +169,5 @@ private class LocCounter(func: FuncDecl, pc: int, op: Opcode, var count: u64, va
 		if (this.func.func_index > that.func.func_index) return false;
 		if (this.pc < that.pc) return true;
 		return false;
-	}
-	def fire(loc: DynamicLoc) -> Resumption {
-		count++;
-		return Resumption.Continue;
 	}
 }


### PR DESCRIPTION
- `ProbeList` now extends `Probe`, so `Probe`s and `ProbeList` can both be fired in the same way.

I have both potential optimizations turned off for now, since they cause some tests to fail:
- the `CountProbe` optimization works until there's a GC, since we don't update the pointer of the `count` field in the JIT'd code right now
- the operand probe optimization doesn't work for now, haven't had time to fix it but some register is getting overwritten