### PR TITLE
[simd/jit]: Implement f32x4 comparison instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -522,6 +522,12 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F32X4_DIV() { do_op2_x_x(ValueKind.V128, asm.divps_s_s); }
 	def visit_F32X4_NEG() { visit_V128_F_NEG_ABS(mmasm.emit_v128_negps); }
 	def visit_F32X4_SQRT() { do_op1_x_x(ValueKind.V128, asm.sqrtps_s_s); }
+	def visit_F32X4_EQ() { do_op2_x_x(ValueKind.V128, asm.cmpeqps_s_s); }
+	def visit_F32X4_NE() { do_op2_x_x(ValueKind.V128, asm.cmpneqps_s_s); }
+	def visit_F32X4_GT() { do_c_op2_x_x(ValueKind.V128, asm.cmpltps_s_s); }
+	def visit_F32X4_LT() { do_op2_x_x(ValueKind.V128, asm.cmpltps_s_s); }
+	def visit_F32X4_GE() { do_c_op2_x_x(ValueKind.V128, asm.cmpleps_s_s); }
+	def visit_F32X4_LE() { do_op2_x_x(ValueKind.V128, asm.cmpleps_s_s); }
 
 	def visit_F64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.addpd_s_s); }
 	def visit_F64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.subpd_s_s); }


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_f32x4_cmp.bin.wast`