### PR TITLE
[simd/jit]: Implement v128 store_lane instructions

### DIFF
--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -141,9 +141,13 @@ class X86_64MacroAssembler extends MacroAssembler {
 			ABS, V128 => asm.movdqu_s_m(X(dst), X86_64Addr.new(b, t.0, 1, t.1));
 		}
 	}
-	def emit_v128_load_lane_r_m<T>(dst: Reg, addr: X86_64Addr, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T) {
+	def emit_v128_load_lane_r_m<T>(dst: Reg, src: X86_64Addr, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T) {
 		recordCurSourceLoc();
-		asm_mov_r_m(G(dst), addr);
+		asm_mov_r_m(G(dst), src);
+	}
+	def emit_v128_store_lane_m_r<T>(dst: X86_64Addr, src: Reg, asm_mov_m_r: (X86_64Addr, X86_64Gpr) -> T) {
+		recordCurSourceLoc();
+		asm_mov_m_r(dst, G(src));
 	}
 	def decode_memarg_addr(base: Reg, index: Reg, offset: u32) -> X86_64Addr {
 		var t = handle_large_offset(index, offset);

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -710,6 +710,11 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		state.push(SpcConsts.kindToFlags(kind) | IN_REG, d, 0);
 	}
 
+	def visit_V128_STORE_8_LANE(imm: MemArg, lane: byte) { visit_V128_STORE_LANE(imm, lane, storeMemarg_b, asm.pextrb_r_s_i); }
+	def visit_V128_STORE_16_LANE(imm: MemArg, lane: byte) { visit_V128_STORE_LANE(imm, lane, storeMemarg_w, asm.pextrw_r_s_i); }
+	def visit_V128_STORE_32_LANE(imm: MemArg, lane: byte) { visit_V128_STORE_LANE(imm, lane, storeMemarg_d, asm.pextrd_r_s_i); }
+	def visit_V128_STORE_64_LANE(imm: MemArg, lane: byte) { visit_V128_STORE_LANE(imm, lane, storeMemarg_q, asm.pextrq_r_s_i); }
+
 	def visit_V128_BITSELECT() {
 		var c = popReg();
 		var b = popReg();
@@ -762,17 +767,36 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		}
 		return (mmasm.decode_memarg_addr(base_reg, index_reg, u32.!(offset)), TrapReason.NONE);
 	}
-	// Utilities to load a memarg into a register
-	private def loadMemarg<T>(dst: Reg, imm: MemArg, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T) {
-		def t = decodeMemarg(imm);
+	// Utility functions for loading a value from memory into a register.
+	private def loadMemarg<T>(dst: Reg, src: MemArg, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T) {
+		def t = decodeMemarg(src);
 		if (t.1 != TrapReason.NONE) return emitTrap(t.1);
 		def addr = t.0;
 		mmasm.emit_v128_load_lane_r_m(dst, addr, asm_mov_r_m);
 	}
-	private def loadMemarg_b(dst: Reg, imm: MemArg) { loadMemarg(dst, imm, asm.q.movb_r_m); }
-	private def loadMemarg_w(dst: Reg, imm: MemArg) { loadMemarg(dst, imm, asm.q.movw_r_m); }
-	private def loadMemarg_d(dst: Reg, imm: MemArg) { loadMemarg(dst, imm, asm.q.movd_r_m); }
-	private def loadMemarg_q(dst: Reg, imm: MemArg) { loadMemarg(dst, imm, asm.q.movq_r_m); }
+	private def loadMemarg_b(dst: Reg, src: MemArg) { loadMemarg(dst, src, asm.q.movb_r_m); }
+	private def loadMemarg_w(dst: Reg, src: MemArg) { loadMemarg(dst, src, asm.q.movw_r_m); }
+	private def loadMemarg_d(dst: Reg, src: MemArg) { loadMemarg(dst, src, asm.q.movd_r_m); }
+	private def loadMemarg_q(dst: Reg, src: MemArg) { loadMemarg(dst, src, asm.q.movq_r_m); }
+
+	// Utility functions for storing a value from a register into memory.
+	private def storeMemarg<T>(dst: MemArg, src: Reg, asm_mov_m_r: (X86_64Addr, X86_64Gpr) -> T) {
+		def t = decodeMemarg(dst);
+		if (t.1 != TrapReason.NONE) return emitTrap(t.1);
+		def addr = t.0;
+		mmasm.emit_v128_store_lane_m_r(addr, src, asm_mov_m_r);
+	}
+	private def storeMemarg_b(dst: MemArg, src: Reg) { storeMemarg(dst, src, asm.q.movb_m_r); }
+	private def storeMemarg_w(dst: MemArg, src: Reg) { storeMemarg(dst, src, asm.q.movw_m_r); }
+	private def storeMemarg_d(dst: MemArg, src: Reg) { storeMemarg(dst, src, asm.q.movd_m_r); }
+	private def storeMemarg_q(dst: MemArg, src: Reg) { storeMemarg(dst, src, asm.q.movq_m_r); }
+
+	def visit_V128_STORE_LANE<T>(imm: MemArg, lane: byte, storeMem: (MemArg, Reg) -> void, asm_pext_r_s_i: (X86_64Gpr, X86_64Xmmr, byte) -> T) {
+		var sv = popReg();
+		var val = allocTmp(ValueKind.I64);
+		asm_pext_r_s_i(G(val), X(sv.reg), lane);
+		storeMem(imm, val);
+	}
 
 	private def visit_V128_LOAD_LANE<T>(imm: MemArg, lane: byte, loadMem: (Reg, MemArg) -> void, asm_pins_s_r_i: (X86_64Xmmr, X86_64Gpr, byte) -> T) {
 		var sv = popRegToOverwrite(), r = X(sv.reg);


### PR DESCRIPTION
Tested by:
```
make -j
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_store8_lane.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_store16_lane.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_store32_lane.bin.wast
bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_store64_lane.bin.wast
```