### PR TITLE
[simd/jit]: Implement more i16x8 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -489,6 +489,12 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_GE_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ge_u); }
 	def visit_I16X8_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ge_s); }
 	def visit_I16X8_LE_U() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ge_u); }
+	def visit_I16X8_MIN_S() { do_op2_x_x(ValueKind.V128, asm.pminsw_s_s); }
+	def visit_I16X8_MIN_U() { do_op2_x_x(ValueKind.V128, asm.pminuw_s_s); }
+	def visit_I16X8_MAX_S() { do_op2_x_x(ValueKind.V128, asm.pmaxsw_s_s); }
+	def visit_I16X8_MAX_U() { do_op2_x_x(ValueKind.V128, asm.pmaxuw_s_s); }
+	def visit_I16X8_AVGR_U() { do_op2_x_x(ValueKind.V128, asm.pavgw_s_s); }
+	def visit_I16X8_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsw_s_s); }
 
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i16x8_arith2.bin.wast`