### PR TITLE
[simd/jit]: Implement more f32x4 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -551,6 +551,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F32X4_LT() { do_op2_x_x(ValueKind.V128, asm.cmpltps_s_s); }
 	def visit_F32X4_GE() { do_c_op2_x_x(ValueKind.V128, asm.cmpleps_s_s); }
 	def visit_F32X4_LE() { do_op2_x_x(ValueKind.V128, asm.cmpleps_s_s); }
+	def visit_F32X4_PMIN() { do_c_op2_x_x(ValueKind.V128, asm.minps_s_s); }
+	def visit_F32X4_PMAX() { do_c_op2_x_x(ValueKind.V128, asm.maxps_s_s); }
 
 	def visit_F64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.addpd_s_s); }
 	def visit_F64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.subpd_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -553,6 +553,9 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F32X4_LE() { do_op2_x_x(ValueKind.V128, asm.cmpleps_s_s); }
 	def visit_F32X4_PMIN() { do_c_op2_x_x(ValueKind.V128, asm.minps_s_s); }
 	def visit_F32X4_PMAX() { do_c_op2_x_x(ValueKind.V128, asm.maxps_s_s); }
+	def visit_F32X4_MIN() { do_op2_x_x(ValueKind.V128, mmasm.emit_f32x4_min(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_F32X4_MAX() { do_op2_x_x(ValueKind.V128, mmasm.emit_f32x4_max(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_F32X4_ABS() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_v128_absps); }
 
 	def visit_F64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.addpd_s_s); }
 	def visit_F64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.subpd_s_s); }


### PR DESCRIPTION
Tested by:
- `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_f32x4_pmin_pmax.bin.wast`
- `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_f32x4.bin.wast`