### PR TITLE
[simd/jit]: Implement i32x4 trunc instructions

### DIFF
--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2671,67 +2671,12 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 			endHandler();
 		}
-		bindHandler(Opcode.I32X4_TRUNC_SAT_F32X4_S); {
-			def dst = r_xmm0;
-			def tmp = r_xmm1;
-			asm.movdqu_s_m(dst, vsph[-1].value);
-			// NAN -> 0
-			asm.movaps_s_s(tmp, dst);
-			asm.cmpeqps_s_s(tmp, tmp);
-			asm.pand_s_s(dst, tmp);
-			// set top bit if >= 0 (but not -0.0!)
-			asm.pxor_s_s(tmp, dst);
-			// convert
-			asm.cvttps2dq_s_s(dst, dst);
-			// set top bit if >=0 is now < 0
-			asm.pand_s_s(tmp, dst);
-			asm.psrad_i(tmp, 31);
-			// set positive overflow lanes to 0x7FFFFFFF
-			asm.pxor_s_s(dst, tmp);
-			asm.movdqu_m_s(vsph[-1].value, dst);
-			endHandler();
-		}
-		bindHandler(Opcode.I32X4_TRUNC_SAT_F32X4_U); {
-			def dst = r_xmm0;
-			def tmp1 = r_xmm1;
-			def tmp2 = r_xmm2;
-			asm.movdqu_s_m(dst, vsph[-1].value);
-			// NAN -> 0, negative -> 0
-			asm.pxor_s_s(tmp2, tmp2);
-			asm.maxps_s_s(dst, tmp2);
-			 // tmp2: float representation of max_signed
-			asm.pcmpeqd_s_s(tmp2, tmp2);
-			asm.psrld_i(tmp2, 1); // 0x7fffffff
-			asm.cvtdq2ps_s_s(tmp2, tmp2); // 0x4f000000
-			// tmp: convert (src-max_signed).
-	      		// positive overflow lanes -> 0x7FFFFFFF
-			// negative lanes -> 0
-			asm.movaps_s_s(tmp1, dst);
-			asm.subps_s_s(tmp1, tmp2);
-			asm.cmpleps_s_s(tmp2, tmp1);
-			asm.cvttps2dq_s_s(tmp1, tmp1);
-			asm.pxor_s_s(tmp1, tmp2);
-			asm.pxor_s_s(tmp2, tmp2);
-			asm.pmaxsd_s_s(tmp1, tmp2);
-			// convert. Overflow lanes above max_signed will be 0x80000000
-			asm.cvttps2dq_s_s(dst, dst);
-			// add (src-max_signed) for overflow lanes.
-			asm.paddd_s_s(dst, tmp1);
-			asm.movdqu_m_s(vsph[-1].value, dst);
-			endHandler();
-		}
-		bindHandler(Opcode.I32X4_TRUNC_SAT_F64X2_S_ZERO); {
-			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-			masm.emit_i32x4_trunc_sat_f64x2_s_zero(r_xmm0, r_tmp0, r_xmm1, r_xmm2);
-			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
-			endHandler();
-		}
-		bindHandler(Opcode.I32X4_TRUNC_SAT_F64X2_U_ZERO); {
-			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-			masm.emit_i32x4_trunc_sat_f64x2_u_zero(r_xmm0, r_tmp0, r_xmm1, r_xmm2);
-			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
-			endHandler();
-		}
+		
+		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F32X4_S, masm.emit_i32x4_trunc_sat_f32x4_s(_, r_xmm1));
+		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F32X4_U, masm.emit_i32x4_trunc_sat_f32x4_u(_, r_xmm1, r_xmm2));
+		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F64X2_S_ZERO, masm.emit_i32x4_trunc_sat_f64x2_s_zero(_, r_tmp0, r_xmm1, r_xmm2));
+		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F64X2_U_ZERO, masm.emit_i32x4_trunc_sat_f64x2_u_zero(_, r_tmp0, r_xmm1, r_xmm2));
+
 		bindHandler(Opcode.I8X16_SHUFFLE); {
 			var RHS = X86_64Label.new(), LOOP_PRO = X86_64Label.new(), LOOP_EPI = X86_64Label.new();
 			incrementVsp(); // make room for a local variable dst (the result)
@@ -2837,6 +2782,13 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		f(r_xmm0, r_xmm1);
 		asm.movdqu_m_s(vsph[-2].value, r_xmm0);
 		decrementVsp();
+		endHandler();
+	}
+	def genSimdUnop<T>(opcode: Opcode, f: (X86_64Xmmr) -> T) {
+		bindHandler(opcode);
+		asm.movdqu_s_m(r_xmm0, vsph[-1].value);
+		f(r_xmm0);
+		asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 		endHandler();
 	}
 	def bindHandler(opcode: Opcode) {

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2672,10 +2672,18 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			endHandler();
 		}
 		
