### PR TITLE
[simd/jit]: Implement v128 shuffling and swizzling

### DIFF
--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -788,25 +788,25 @@ class X86_64MacroAssembler extends MacroAssembler {
 	}
 	// SSE assemblers and helpers
 	// Masks for simd instructions
-	def mask_i8x16_splat_0x0f: (long, long) = (0x0F0F0F0F0F0F0F0F, 0x0F0F0F0F0F0F0F0F);
-	def mask_i8x16_popcnt: (long, long) = (0x0302020102010100, 0x0403030203020201);
-	def mask_v128_float_neg_constant: (long, long) = (0x8000000080000000, 0x8000000080000000);
-	def mask_v128_double_neg_constant: (long, long) = (0x8000000000000000, 0x8000000000000000);
-	def mask_v128_float_absolute_constant: (long, long) = (0x7FFFFFFF7FFFFFFF, 0x7FFFFFFF7FFFFFFF);
-	def mask_v128_double_absolute_constant: (long, long) = (0x7FFFFFFFFFFFFFFF, 0x7FFFFFFFFFFFFFFF);
-	def mask_f64x2_convert_low_i32x4_u_int: (long, long) = (0x4330000043300000, 0x4330000043300000);
-	def mask_double_2_power_52: (long, long) = (0x4330000000000000, 0x4330000000000000);
-	def mask_i8x16_splat_0x01: (long, long) = (0x0101010101010101, 0x0101010101010101);
-	def mask_i16x8_splat_0x0001: (long, long) = (0x0001000100010001, 0x0001000100010001);
-	def mask_i8x16_swizzle: (long, long) = (0x7070707070707070, 0x7070707070707070);
-	def mask_int32_max_as_double: (long, long) = (0x41dfffffffc00000, 0x41dfffffffc00000);
-	def mask_uint32_max_as_double: (long, long) = (0x41efffffffe00000, 0x41efffffffe00000);
+	def mask_i8x16_splat_0x0f: (u64, u64) = (0x0F0F0F0F0F0F0F0F, 0x0F0F0F0F0F0F0F0F);
+	def mask_i8x16_popcnt: (u64, u64) = (0x0302020102010100, 0x0403030203020201);
+	def mask_v128_float_neg_constant: (u64, u64) = (0x8000000080000000, 0x8000000080000000);
+	def mask_v128_double_neg_constant: (u64, u64) = (0x8000000000000000, 0x8000000000000000);
+	def mask_v128_float_absolute_constant: (u64, u64) = (0x7FFFFFFF7FFFFFFF, 0x7FFFFFFF7FFFFFFF);
+	def mask_v128_double_absolute_constant: (u64, u64) = (0x7FFFFFFFFFFFFFFF, 0x7FFFFFFFFFFFFFFF);
+	def mask_f64x2_convert_low_i32x4_u_int: (u64, u64) = (0x4330000043300000, 0x4330000043300000);
+	def mask_double_2_power_52: (u64, u64) = (0x4330000000000000, 0x4330000000000000);
+	def mask_i8x16_splat_0x01: (u64, u64) = (0x0101010101010101, 0x0101010101010101);
+	def mask_i16x8_splat_0x0001: (u64, u64) = (0x0001000100010001, 0x0001000100010001);
+	def mask_i8x16_swizzle: (u64, u64) = (0x7070707070707070, 0x7070707070707070);
+	def mask_int32_max_as_double: (u64, u64) = (0x41dfffffffc00000, 0x41dfffffffc00000);
+	def mask_uint32_max_as_double: (u64, u64) = (0x41efffffffe00000, 0x41efffffffe00000);
 	// Load a mask into an Xmm register s
