### PR TITLE
[simd/jit]: Refactor unops using partial application

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -463,7 +463,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 
 	def visit_I8X16_ADD() { do_op2_x_x(ValueKind.V128, asm.paddb_s_s); }
 	def visit_I8X16_SUB() { do_op2_x_x(ValueKind.V128, asm.psubb_s_s); }
-	def visit_I8X16_NEG() { visit_V128_I_NEG(mmasm.emit_i8x16_neg); }
+	def visit_I8X16_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i8x16_neg(_,  X(allocTmp(ValueKind.V128)))); }
 	def visit_I8X16_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqb_s_s); }
 	def visit_I8X16_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ne); }
 	def visit_I8X16_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtb_s_s); }
@@ -485,7 +485,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_ADD() { do_op2_x_x(ValueKind.V128, asm.paddw_s_s); }
 	def visit_I16X8_SUB() { do_op2_x_x(ValueKind.V128, asm.psubw_s_s); }
 	def visit_I16X8_MUL() { do_op2_x_x(ValueKind.V128, asm.pmullw_s_s); }
-	def visit_I16X8_NEG() { visit_V128_I_NEG(mmasm.emit_i16x8_neg); }
+	def visit_I16X8_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i16x8_neg(_,  X(allocTmp(ValueKind.V128)))); }
 	def visit_I16X8_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqw_s_s); }
 	def visit_I16X8_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ne); }
 	def visit_I16X8_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtw_s_s); }
@@ -506,7 +506,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }
 	def visit_I32X4_MUL() { do_op2_x_x(ValueKind.V128, asm.pmulld_s_s); }
-	def visit_I32X4_NEG() { visit_V128_I_NEG(mmasm.emit_i32x4_neg); }
+	def visit_I32X4_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i32x4_neg(_,  X(allocTmp(ValueKind.V128)))); }
 	def visit_I32X4_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqd_s_s); }
 	def visit_I32X4_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ne); }
 	def visit_I32X4_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtd_s_s); }
@@ -526,20 +526,20 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }
 	def visit_I64X2_MUL() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_mul(_, _, X(allocTmp(ValueKind.V128)), X(allocTmp(ValueKind.V128)))); }
-	def visit_I64X2_NEG() { visit_V128_I_NEG(mmasm.emit_i64x2_neg); }
+	def visit_I64X2_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i64x2_neg(_,  X(allocTmp(ValueKind.V128)))); }
 	def visit_I64X2_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqq_s_s); }
 	def visit_I64X2_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ne); }
 	def visit_I64X2_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
 	def visit_I64X2_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
 	def visit_I64X2_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
 	def visit_I64X2_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_I64X2_ABS() { visit_V128_I_NEG(mmasm.emit_i64x2_abs); } // todo: generalize and factor out visit_V128_I_NEG
+	def visit_I64X2_ABS() { do_op1_x(ValueKind.V128, mmasm.emit_i64x2_abs(_,  X(allocTmp(ValueKind.V128)))); }
 
 	def visit_F32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.addps_s_s); }
 	def visit_F32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.subps_s_s); }
 	def visit_F32X4_MUL() { do_op2_x_x(ValueKind.V128, asm.mulps_s_s); }
 	def visit_F32X4_DIV() { do_op2_x_x(ValueKind.V128, asm.divps_s_s); }
-	def visit_F32X4_NEG() { visit_V128_F_NEG_ABS(mmasm.emit_v128_negps); }
+	def visit_F32X4_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_v128_negps(_, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)))); }
 	def visit_F32X4_SQRT() { do_op1_x_x(ValueKind.V128, asm.sqrtps_s_s); }
 	def visit_F32X4_EQ() { do_op2_x_x(ValueKind.V128, asm.cmpeqps_s_s); }
 	def visit_F32X4_NE() { do_op2_x_x(ValueKind.V128, asm.cmpneqps_s_s); }
@@ -552,7 +552,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.subpd_s_s); }
 	def visit_F64X2_MUL() { do_op2_x_x(ValueKind.V128, asm.mulpd_s_s); }
 	def visit_F64X2_DIV() { do_op2_x_x(ValueKind.V128, asm.divpd_s_s); }