-		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F32X4_S, masm.emit_i32x4_trunc_sat_f32x4_s(_, r_xmm1));
-		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F32X4_U, masm.emit_i32x4_trunc_sat_f32x4_u(_, r_xmm1, r_xmm2));
-		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F64X2_S_ZERO, masm.emit_i32x4_trunc_sat_f64x2_s_zero(_, r_tmp0, r_xmm1, r_xmm2));
-		genSimdUnop(Opcode.I32X4_TRUNC_SAT_F64X2_U_ZERO, masm.emit_i32x4_trunc_sat_f64x2_u_zero(_, r_tmp0, r_xmm1, r_xmm2));
+		for (t in [
+			(Opcode.I32X4_TRUNC_SAT_F32X4_S, masm.emit_i32x4_trunc_sat_f32x4_s(_, r_xmm1)),
+			(Opcode.I32X4_TRUNC_SAT_F32X4_U, masm.emit_i32x4_trunc_sat_f32x4_u(_, r_xmm1, r_xmm2)),
+			(Opcode.I32X4_TRUNC_SAT_F64X2_S_ZERO, masm.emit_i32x4_trunc_sat_f64x2_s_zero(_, r_tmp0, r_xmm1, r_xmm2)),
+			(Opcode.I32X4_TRUNC_SAT_F64X2_U_ZERO, masm.emit_i32x4_trunc_sat_f64x2_u_zero(_, r_tmp0, r_xmm1, r_xmm2))
+		]) {
+			bindHandler(t.0);
+			asm.movdqu_s_m(r_xmm0, vsph[-1].value);
+			t.1(r_xmm0);
+			asm.movdqu_m_s(vsph[-1].value, r_xmm0);
+			endHandler();
+		}
 
 		bindHandler(Opcode.I8X16_SHUFFLE); {
 			var RHS = X86_64Label.new(), LOOP_PRO = X86_64Label.new(), LOOP_EPI = X86_64Label.new();
@@ -2782,13 +2790,6 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		f(r_xmm0, r_xmm1);
 		asm.movdqu_m_s(vsph[-2].value, r_xmm0);
 		decrementVsp();
-		endHandler();
-	}
-	def genSimdUnop<T>(opcode: Opcode, f: (X86_64Xmmr) -> T) {
-		bindHandler(opcode);
-		asm.movdqu_s_m(r_xmm0, vsph[-1].value);
-		f(r_xmm0);
-		asm.movdqu_m_s(vsph[-1].value, r_xmm0);
 		endHandler();
 	}
 	def bindHandler(opcode: Opcode) {

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -1177,6 +1177,44 @@ class X86_64MacroAssembler extends MacroAssembler {
 		load_v128_mask(mask, mask_i16x8_splat_0x0001, tmp);
 		asm.pmaddwd_s_s(dst, mask);
 	}
+	def emit_i32x4_trunc_sat_f32x4_s(dst: X86_64Xmmr, tmp: X86_64Xmmr) {
+		// NAN -> 0
+		asm.movaps_s_s(tmp, dst);
+		asm.cmpeqps_s_s(tmp, tmp);
+		asm.pand_s_s(dst, tmp);
+		// set top bit if >= 0 (but not -0.0!)
+		asm.pxor_s_s(tmp, dst);
+		// convert
+		asm.cvttps2dq_s_s(dst, dst);
+		// set top bit if >=0 is now < 0
+		asm.pand_s_s(tmp, dst);
+		asm.psrad_i(tmp, 31);
+		// set positive overflow lanes to 0x7FFFFFFF
+		asm.pxor_s_s(dst, tmp);
+	}
+	def emit_i32x4_trunc_sat_f32x4_u(dst: X86_64Xmmr, tmp1: X86_64Xmmr, tmp2: X86_64Xmmr) {
+		// NAN -> 0, negative -> 0
+		asm.pxor_s_s(tmp2, tmp2);
+		asm.maxps_s_s(dst, tmp2);
+		// tmp2: float representation of max_signed
+		asm.pcmpeqd_s_s(tmp2, tmp2);
+		asm.psrld_i(tmp2, 1); // 0x7fffffff
+		asm.cvtdq2ps_s_s(tmp2, tmp2); // 0x4f000000
+		// tmp: convert (src-max_signed).
+		// positive overflow lanes -> 0x7FFFFFFF
+		// negative lanes -> 0
+		asm.movaps_s_s(tmp1, dst);
+		asm.subps_s_s(tmp1, tmp2);
+		asm.cmpleps_s_s(tmp2, tmp1);
+		asm.cvttps2dq_s_s(tmp1, tmp1);
+		asm.pxor_s_s(tmp1, tmp2);
+		asm.pxor_s_s(tmp2, tmp2);
+		asm.pmaxsd_s_s(tmp1, tmp2);
+		// convert. Overflow lanes above max_signed will be 0x80000000
+		asm.cvttps2dq_s_s(dst, dst);
+		// add (src-max_signed) for overflow lanes.
+		asm.paddd_s_s(dst, tmp1);
+	}
 	def emit_i32x4_extadd_pairwise_i16x8_u(dst: X86_64Xmmr, scratch: X86_64Xmmr) {
 		asm.movaps_s_s(scratch, dst);
 		asm.psrld_i(scratch, 16);

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -544,6 +544,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_EXTMUL_LOW_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), true, false)); }
 	def visit_I32X4_EXTMUL_HIGH_I16X8_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, true)); }
 	def visit_I32X4_EXTMUL_HIGH_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, false)); }
+	def visit_I32X4_TRUNC_SAT_F32X4_S() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f32x4_s); }
+	def visit_I32X4_TRUNC_SAT_F32X4_U() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f32x4_u(_, _, X(allocTmp(ValueKind.V128)))); }
 
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -546,6 +546,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_EXTMUL_HIGH_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, false)); }
 	def visit_I32X4_TRUNC_SAT_F32X4_S() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f32x4_s); }
 	def visit_I32X4_TRUNC_SAT_F32X4_U() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f32x4_u(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I32X4_TRUNC_SAT_F64X2_S_ZERO() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f64x2_s_zero(_, _, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I32X4_TRUNC_SAT_F64X2_U_ZERO() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f64x2_u_zero(_, _, _, X(allocTmp(ValueKind.V128)))); }
 
 	def visit_I64X2_ADD() { do_op2_x_x(ValueKind.V128, asm.paddq_s_s); }
 	def visit_I64X2_SUB() { do_op2_x_x(ValueKind.V128, asm.psubq_s_s); }


### PR DESCRIPTION
Tested by:
```
make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_trunc_sat_f32x4.bin.wast
make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i32x4_trunc_sat_f64x2.bin.wast
```