### PR TITLE
[simd/jit]: Implement i64x2_abs

### DIFF
--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2560,24 +2560,17 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		genSimdBinopCommute(Opcode.I16X8_LT_U, masm.emit_i16x8_gt_u(_, _, r_xmm2));
 		genSimdBinopCommute(Opcode.I32X4_LT_U, masm.emit_i32x4_gt_u(_, _, r_xmm2));
 
+		// todo: factor out this loop	
 		for (t in [
 			(Opcode.I8X16_NEG, masm.emit_i8x16_neg),
 			(Opcode.I16X8_NEG, masm.emit_i16x8_neg),
 			(Opcode.I32X4_NEG, masm.emit_i32x4_neg),
-			(Opcode.I64X2_NEG, masm.emit_i64x2_neg)
+			(Opcode.I64X2_NEG, masm.emit_i64x2_neg),
+			(Opcode.I64X2_ABS, masm.emit_i64x2_abs)
 		]) {
 			bindHandler(t.0);
 			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
 			t.1(r_xmm0, r_xmm1);
-			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
-			endHandler();
-		}
-		bindHandler(Opcode.I64X2_ABS); {
-			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-			asm.movshdup_s_s(r_xmm1, r_xmm0);
-			asm.psrad_i(r_xmm1, 31);
-			asm.xorps_s_s(r_xmm0, r_xmm1);
-			asm.psubq_s_s(r_xmm0, r_xmm1);
 			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 			endHandler();
 		}

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -981,6 +981,12 @@ class X86_64MacroAssembler extends MacroAssembler {
 		asm.psrlw_s_s(dst, tmp3);
 		asm.packuswb_s_s(dst, tmp2);
 	}
+	def emit_i64x2_abs(dst: X86_64Xmmr, scratch: X86_64Xmmr) {
+		asm.movshdup_s_s(scratch, dst);
+		asm.psrad_i(scratch, 31);
+		asm.xorps_s_s(dst, scratch);
+		asm.psubq_s_s(dst, scratch);
+	}
 	def emit_i64x2_shr_s(dst: X86_64Xmmr, shift: X86_64Gpr, xmm_tmp: X86_64Xmmr, xmm_shift: X86_64Xmmr, tmp_shift: X86_64Gpr) {
 		asm.pcmpeqd_s_s(xmm_tmp, xmm_tmp);
 		asm.psllq_i(xmm_tmp, 63);

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -515,6 +515,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I64X2_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
 	def visit_I64X2_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
 	def visit_I64X2_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I64X2_ABS() { visit_V128_I_NEG(mmasm.emit_i64x2_abs); } // todo: generalize and factor out visit_V128_I_NEG
 
 	def visit_F32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.addps_s_s); }
 	def visit_F32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.subps_s_s); }


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i64x2_arith2.bin.wast`