-	def visit_F64X2_NEG() { visit_V128_F_NEG_ABS(mmasm.emit_v128_negpd); }
+	def visit_F64X2_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_v128_negpd(_, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)))); }
 	def visit_F64X2_SQRT() { do_op1_x_x(ValueKind.V128, asm.sqrtpd_s_s); }
 	def visit_F64X2_EQ() { do_op2_x_x(ValueKind.V128, asm.cmpeqpd_s_s); }
 	def visit_F64X2_NE() { do_op2_x_x(ValueKind.V128, asm.cmpneqpd_s_s); }
@@ -569,21 +569,6 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		var t = allocTmp(ValueKind.V128);
 		mmasm.emit_v128_bitselect(X(a.reg), X(b.reg), X(c.reg), X(t));
 		state.push(a.kindFlagsMatching(ValueKind.V128, IN_REG), a.reg, 0);
-	}
-
-	private def visit_V128_F_NEG_ABS<T>(emit: (X86_64Xmmr, X86_64Gpr, X86_64Xmmr) -> T) -> void {
-		var sv = popRegToOverwrite();
-		var tmp = allocTmp(ValueKind.I64);
-		var mask = allocTmp(ValueKind.V128);
-		emit(X(sv.reg), G(tmp), X(mask));
-		state.push(sv.kindFlagsMatching(ValueKind.V128, IN_REG), sv.reg, 0);
-	}
-
-	private def visit_V128_I_NEG<T>(emit: (X86_64Xmmr, X86_64Xmmr) -> T) -> void {
-		var sv = popReg(), r = X(sv.reg);
-		var tmp = allocTmp(ValueKind.V128), t = X(tmp);
-		emit(r, t);
-		state.push(sv.kindFlagsMatching(ValueKind.V128, IN_REG), sv.reg, 0);
 	}
 
 	// r1 = op(r1)

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -539,7 +539,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.subps_s_s); }
 	def visit_F32X4_MUL() { do_op2_x_x(ValueKind.V128, asm.mulps_s_s); }
 	def visit_F32X4_DIV() { do_op2_x_x(ValueKind.V128, asm.divps_s_s); }
-	def visit_F32X4_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_v128_negps(_, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)))); }
+	def visit_F32X4_NEG() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_v128_negps); }
 	def visit_F32X4_SQRT() { do_op1_x_x(ValueKind.V128, asm.sqrtps_s_s); }
 	def visit_F32X4_EQ() { do_op2_x_x(ValueKind.V128, asm.cmpeqps_s_s); }
 	def visit_F32X4_NE() { do_op2_x_x(ValueKind.V128, asm.cmpneqps_s_s); }
@@ -552,7 +552,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.subpd_s_s); }
 	def visit_F64X2_MUL() { do_op2_x_x(ValueKind.V128, asm.mulpd_s_s); }
 	def visit_F64X2_DIV() { do_op2_x_x(ValueKind.V128, asm.divpd_s_s); }
-	def visit_F64X2_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_v128_negpd(_, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)))); }
+	def visit_F64X2_NEG() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_v128_negpd); }
 	def visit_F64X2_SQRT() { do_op1_x_x(ValueKind.V128, asm.sqrtpd_s_s); }
 	def visit_F64X2_EQ() { do_op2_x_x(ValueKind.V128, asm.cmpeqpd_s_s); }
 	def visit_F64X2_NE() { do_op2_x_x(ValueKind.V128, asm.cmpneqpd_s_s); }
@@ -633,6 +633,15 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	private def do_op1_x<T>(kind: ValueKind, emit: (X86_64Xmmr) -> T) -> bool {
 		var sv = popRegToOverwrite(), r = X(sv.reg);
 		emit(r);
+		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
+		return true;
+	}
+	// r1 = op(r1, gtmp, xtmp)
+	private def do_op1_x_gtmp_xtmp<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Gpr, X86_64Xmmr) -> T) -> bool {
+		var sv = popRegToOverwrite(), r = X(sv.reg);
+		var g_tmp = G(allocTmp(ValueKind.I64));
+		var x_tmp = X(allocTmp(ValueKind.V128));
+		emit(r, g_tmp, x_tmp);
 		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
 		return true;
 	}

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -463,7 +463,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 
 	def visit_I8X16_ADD() { do_op2_x_x(ValueKind.V128, asm.paddb_s_s); }
 	def visit_I8X16_SUB() { do_op2_x_x(ValueKind.V128, asm.psubb_s_s); }
