### PR TITLE
[simd/jit]: Factor out do_op2_x_x_xtmp() and do_c_op2_x_x_xtmp()

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -467,9 +467,9 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I8X16_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqb_s_s); }
 	def visit_I8X16_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ne); }
 	def visit_I8X16_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtb_s_s); }
-	def visit_I8X16_GT_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_gt_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I8X16_GT_U() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i8x16_gt_u); }
 	def visit_I8X16_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtb_s_s); }
-	def visit_I8X16_LT_U() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_gt_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I8X16_LT_U() { do_c_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i8x16_gt_u); }
 	def visit_I8X16_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ge_s); }
 	def visit_I8X16_GE_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ge_u); }
 	def visit_I8X16_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_ge_s); }
@@ -493,9 +493,9 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqw_s_s); }
 	def visit_I16X8_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ne); }
 	def visit_I16X8_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtw_s_s); }
-	def visit_I16X8_GT_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_gt_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I16X8_GT_U() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_gt_u); }
 	def visit_I16X8_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtw_s_s); }
-	def visit_I16X8_LT_U() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_gt_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I16X8_LT_U() { do_c_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_gt_u); }
 	def visit_I16X8_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ge_s); }
 	def visit_I16X8_GE_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ge_u); }
 	def visit_I16X8_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_ge_s); }
@@ -514,9 +514,9 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_EXTADDPAIRWISE_I8X16_U() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_u); }
 	def visit_I16X8_EXTMUL_LOW_I8X16_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), true)); }
 	def visit_I16X8_EXTMUL_LOW_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), false)); }
-	def visit_I16X8_EXTMUL_HIGH_I8X16_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_high_s(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_I16X8_EXTMUL_HIGH_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_high_u(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_I16X8_Q15MULRSAT_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_q15mulrsat_s(_, _, X(allocTmp(ValueKind.V128)))); } // todo: factor out this routine
+	def visit_I16X8_EXTMUL_HIGH_I8X16_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_extmul_high_s); }
+	def visit_I16X8_EXTMUL_HIGH_I8X16_U() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_extmul_high_u); }
+	def visit_I16X8_Q15MULRSAT_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_q15mulrsat_s); } // todo: factor out this routine
 
 	def visit_I32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.paddd_s_s); }
 	def visit_I32X4_SUB() { do_op2_x_x(ValueKind.V128, asm.psubd_s_s); }
@@ -525,9 +525,9 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_EQ() { do_op2_x_x(ValueKind.V128, asm.pcmpeqd_s_s); }
 	def visit_I32X4_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ne); }
 	def visit_I32X4_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtd_s_s); }
-	def visit_I32X4_GT_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_gt_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I32X4_GT_U() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_gt_u); }
 	def visit_I32X4_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtd_s_s); }
-	def visit_I32X4_LT_U() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_gt_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I32X4_LT_U() { do_c_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_gt_u); }
 	def visit_I32X4_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ge_s); }
 	def visit_I32X4_GE_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ge_u); }
 	def visit_I32X4_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_ge_s); }
@@ -546,8 +546,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I64X2_NE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ne); }
 	def visit_I64X2_GT_S() { do_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
 	def visit_I64X2_LT_S() { do_c_op2_x_x(ValueKind.V128, asm.pcmpgtq_s_s); }
-	def visit_I64X2_GE_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_I64X2_LE_S() { do_c_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_ge_s(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I64X2_GE_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_ge_s); }
+	def visit_I64X2_LE_S() { do_c_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_ge_s); }
 	def visit_I64X2_ABS() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_abs); }
 
 	def visit_F32X4_ADD() { do_op2_x_x(ValueKind.V128, asm.addps_s_s); }
@@ -564,8 +564,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F32X4_LE() { do_op2_x_x(ValueKind.V128, asm.cmpleps_s_s); }
 	def visit_F32X4_PMIN() { do_c_op2_x_x(ValueKind.V128, asm.minps_s_s); }
 	def visit_F32X4_PMAX() { do_c_op2_x_x(ValueKind.V128, asm.maxps_s_s); }
