### PR TITLE
[simd/jit]: Implement more f64x2 arithmetic instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -564,6 +564,11 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F64X2_LT() { do_op2_x_x(ValueKind.V128, asm.cmpltpd_s_s); }
 	def visit_F64X2_GE() { do_c_op2_x_x(ValueKind.V128, asm.cmplepd_s_s); }
 	def visit_F64X2_LE() { do_op2_x_x(ValueKind.V128, asm.cmplepd_s_s); }
+	def visit_F64X2_PMIN() { do_c_op2_x_x(ValueKind.V128, asm.minpd_s_s); }
+	def visit_F64X2_PMAX() { do_c_op2_x_x(ValueKind.V128, asm.maxpd_s_s); }
+	def visit_F64X2_MIN() { do_op2_x_x(ValueKind.V128, mmasm.emit_f64x2_min(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_F64X2_MAX() { do_op2_x_x(ValueKind.V128, mmasm.emit_f64x2_max(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_F64X2_ABS() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_v128_abspd); }
 
 
 	def visit_V128_BITSELECT() {


### PR DESCRIPTION
Tested by:
```
make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_f64x2_pmin_pmax.bin.wast
make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_f64x2.bin.wast
```