### PR TITLE
[simd/jit]: Implement f64x2 comparison instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -529,6 +529,13 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F64X2_DIV() { do_op2_x_x(ValueKind.V128, asm.divpd_s_s); }
 	def visit_F64X2_NEG() { visit_V128_F_NEG_ABS(mmasm.emit_v128_negpd); }
 	def visit_F64X2_SQRT() { do_op1_x_x(ValueKind.V128, asm.sqrtpd_s_s); }
+	def visit_F64X2_EQ() { do_op2_x_x(ValueKind.V128, asm.cmpeqpd_s_s); }
+	def visit_F64X2_NE() { do_op2_x_x(ValueKind.V128, asm.cmpneqpd_s_s); }
+	def visit_F64X2_GT() { do_c_op2_x_x(ValueKind.V128, asm.cmpltpd_s_s); }
+	def visit_F64X2_LT() { do_op2_x_x(ValueKind.V128, asm.cmpltpd_s_s); }
+	def visit_F64X2_GE() { do_c_op2_x_x(ValueKind.V128, asm.cmplepd_s_s); }
+	def visit_F64X2_LE() { do_op2_x_x(ValueKind.V128, asm.cmplepd_s_s); }
+
 
 	def visit_V128_BITSELECT() {
 		var c = popReg();


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_f64x2_cmp.bin.wast`