-	def load_v128_mask(dst: X86_64Xmmr, mask: (long, long), tmp: X86_64Gpr) {
+	def load_v128_mask(dst: X86_64Xmmr, mask: (u64, u64), tmp: X86_64Gpr) {
 		// move 64 bit wide general purpose register into an xmm's lower half
-		asm.movq_r_l(tmp, mask.0);
+		asm.movq_r_l(tmp, long.view(mask.0));
 		asm.pinsrq_s_r_i(dst, tmp, 0);
-		asm.movq_r_l(tmp, mask.1);
+		asm.movq_r_l(tmp, long.view(mask.1));
 		asm.pinsrq_s_r_i(dst, tmp, 1);
 	}
 	def emit_v128_orps(dst: X86_64Xmmr, src: X86_64Xmmr) {

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -732,6 +732,28 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_F32X4_SPLAT() { visit_V128_SPLAT_F(asm.pshufd_s_s_i(_, _, 0)); }
 	def visit_F64X2_SPLAT() { visit_V128_SPLAT_F(asm.movddup_s_s); }
 
+	def visit_I8X16_SWIZZLE() { do_op2_x_x(ValueKind.V128, mmasm.emit_i8x16_swizzle(_, _, G(allocTmp(ValueKind.I64)), X(allocTmp(ValueKind.V128)))); }
+	def visit_I8X16_SHUFFLE(imms: Array<byte>) {
+		var b = popReg();
+		var a = popRegToOverwrite();
+		var val = G(allocTmp(ValueKind.I64));
+		var dest = X(allocTmp(ValueKind.V128));
+		def SIMD_128_SIZE: byte = 16;
+
+		for (i: byte = 0; i < SIMD_128_SIZE; i++) {
+			def lane = imms[i];
+			if (lane < SIMD_128_SIZE) {
+				asm.pextrb_r_s_i(val, X(a.reg), imms[i]);
+				asm.pinsrb_s_r_i(dest, val, i);
+			} else {
+				asm.pextrb_r_s_i(val, X(b.reg), imms[i] - SIMD_128_SIZE);
+				asm.pinsrb_s_r_i(dest, val, i);
+			}
+		}
+		asm.movaps_s_s(X(a.reg), dest);
+		state.push(a.kindFlagsMatching(ValueKind.V128, IN_REG), a.reg, 0);
+	}
+
 	def visit_V128_BITSELECT() {
 		var c = popReg();
 		var b = popReg();

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -736,17 +736,30 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I8X16_SHUFFLE(imms: Array<byte>) {
 		var b = popReg();
 		var a = popRegToOverwrite();
-		var val = G(allocTmp(ValueKind.I64));
-		var xtmp = X(allocTmp(ValueKind.V128));
-		def SIMD_128_SIZE: byte = 16;
+		var gtmp = G(allocTmp(ValueKind.I64));
+		var xtmp_mask = X(allocTmp(ValueKind.V128));
 
-		for (i: byte = 0; i < SIMD_128_SIZE; i++) {
-			def lane = if(imms[i] < SIMD_128_SIZE, imms[i], imms[i] - SIMD_128_SIZE);
-			def sreg = if(imms[i] < SIMD_128_SIZE, X(a.reg), X(b.reg)); // source register
-			asm.pextrb_r_s_i(val, sreg, lane);
-			asm.pinsrb_s_r_i(xtmp, val, i);
+		def SIMD_128_SIZE: byte = 16;
+		var mask1: Array<u64> = [0x0, 0x0];
+		var mask2: Array<u64> = [0x0, 0x0];
+		for (i = 15; i >= 0; i--) {
+			def lane = imms[i];
+			def j: int = i >> 3;
+			// Construct a mask for a 
+			mask1[j] <<= 8;
+			mask1[j] |= if (lane < SIMD_128_SIZE, lane, 0x80);
+			// Construct a mask for b
+			mask2[j] <<= 8;
+			mask2[j] |= if (lane >= SIMD_128_SIZE, byte.view(lane & 0x0F), 0x80);
 		}
-		asm.movaps_s_s(X(a.reg), xtmp);
+		// Extract bytes from a
+		mmasm.load_v128_mask(xtmp_mask, (mask1[0], mask1[1]), gtmp);
+		asm.pshufb_s_s(X(a.reg), xtmp_mask);
+		// Extract bytes from b
+		mmasm.load_v128_mask(xtmp_mask, (mask2[0], mask2[1]), gtmp);
+		asm.pshufb_s_s(X(b.reg), xtmp_mask);
+		// Merge the two results
+		asm.orps_s_s(X(a.reg), X(b.reg));
 		state.push(a.kindFlagsMatching(ValueKind.V128, IN_REG), a.reg, 0);
 	}
 

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -737,20 +737,16 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		var b = popReg();
 		var a = popRegToOverwrite();
 		var val = G(allocTmp(ValueKind.I64));
-		var dest = X(allocTmp(ValueKind.V128));
+		var xtmp = X(allocTmp(ValueKind.V128));
 		def SIMD_128_SIZE: byte = 16;
 
 		for (i: byte = 0; i < SIMD_128_SIZE; i++) {
-			def lane = imms[i];
-			if (lane < SIMD_128_SIZE) {
-				asm.pextrb_r_s_i(val, X(a.reg), imms[i]);
-				asm.pinsrb_s_r_i(dest, val, i);
-			} else {
-				asm.pextrb_r_s_i(val, X(b.reg), imms[i] - SIMD_128_SIZE);
-				asm.pinsrb_s_r_i(dest, val, i);
-			}
+			def lane = if(imms[i] < SIMD_128_SIZE, imms[i], imms[i] - SIMD_128_SIZE);
+			def sreg = if(imms[i] < SIMD_128_SIZE, X(a.reg), X(b.reg)); // source register
+			asm.pextrb_r_s_i(val, sreg, lane);
+			asm.pinsrb_s_r_i(xtmp, val, i);
 		}
-		asm.movaps_s_s(X(a.reg), dest);
+		asm.movaps_s_s(X(a.reg), xtmp);
 		state.push(a.kindFlagsMatching(ValueKind.V128, IN_REG), a.reg, 0);
 	}
 


### PR DESCRIPTION
Tested by 
- `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/v128_shuffle.bin.wast`
- `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/v128_swizzle.bin.wast`