### PR TITLE
[simd/jit]: Implement i8x16 saturating integer arithmetic

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -481,6 +481,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I8X16_AVGR_U() { do_op2_x_x(ValueKind.V128, asm.pavgb_s_s); }
 	def visit_I8X16_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsb_s_s); }
 	def visit_I8X16_POPCNT() { do_op1_x(ValueKind.V128, mmasm.emit_i8x16_popcnt(_, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)), X(allocTmp(ValueKind.V128)), X(allocTmp(ValueKind.V128)))); }
+	def visit_I8X16_ADD_SAT_S() { do_op2_x_x(ValueKind.V128, asm.paddsb_s_s); }
+	def visit_I8X16_ADD_SAT_U() { do_op2_x_x(ValueKind.V128, asm.paddusb_s_s); }
+	def visit_I8X16_SUB_SAT_S() { do_op2_x_x(ValueKind.V128, asm.psubsb_s_s); }
+	def visit_I8X16_SUB_SAT_U() { do_op2_x_x(ValueKind.V128, asm.psubusb_s_s); }
 
 	def visit_I16X8_ADD() { do_op2_x_x(ValueKind.V128, asm.paddw_s_s); }
 	def visit_I16X8_SUB() { do_op2_x_x(ValueKind.V128, asm.psubw_s_s); }


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i8x16_sat_arith.bin.wast`