### PR TITLE
[simd/jit]: Implement i64x2 extmul instructions

### DIFF
--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -530,8 +530,8 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I16X8_SUB_SAT_U() { do_op2_x_x(ValueKind.V128, asm.psubusw_s_s); }
 	def visit_I16X8_EXTADDPAIRWISE_I8X16_S() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_s); }
 	def visit_I16X8_EXTADDPAIRWISE_I8X16_U() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i16x8_extadd_pairwise_i8x16_u); }
-	def visit_I16X8_EXTMUL_LOW_I8X16_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), true)); }
-	def visit_I16X8_EXTMUL_LOW_I8X16_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i16x8_extmul_low(_, _, X(allocTmp(ValueKind.V128)), false)); }
+	def visit_I16X8_EXTMUL_LOW_I8X16_S() { visit_V128_EXTMUL2(ValueKind.V128, mmasm.emit_i16x8_extmul_low, true); }
+	def visit_I16X8_EXTMUL_LOW_I8X16_U() { visit_V128_EXTMUL2(ValueKind.V128, mmasm.emit_i16x8_extmul_low, false); }
 	def visit_I16X8_EXTMUL_HIGH_I8X16_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_extmul_high_s); }
 	def visit_I16X8_EXTMUL_HIGH_I8X16_U() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_extmul_high_u); }
 	def visit_I16X8_Q15MULRSAT_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i16x8_q15mulrsat_s); }
@@ -567,10 +567,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I32X4_DOT_I16X8_S() { do_op2_x_x(ValueKind.V128, asm.pmaddwd_s_s); }
 	def visit_I32X4_EXTADDPAIRWISE_I16X8_S() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i32x4_extadd_pairwise_i16x8_s); }
 	def visit_I32X4_EXTADDPAIRWISE_I16X8_U() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_extadd_pairwise_i16x8_u); }
-	def visit_I32X4_EXTMUL_LOW_I16X8_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), true, true)); }
-	def visit_I32X4_EXTMUL_LOW_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), true, false)); }
-	def visit_I32X4_EXTMUL_HIGH_I16X8_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, true)); }
-	def visit_I32X4_EXTMUL_HIGH_I16X8_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i32x4_extmul(_, _, X(allocTmp(ValueKind.V128)), false, false)); }
+	def visit_I32X4_EXTMUL_LOW_I16X8_S() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i32x4_extmul, true, true); }
+	def visit_I32X4_EXTMUL_LOW_I16X8_U() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i32x4_extmul, true, false); }
+	def visit_I32X4_EXTMUL_HIGH_I16X8_S() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i32x4_extmul, false, true); }
+	def visit_I32X4_EXTMUL_HIGH_I16X8_U() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i32x4_extmul, false, false); }
 	def visit_I32X4_TRUNC_SAT_F32X4_S() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f32x4_s); }
 	def visit_I32X4_TRUNC_SAT_F32X4_U() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f32x4_u(_, _, X(allocTmp(ValueKind.V128)))); }
 	def visit_I32X4_TRUNC_SAT_F64X2_S_ZERO() { do_op1_x_gtmp_xtmp(ValueKind.V128, mmasm.emit_i32x4_trunc_sat_f64x2_s_zero(_, _, _, X(allocTmp(ValueKind.V128)))); }
@@ -594,10 +594,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I64X2_GE_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_ge_s); }
 	def visit_I64X2_LE_S() { do_c_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_ge_s); }
 	def visit_I64X2_ABS() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_abs); }
-	def visit_I64X2_EXTMUL_LOW_I32X4_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), true, true)); }
-	def visit_I64X2_EXTMUL_LOW_I32X4_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), true, false)); }
-	def visit_I64X2_EXTMUL_HIGH_I32X4_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), false, true)); }
-	def visit_I64X2_EXTMUL_HIGH_I32X4_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), false, false)); }
+	def visit_I64X2_EXTMUL_LOW_I32X4_S() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i64x2_extmul, true, true); }
+	def visit_I64X2_EXTMUL_LOW_I32X4_U() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i64x2_extmul, true, false); }
+	def visit_I64X2_EXTMUL_HIGH_I32X4_S() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i64x2_extmul, false, true); }
+	def visit_I64X2_EXTMUL_HIGH_I32X4_U() { visit_V128_EXTMUL1(ValueKind.V128, mmasm.emit_i64x2_extmul, false, false); }
 	def visit_I64X2_EXTEND_LOW_I32X4_S() { do_op1_x_x(ValueKind.V128, asm.pmovsxdq_s_s); }
 	def visit_I64X2_EXTEND_LOW_I32X4_U() { do_op1_x_x(ValueKind.V128, asm.pmovzxdq_s_s); }
 	def visit_I64X2_EXTEND_HIGH_I32X4_S() { do_op1_x(ValueKind.V128, mmasm.emit_i64x2_s_convert_i32x4_high); }
@@ -887,6 +887,20 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 		var d = allocRegTos(ValueKind.V128);
 		asm_meth(X(d), X(val.reg));
 		state.push(KIND_V128 | IN_REG, d, 0);
+	}
+	private def visit_V128_EXTMUL1<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr, X86_64Xmmr, bool, bool) -> T, is_low: bool, is_signed: bool) {
+		var b = popReg();
+		var a = popRegToOverwrite();
+		var x_tmp = X(allocTmp(kind));
+		emit(X(a.reg), X(b.reg), x_tmp, is_low, is_signed);
+		state.push(a.kindFlagsMatching(kind, IN_REG), a.reg, 0);
+	}
+	private def visit_V128_EXTMUL2<T>(kind: ValueKind, emit: (X86_64Xmmr, X86_64Xmmr, X86_64Xmmr, bool) -> T, is_signed: bool) {
+		var b = popReg();
+		var a = popRegToOverwrite();
+		var x_tmp = X(allocTmp(kind));
+		emit(X(a.reg), X(b.reg), x_tmp, is_signed);
+		state.push(a.kindFlagsMatching(kind, IN_REG), a.reg, 0);
 	}
 
 	// r1 = op(r1)

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -594,6 +594,10 @@ class X86_64SinglePassCompiler extends SinglePassCompiler {
 	def visit_I64X2_GE_S() { do_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_ge_s); }
 	def visit_I64X2_LE_S() { do_c_op2_x_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_ge_s); }
 	def visit_I64X2_ABS() { do_op1_x_xtmp(ValueKind.V128, mmasm.emit_i64x2_abs); }
+	def visit_I64X2_EXTMUL_LOW_I32X4_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), true, true)); }
+	def visit_I64X2_EXTMUL_LOW_I32X4_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), true, false)); }
+	def visit_I64X2_EXTMUL_HIGH_I32X4_S() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), false, true)); }
+	def visit_I64X2_EXTMUL_HIGH_I32X4_U() { do_op2_x_x(ValueKind.V128, mmasm.emit_i64x2_extmul(_, _, X(allocTmp(ValueKind.V128)), false, false)); }
 	def visit_I64X2_EXTEND_LOW_I32X4_S() { do_op1_x_x(ValueKind.V128, asm.pmovsxdq_s_s); }
 	def visit_I64X2_EXTEND_LOW_I32X4_U() { do_op1_x_x(ValueKind.V128, asm.pmovzxdq_s_s); }
 	def visit_I64X2_EXTEND_HIGH_I32X4_S() { do_op1_x(ValueKind.V128, mmasm.emit_i64x2_s_convert_i32x4_high); }


### PR DESCRIPTION
Tested by: `make -j && bin/spectest.x86-64-linux -tk -mode=spc test/regress/simd/simd_i64x2_extmul_i32x4.bin.wast`