### PR TITLE
[simd/jit]: Implement v128 splat instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -715,6 +715,13 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_V128_STORE_32_LANE(imm: MemArg, lane: byte) { visit_V128_STORE_LANE(imm, lane, storeMemarg_d, asm.pextrd_r_s_i); }
 	def visit_V128_STORE_64_LANE(imm: MemArg, lane: byte) { visit_V128_STORE_LANE(imm, lane, storeMemarg_q, asm.pextrq_r_s_i); }
 
+	def visit_I8X16_SPLAT() { visit_V128_SPLAT_I(mmasm.emit_i8x16_splat(_, _, X(allocTmp(ValueKind.V128)))); }
+	def visit_I16X8_SPLAT() { visit_V128_SPLAT_I(mmasm.emit_i16x8_splat); }
+	def visit_I32X4_SPLAT() { visit_V128_SPLAT_I(mmasm.emit_i32x4_splat); }
+	def visit_I64X2_SPLAT() { visit_V128_SPLAT_I(mmasm.emit_i64x2_splat); }
+	def visit_F32X4_SPLAT() { visit_V128_SPLAT_F(asm.pshufd_s_s_i(_, _, 0)); }
+	def visit_F64X2_SPLAT() { visit_V128_SPLAT_F(asm.movddup_s_s); }
+
 	def visit_V128_BITSELECT() {
 		var c = popReg();
 		var b = popReg();
@@ -852,6 +859,19 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		var d = allocRegTos(ValueKind.V128);
 		loadMem(val, imm);
 		masm_splat(X(d), G(val));
+		state.push(KIND_V128 | IN_REG, d, 0);
+	}
+
+	private def visit_V128_SPLAT_I<T>(masm_splat: (X86_64Xmmr, X86_64Gpr) -> T) {
+		var val = popReg();
+		var d = allocRegTos(ValueKind.V128);
+		masm_splat(X(d), G(val.reg));
+		state.push(KIND_V128 | IN_REG, d, 0);
+	}
+	private def visit_V128_SPLAT_F<T>(asm_meth: (X86_64Xmmr, X86_64Xmmr) -> T) {
+		var val = popReg();
+		var d = allocRegTos(ValueKind.V128);
+		asm_meth(X(d), X(val.reg));
 		state.push(KIND_V128 | IN_REG, d, 0);
 	}
 


### PR DESCRIPTION
Tested by `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_splat.bin.wast`