### PR TITLE
[simd/jit]: Implement more i32x4 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -504,6 +504,11 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_GE_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ge_u); }
 	def visit_I32X4_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ge_s); }
 	def visit_I32X4_LE_U() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ge_u); }
+	def visit_I32X4_MIN_S() { do_op2_x_x(ValueKind.V128, asm.pminsd_s_s); }
+	def visit_I32X4_MIN_U() { do_op2_x_x(ValueKind.V128, asm.pminud_s_s); }
+	def visit_I32X4_MAX_S() { do_op2_x_x(ValueKind.V128, asm.pmaxsd_s_s); }
+	def visit_I32X4_MAX_U() { do_op2_x_x(ValueKind.V128, asm.pmaxud_s_s); }
+	def visit_I32X4_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsd_s_s); }
 
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_arith2.bin.wast`