### PR TITLE
[simd/jit]: Implement i64x2 comparison instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -496,6 +496,12 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		state.push(a.kindFlagsMatching(ValueKind.V128, IN_REG), a.reg, 0);
 	}
 	def visit_I64X2_NEG() { visit_V128_I_NEG(mmasm.emit_i64x2_neg); }
+	def visit_I64X2_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqq_s_s); }
+	def visit_I64X2_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ne); }
+	def visit_I64X2_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
+	def visit_I64X2_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
+	def visit_I64X2_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I64X2_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
 
 	def visit_F32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.addps_s_s); }
 	def visit_F32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.subps_s_s); }


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i64x2_cmp.bin.wast`