-	def visit_F32X4_MIN() { do_op2_x_x(ValueKind.V128, mmasm.emit_f32x4_min(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_F32X4_MAX() { do_op2_x_x(ValueKind.V128, mmasm.emit_f32x4_max(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_F32X4_MIN() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_f32x4_min); }
+	def visit_F32X4_MAX() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_f32x4_max); }
 	def visit_F32X4_ABS() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_v128_absps); }
 
 	def visit_F64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.addpd_s_s); }
@@ -582,8 +582,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F64X2_LE() { do_op2_x_x(ValueKind.V128, asm.cmplepd_s_s); }
 	def visit_F64X2_PMIN() { do_c_op2_x_x(ValueKind.V128, asm.minpd_s_s); }
 	def visit_F64X2_PMAX() { do_c_op2_x_x(ValueKind.V128, asm.maxpd_s_s); }
-	def visit_F64X2_MIN() { do_op2_x_x(ValueKind.V128, mmasm.emit_f64x2_min(_, _, X(allocTmp(ValueKind.V128)))); }
-	def visit_F64X2_MAX() { do_op2_x_x(ValueKind.V128, mmasm.emit_f64x2_max(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_F64X2_MIN() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_f64x2_min); }
+	def visit_F64X2_MAX() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_f64x2_max); }
 	def visit_F64X2_ABS() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_v128_abspd); }
 
 
@@ -664,7 +664,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	// r1 = op(r1, xtmp)
 	private def do_op1_x_xtmp<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr) -> T) -> bool {
 		var sv = popRegToOverwrite(), r = X(sv.reg);
-		var x_tmp = X(allocTmp(ValueKind.V128));
+		var x_tmp = X(allocTmp(kind));
 		emit(r, x_tmp);
 		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
 		return true;
@@ -673,7 +673,7 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	private def do_op1_x_gtmp_xtmp<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Gpr, X86_64Xmmr) -> T) -> bool {
 		var sv = popRegToOverwrite(), r = X(sv.reg);
 		var g_tmp = G(allocTmp(ValueKind.I64));
-		var x_tmp = X(allocTmp(ValueKind.V128));
+		var x_tmp = X(allocTmp(kind));
 		emit(r, g_tmp, x_tmp);
 		state.push(sv.kindFlagsMatching(kind, IN_REG), sv.reg, 0);
 		return true;
@@ -686,11 +686,29 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		state.push(a.kindFlagsMatching(kind, IN_REG), a.reg, 0);
 		return true;
 	}
+	// x1 = op(x1, x2, xtmp)
+	private def do_op2_x_x_xtmp<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr, X86_64Xmmr) -> T) -> bool {
+		var b = popReg();
+		var a = popRegToOverwrite();
+		var x_tmp = X(allocTmp(kind));
+		emit(X(a.reg), X(b.reg), x_tmp);
+		state.push(a.kindFlagsMatching(kind, IN_REG), a.reg, 0);
+		return true;
+	}
 	// x2 = op(x2, x1), commuted version of do_op2_x_x
 	private def do_c_op2_x_x<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr) -> T) -> bool {
 		var b = popRegToOverwrite();
 		var a = popReg();
 		emit(X(b.reg), X(a.reg));
+		state.push(b.kindFlagsMatching(kind, IN_REG), b.reg, 0);
+		return true;
+	}
+	// x2 = op(x2, x1, xtmp), commuted version of do_op2_x_x_xtmp
+	private def do_c_op2_x_x_xtmp<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr, X86_64Xmmr) -> T) -> bool {
+		var b = popRegToOverwrite();
+		var a = popReg();
+		var x_tmp = X(allocTmp(kind));
+		emit(X(b.reg), X(a.reg), x_tmp);
 		state.push(b.kindFlagsMatching(kind, IN_REG), b.reg, 0);
 		return true;
 	}


### PR DESCRIPTION
Tested by:

```bash
function jit_regress {
  make -j

  # Array of variables
  var_list=("i8x16" "i16x8" "i32x4" "i64x2" "f32x4" "f64x2")

  # Loop over array and execute command
  for var in "${var_list[@]}"
  do
      bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_${var}_arith.bin.wast
      # Only integer types have the second test
      if [[ ${var:0:1} != "f" ]]
      then
          bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_${var}_arith2.bin.wast
      else
          bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_${var}.bin.wast
      fi
  done | progress
}

jit_regress
```