### PR TITLE
[simd/jit]: Implement simple i32x4 arithmetic operations

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -464,6 +464,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I8X16_ADD() { do_op2_x_x(ValueKind.V128, asm.paddb_s_s); }
 	def visit_I8X16_SUB() { do_op2_x_x(ValueKind.V128, asm.psubb_s_s); }
 
+	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
+	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }
+	def visit_I32X4_MUL() { do_op2_x_x(ValueKind.V128, asm.pmulld_s_s); }
+
 	private def visit_V128_NEG<T>(emit: (X86_64Xmmr, X86_64Xmmr) -> T) -> void {
 		var sv = popReg(), r = X(sv.reg);
 		var tmp = allocTmp(ValueKind.V128), t = X(tmp);
@@ -471,6 +475,9 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		state.push(sv.kindFlagsMatching(ValueKind.V128, IN_REG), sv.reg, 0);
 	}
 	def visit_I8X16_NEG() { visit_V128_NEG(mmasm.emit_i8x16_neg); }
+
+	def visit_I32X4_NEG() { visit_V128_NEG(mmasm.emit_i32x4_neg); }
+
 	def visit_V128_BITSELECT() {
 		var c = popReg();
 		var b = popReg();


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_arith.bin.wast`