### PR TITLE
[simd/jit]: Implement more i32x4 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -537,6 +537,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_MAX_S() { do_op2_x_x(ValueKind.V128, asm.pmaxsd_s_s); }
 	def visit_I32X4_MAX_U() { do_op2_x_x(ValueKind.V128, asm.pmaxud_s_s); }
 	def visit_I32X4_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsd_s_s); }
+	def visit_I32X4_DOT_I16X8_S() { do_op2_x_x(ValueKind.V128, asm.pmaddwd_s_s); }
 
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -538,6 +538,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_MAX_U() { do_op2_x_x(ValueKind.V128, asm.pmaxud_s_s); }
 	def visit_I32X4_ABS() { do_op1_x_x(ValueKind.V128, asm.pabsd_s_s); }
 	def visit_I32X4_DOT_I16X8_S() { do_op2_x_x(ValueKind.V128, asm.pmaddwd_s_s); }
+	def visit_I32X4_EXTADDPAIRWISE_I16X8_S() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i32x4_extadd_pairwise_i16x8_s); }
+	def visit_I32X4_EXTADDPAIRWISE_I16X8_U() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_extadd_pairwise_i16x8_u); }
 
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -540,6 +540,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_DOT_I16X8_S() { do_op2_x_x(ValueKind.V128, asm.pmaddwd_s_s); }
 	def visit_I32X4_EXTADDPAIRWISE_I16X8_S() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i32x4_extadd_pairwise_i16x8_s); }
 	def visit_I32X4_EXTADDPAIRWISE_I16X8_U() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_extadd_pairwise_i16x8_u); }
+	def visit_I32X4_EXTMUL_LOW_I16X8_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), true, true)); }
+	def visit_I32X4_EXTMUL_LOW_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), true, false)); }
+	def visit_I32X4_EXTMUL_HIGH_I16X8_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, true)); }
+	def visit_I32X4_EXTMUL_HIGH_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, false)); }
 
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }


### PR DESCRIPTION
Tested by
```
make -j
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_dot_i16x8.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_extadd_pairwise_i16x8.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_extmul_i16x8.bin.wast
```