### PR TITLE
[simd/jit]: Implement v128 lane loading instructions

### DIFF
--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -141,7 +141,11 @@ class X86_64MacroAssembler extends MacroAssembler {
 			ABS, V128 => asm.movdqu_s_m(X(dst), X86_64Addr.new(b, t.0, 1, t.1));
 		}
 	}
-
+	def emit_v128_load_lane_r_m<T>(dst: Reg, base: Reg, index: Reg, offset: u32, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T) {
+		var b = G(base), t = handle_large_offset(index, offset);
+		recordCurSourceLoc();
+		asm_mov_r_m(G(dst), X86_64Addr.new(b, t.0, 1, t.1));
+	}
 	def emit_storeb_r_r_r_i(kind: ValueKind, val: Reg, base: Reg, index: Reg, offset: u32) {
 		var t = handle_large_offset(index, offset);
 		recordCurSourceLoc();

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -627,6 +627,11 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F64X2_CONVERT_LOW_I32X4_U() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_f64x2_convert_low_i32x4_u); }
 	def visit_F64X2_PROMOTE_LOW_F32X4() { do_op1_x_x(ValueKind.V128, asm.cvtps2pd_s_s); }
 
+	def visit_V128_LOAD_8_LANE(imm: MemArg, lane: byte) { visit_V128_LOAD_LANE(imm, lane, asm.q.movb_r_m, asm.pinsrb_s_r_i); }
+	def visit_V128_LOAD_16_LANE(imm: MemArg, lane: byte) { visit_V128_LOAD_LANE(imm, lane, asm.q.movw_r_m, asm.pinsrw_s_r_i); }
+	def visit_V128_LOAD_32_LANE(imm: MemArg, lane: byte) { visit_V128_LOAD_LANE(imm, lane, asm.q.movd_r_m, asm.pinsrd_s_r_i); }
+	def visit_V128_LOAD_64_LANE(imm: MemArg, lane: byte) { visit_V128_LOAD_LANE(imm, lane, asm.q.movq_r_m, asm.pinsrq_s_r_i); }
+
 	def visit_V128_BITSELECT() {
 		var c = popReg();
 		var b = popReg();
@@ -634,6 +639,34 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		var t = allocTmp(ValueKind.V128);
 		mmasm.emit_v128_bitselect(X(a.reg), X(b.reg), X(c.reg), X(t));
 		state.push(a.kindFlagsMatching(ValueKind.V128, IN_REG), a.reg, 0);
+	}
+
+	private def visit_V128_LOAD_LANE<T>(imm: MemArg, lane: byte, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T, asm_pins_s_r_i: (X86_64Xmmr, X86_64Gpr, byte) -> T) {
+		var sv = popRegToOverwrite(), r = X(sv.reg);
+		var base_reg = regs.mem0_base;
+		if (imm.memory_index != 0) {
+			// XXX: cache the base register for memories > 0
+			var offsets = masm.getOffsets();
+			base_reg = allocTmp(ValueKind.REF);
+			emit_load_instance(base_reg);
+			mmasm.emit_mov_r_m(ValueKind.REF, base_reg, MasmAddr(base_reg, offsets.Instance_memories));
+			mmasm.emit_read_v3_array_r_i(ValueKind.REF, base_reg, base_reg, imm.memory_index);
+			mmasm.emit_read_v3_mem_base(base_reg, base_reg);
+		}
+		var iv = pop();
+		var index_reg: Reg;
+		var offset = imm.offset;
+		if (iv.isConst()) {
+			var sum = u64.view(offset) + u32.view(iv.const); // fold offset calculation
+			if (sum > u32.max) return emitTrap(TrapReason.MEM_OUT_OF_BOUNDS); // statically OOB
+			offset = u32.view(sum);
+		} else {
+			index_reg = ensureReg(iv, state.sp);
+		}
+		var lane_val = allocTmp(ValueKind.I64); // XXX: can reuse index reg if frequency == 1 and ValueKind.I32
+		mmasm.emit_v128_load_lane_r_m(lane_val, base_reg, index_reg, u32.!(offset), asm_mov_r_m);
+		asm_pins_s_r_i(r, G(lane_val), lane);
+		state.push(sv.kindFlagsMatching(ValueKind.V128, IN_REG), sv.reg, 0);
 	}
 
 	// r1 = op(r1)


### PR DESCRIPTION
Tested by
```
make -j
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_load8_lane.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_load16_lane.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_load32_lane.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_load64_lane.bin.wast
```

The `visit_V128_LOAD_LANE` method's code is mostly borrowed from the `emitLoad` method in `SinglePassCompiler.v3` with a modified prologue and epilogue. Let me know if there are any hidden bugs or factoring out needed