### PR TITLE
[simd/jit]: Implement more i16x8 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -506,6 +506,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_ADD_SAT_U() { do_op2_x_x(ValueKind.V128, asm.paddusw_s_s); }
 	def visit_I16X8_SUB_SAT_S() { do_op2_x_x(ValueKind.V128, asm.psubsw_s_s); }
 	def visit_I16X8_SUB_SAT_U() { do_op2_x_x(ValueKind.V128, asm.psubusw_s_s); }
+	def visit_I16X8_EXTADDPAIRWISE_I8X16_S() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_s); }
+	def visit_I16X8_EXTADDPAIRWISE_I8X16_U() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_u); }
 
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -512,6 +512,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_EXTMUL_LOW_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), false)); }
 	def visit_I16X8_EXTMUL_HIGH_I8X16_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_high_s(_, _, X(allocTmp(ValueKind.V128)))); }
 	def visit_I16X8_EXTMUL_HIGH_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_high_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I16X8_Q15MULRSAT_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_q15mulrsat_s(_, _, X(allocTmp(ValueKind.V128)))); } // todo: factor out this routine
 
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -502,6 +502,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_MAX_U() { do_op2_x_x(ValueKind.V128, asm.pmaxuw_s_s); }
 	def visit_I16X8_AVGR_U() { do_op2_x_x(ValueKind.V128, asm.pavgw_s_s); }
 	def visit_I16X8_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsw_s_s); }
+	def visit_I16X8_ADD_SAT_S() { do_op2_x_x(ValueKind.V128, asm.paddsw_s_s); }
+	def visit_I16X8_ADD_SAT_U() { do_op2_x_x(ValueKind.V128, asm.paddusw_s_s); }
+	def visit_I16X8_SUB_SAT_S() { do_op2_x_x(ValueKind.V128, asm.psubsw_s_s); }
+	def visit_I16X8_SUB_SAT_U() { do_op2_x_x(ValueKind.V128, asm.psubusw_s_s); }
 
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -508,6 +508,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_SUB_SAT_U() { do_op2_x_x(ValueKind.V128, asm.psubusw_s_s); }
 	def visit_I16X8_EXTADDPAIRWISE_I8X16_S() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_s); }
 	def visit_I16X8_EXTADDPAIRWISE_I8X16_U() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_u); }
+	def visit_I16X8_EXTMUL_LOW_I8X16_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), true)); }
+	def visit_I16X8_EXTMUL_LOW_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), false)); }
+	def visit_I16X8_EXTMUL_HIGH_I8X16_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_high_s(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I16X8_EXTMUL_HIGH_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_high_u(_, _, X(allocTmp(ValueKind.V128)))); }
 
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }


### PR DESCRIPTION
Tested by:
```bash
make -j
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i16x8_q15mulr_sat_s.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i16x8_extmul_i8x16.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i16x8_extadd_pairwise_i8x16.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i16x8_sat_arith.bin.wast
```