### PR TITLE
[simd/jit]: Implement more i8x16 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -474,6 +474,13 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I8X16_GE_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ge_u); }
 	def visit_I8X16_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ge_s); }
 	def visit_I8X16_LE_U() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ge_u); }
+	def visit_I8X16_MIN_S() { do_op2_x_x(ValueKind.V128, asm.pminsb_s_s); }
+	def visit_I8X16_MIN_U() { do_op2_x_x(ValueKind.V128, asm.pminub_s_s); }
+	def visit_I8X16_MAX_S() { do_op2_x_x(ValueKind.V128, asm.pmaxsb_s_s); }
+	def visit_I8X16_MAX_U() { do_op2_x_x(ValueKind.V128, asm.pmaxub_s_s); }
+	def visit_I8X16_AVGR_U() { do_op2_x_x(ValueKind.V128, asm.pavgb_s_s); }
+	def visit_I8X16_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsb_s_s); }
+	def visit_I8X16_POPCNT() { do_op1_x(ValueKind.V128, mmasm.emit_i8x16_popcnt(_, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)), X(allocTmp(ValueKind.V128)), X(allocTmp(ValueKind.V128)))); }
 
 	def visit_I16X8_ADD() { do_op2_x_x(ValueKind.V128, asm.paddw_s_s); }
 	def visit_I16X8_SUB() { do_op2_x_x(ValueKind.V128, asm.psubw_s_s); }
@@ -610,6 +617,13 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		var d = allocRegTos(kind);
 		emit(X(d), r);
 		state.push(sv.kindFlagsMatching(kind, IN_REG), d, 0);
+		return true;
+	}
+	// r1 = op(r1), SIMD unop
+	private def do_op1_x<T>(kind: ValueKind, emit: (X86_64Xmmr) -> T) -> bool {
+		var sv = popReg(), r = X(sv.reg);
+		emit(r);
+		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
 		return true;
 	}
 	// x1 = op(x1, x2)

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -621,7 +621,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	}
 	// r1 = op(r1), SIMD unop
 	private def do_op1_x<T>(kind: ValueKind, emit: (X86_64Xmmr) -> T) -> bool {
-		var sv = popReg(), r = X(sv.reg);
+		var sv = popRegToOverwrite(), r = X(sv.reg);
 		emit(r);
 		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
 		return true;


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i8x16_arith2.bin.wast`