-	def visit_I8X16_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i8x16_neg(_,  X(allocTmp(ValueKind.V128)))); }
+	def visit_I8X16_NEG() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i8x16_neg); }
 	def visit_I8X16_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqb_s_s); }
 	def visit_I8X16_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ne); }
 	def visit_I8X16_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtb_s_s); }
@@ -485,7 +485,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_ADD() { do_op2_x_x(ValueKind.V128, asm.paddw_s_s); }
 	def visit_I16X8_SUB() { do_op2_x_x(ValueKind.V128, asm.psubw_s_s); }
 	def visit_I16X8_MUL() { do_op2_x_x(ValueKind.V128, asm.pmullw_s_s); }
-	def visit_I16X8_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i16x8_neg(_,  X(allocTmp(ValueKind.V128)))); }
+	def visit_I16X8_NEG() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_neg); }
 	def visit_I16X8_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqw_s_s); }
 	def visit_I16X8_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ne); }
 	def visit_I16X8_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtw_s_s); }
@@ -506,7 +506,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }
 	def visit_I32X4_MUL() { do_op2_x_x(ValueKind.V128, asm.pmulld_s_s); }
-	def visit_I32X4_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i32x4_neg(_,  X(allocTmp(ValueKind.V128)))); }
+	def visit_I32X4_NEG() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_neg); }
 	def visit_I32X4_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqd_s_s); }
 	def visit_I32X4_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ne); }
 	def visit_I32X4_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtd_s_s); }
@@ -526,14 +526,14 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }
 	def visit_I64X2_MUL() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_mul(_, _, X(allocTmp(ValueKind.V128)), X(allocTmp(ValueKind.V128)))); }
-	def visit_I64X2_NEG() { do_op1_x(ValueKind.V128, mmasm.emit_i64x2_neg(_,  X(allocTmp(ValueKind.V128)))); }
+	def visit_I64X2_NEG() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_neg); }
 	def visit_I64X2_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqq_s_s); }
 	def visit_I64X2_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ne); }
 	def visit_I64X2_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
 	def visit_I64X2_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
 	def visit_I64X2_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
 	def visit_I64X2_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_I64X2_ABS() { do_op1_x(ValueKind.V128, mmasm.emit_i64x2_abs(_,  X(allocTmp(ValueKind.V128)))); }
+	def visit_I64X2_ABS() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_abs); }
 
 	def visit_F32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.addps_s_s); }
 	def visit_F32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.subps_s_s); }
@@ -633,6 +633,14 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	private def do_op1_x<T>(kind: ValueKind, emit: (X86_64Xmmr) -> T) -> bool {
 		var sv = popRegToOverwrite(), r = X(sv.reg);
 		emit(r);
+		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
+		return true;
+	}
+	// r1 = op(r1, xtmp)
+	private def do_op1_x_xtmp<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr) -> T) -> bool {
+		var sv = popRegToOverwrite(), r = X(sv.reg);
+		var x_tmp = X(allocTmp(ValueKind.V128));
+		emit(r, x_tmp);
 		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
 		return true;
 	}


### PR DESCRIPTION
Tested by:

```bash
function jit_test {
  make -j

  # Array of variables
  var_list=("i8x16" "i16x8" "i32x4" "i64x2" "f32x4" "f64x2")

  # Loop over array and execute command
  for var in "${var_list[@]}"
  do
      bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_${var}_arith.bin.wast
      # Only integer types have the second test
      if [[ ${var:0:1} != "f" ]]
      then
          bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_${var}_arith2.bin.wast
      fi
  done | progress
}

jit_test
```