### PR TITLE
[simd/v3i]: Implement more integer arithmetic instructions

### DIFF
--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -498,259 +498,260 @@ component V3Eval {
 			_ => return val;
 		}
 	}
-	// Private (i.e. file-scoped) utilities.
-	// ---- v128 arithmetic helpers ----------------------------------------
-	def F32_ADD_U = float_binop(_, _, float.+);
-	def F32_SUB_U = float_binop(_, _, float.-);
-	def F32_MUL_U = float_binop(_, _, float.*);
-	def F32_DIV_U = float_binop(_, _, float./);
-	def F32_NEG_U = float_unop(_, V3Eval.F32_NEG);
-	def F32_SQRT_U = float_unop(_, float.sqrt);
-	def F64_ADD_U = double_binop(_, _, double.+);
-	def F64_SUB_U = double_binop(_, _, double.-);
-	def F64_MUL_U = double_binop(_, _, double.*);
-	def F64_DIV_U = double_binop(_, _, double./);
-	def F64_NEG_U = double_unop(_, V3Eval.F64_NEG);
-	def F64_SQRT_U = double_unop(_, double.sqrt);
+}
 
-	def V128_I8_MIN_S = i8_s_binop(_, _, I8_MIN_S);
-	def V128_I16_MIN_S = i16_s_binop(_, _, I16_MIN_S);
-	def V128_I32_MIN_S = i32_s_binop(_, _, I32_MIN_S);
-	def V128_I8_MAX_S = i8_s_binop(_, _, I8_MAX_S);
-	def V128_I16_MAX_S = i16_s_binop(_, _, I16_MAX_S);
-	def V128_I32_MAX_S = i32_s_binop(_, _, I32_MAX_S);
-	def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
-	def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
-	def V128_I32_ABS = i32_s_unop(_, I32_ABS_S);
-	def V128_I64_ABS = i64_s_unop(_, I64_ABS_S);
+// Private (i.e. file-scoped) utilities.
+// ---- v128 arithmetic helpers ----------------------------------------
+def F32_ADD_U = float_binop(_, _, float.+);
+def F32_SUB_U = float_binop(_, _, float.-);
+def F32_MUL_U = float_binop(_, _, float.*);
+def F32_DIV_U = float_binop(_, _, float./);
+def F32_NEG_U = float_unop(_, V3Eval.F32_NEG);
+def F32_SQRT_U = float_unop(_, float.sqrt);
+def F64_ADD_U = double_binop(_, _, double.+);
+def F64_SUB_U = double_binop(_, _, double.-);
+def F64_MUL_U = double_binop(_, _, double.*);
+def F64_DIV_U = double_binop(_, _, double./);
+def F64_NEG_U = double_unop(_, V3Eval.F64_NEG);
+def F64_SQRT_U = double_unop(_, double.sqrt);
 
-	def I8_MIN_S(a: i8, b: i8) -> i8 {
-		if (a <= b) return a;
-		else return b;
-	}
-	def I16_MIN_S(a: i16, b: i16) -> i16 {
-		if (a <= b) return a;
-		else return b;
-	}
-	def I32_MIN_S(a: i32, b: i32) -> i32 {
-		if (a <= b) return a;
-		else return b;
-	}
- 	def I8_MAX_S(a: i8, b: i8) -> i8 {
-		if (a >= b) return a;
-		else return b;
-	}
-	def I16_MAX_S(a: i16, b: i16) -> i16 {
-		if (a >= b) return a;
-		else return b;
-	}
-	def I32_MAX_S(a: i32, b: i32) -> i32 {
-		if (a >= b) return a;
-		else return b;
-	}
-	def I8_MIN_U(a: u8, b: u8) -> u8 {
-		if (a <= b) return a;
-		else return b;
-	}
-	def I16_MIN_U(a: u16, b: u16) -> u16 {
-		if (a <= b) return a;
-		else return b;
-	}
-	def I32_MIN_U(a: u32, b: u32) -> u32 {
-		if (a <= b) return a;
-		else return b;
-	}
-	def I8_MAX_U(a: u8, b: u8) -> u8 {
-		if (a >= b) return a;
-		else return b;
-	}
-	def I16_MAX_U(a: u16, b: u16) -> u16 {
-		if (a >= b) return a;
-		else return b;
-	}
-	def I32_MAX_U(a: u32, b: u32) -> u32 {
-		if (a >= b) return a;
-		else return b;
-	}
-	def I8_AVGR_U(a: u8, b: u8) -> u8 {
-		// rounding average
-		var sum = u16.view(a) + u16.view(b);
-		return u8.view((sum + 1) / 2);
-	}
-	def I16_AVGR_U(a: u16, b: u16) -> u16 {
-		// rounding average
-		var sum = u32.view(a) + u32.view(b);
-		return u16.view((sum + 1) / 2);
-	}
-	def I8_ABS_S(a: i8) -> i8 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	def I16_ABS_S(a: i16) -> i16 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	def I32_ABS_S(a: i32) -> i32 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	def I64_ABS_S(a: i64) -> i64 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	def I8_POPCNT(a: u8) -> u8 {
-		var count:byte = 0;
-		for (i < 8) {
-			if ((a & 1) == 1) count++;
-			a >>= 1;
-		}
-		return count;
-	}
-	// Adapters
-	def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
-		return u32.view(f(float.view(a), float.view(b)));
-	}
-	def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
-		return u32.view(f(float.view(a)));
-	}
-	def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
-		return u64.view(f(double.view(a), double.view(b)));
-	}
-	def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
-		return u64.view(f(double.view(a)));
-	}
-	def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
-		return u8.view(f(i8.view(a), i8.view(b)));
-	}
-	def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
-		return u8.view(f(i8.view(a)));
-	}
-	def i16_s_binop(a: u16, b: u16, f: (i16, i16) -> i16) -> u16 {  // Adapts a signed i16 binop to a u16 binop
-		return u16.view(f(i16.view(a), i16.view(b)));
-	}
-	def i16_s_unop(a: u16, f: i16 -> i16) -> u16 {  // Adapts a signed i16 unop to a u16 unop
-		return u16.view(f(i16.view(a)));
-	}
-	def i32_s_binop(a: u32, b: u32, f: (i32, i32) -> i32) -> u32 {  // Adapts a signed i32 binop to a u32 binop
-		return u32.view(f(i32.view(a), i32.view(b)));
-	}
-	def i32_s_unop(a: u32, f: i32 -> i32) -> u32 {  // Adapts a signed i32 unop to a u32 unop
-		return u32.view(f(i32.view(a)));
-	}
-	def i64_s_binop(a: u64, b: u64, f: (i64, i64) -> i64) -> u64 {  // Adapts a signed i64 binop to a u64 binop
-		return u64.view(f(i64.view(a), i64.view(b)));
-	}
-	def i64_s_unop(a: u64, f: i64 -> i64) -> u64 {  // Adapts a signed i64 unop to a u64 unop
-		return u64.view(f(i64.view(a)));
-	}
-	// Unary v128 ops
-	def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
-		var r0 = f(a.0);
-		var r1 = f(a.1);
-		return (r0, r1);
-	}
-	def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-lane unop
-		var r0 = f(u32.view(a.0));
-		var r1 = f(u32.view(a.0 >> 32));
-		var r2 = f(u32.view(a.1));
-		var r3 = f(u32.view(a.1 >> 32));
-		return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
-	}
-	def do_v_v_x8(a: (u64, u64), f: (u16) -> u16) -> (u64, u64) { // Performs an 8-lane unop
-		var low: u64 = 0;
-		var high: u64 = 0;
+def V128_I8_MIN_S = i8_s_binop(_, _, I8_MIN_S);
+def V128_I16_MIN_S = i16_s_binop(_, _, I16_MIN_S);
+def V128_I32_MIN_S = i32_s_binop(_, _, I32_MIN_S);
+def V128_I8_MAX_S = i8_s_binop(_, _, I8_MAX_S);
+def V128_I16_MAX_S = i16_s_binop(_, _, I16_MAX_S);
+def V128_I32_MAX_S = i32_s_binop(_, _, I32_MAX_S);
+def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
+def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
+def V128_I32_ABS = i32_s_unop(_, I32_ABS_S);
+def V128_I64_ABS = i64_s_unop(_, I64_ABS_S);
 
+def I8_MIN_S(a: i8, b: i8) -> i8 {
+	if (a <= b) return a;
+	else return b;
+}
+def I16_MIN_S(a: i16, b: i16) -> i16 {
+	if (a <= b) return a;
+	else return b;
+}
+def I32_MIN_S(a: i32, b: i32) -> i32 {
+	if (a <= b) return a;
+	else return b;
+}
+def I8_MAX_S(a: i8, b: i8) -> i8 {
+	if (a >= b) return a;
+	else return b;
+}
+def I16_MAX_S(a: i16, b: i16) -> i16 {
+	if (a >= b) return a;
+	else return b;
+}
+def I32_MAX_S(a: i32, b: i32) -> i32 {
+	if (a >= b) return a;
+	else return b;
+}
+def I8_MIN_U(a: u8, b: u8) -> u8 {
+	if (a <= b) return a;
+	else return b;
+}
+def I16_MIN_U(a: u16, b: u16) -> u16 {
+	if (a <= b) return a;
+	else return b;
+}
+def I32_MIN_U(a: u32, b: u32) -> u32 {
+	if (a <= b) return a;
+	else return b;
+}
+def I8_MAX_U(a: u8, b: u8) -> u8 {
+	if (a >= b) return a;
+	else return b;
+}
+def I16_MAX_U(a: u16, b: u16) -> u16 {
+	if (a >= b) return a;
+	else return b;
+}
+def I32_MAX_U(a: u32, b: u32) -> u32 {
+	if (a >= b) return a;
+	else return b;
+}
+def I8_AVGR_U(a: u8, b: u8) -> u8 {
+	// rounding average
+	var sum = u16.view(a) + u16.view(b);
+	return u8.view((sum + 1) / 2);
+}
+def I16_AVGR_U(a: u16, b: u16) -> u16 {
+	// rounding average
+	var sum = u32.view(a) + u32.view(b);
+	return u16.view((sum + 1) / 2);
+}
+def I8_ABS_S(a: i8) -> i8 {
+	if (a < 0) return -a;
+	else return a;
+}
+def I16_ABS_S(a: i16) -> i16 {
+	if (a < 0) return -a;
+	else return a;
+}
+def I32_ABS_S(a: i32) -> i32 {
+	if (a < 0) return -a;
+	else return a;
+}
+def I64_ABS_S(a: i64) -> i64 {
+	if (a < 0) return -a;
+	else return a;
+}
+def I8_POPCNT(a: u8) -> u8 {
+	var count:byte = 0;
+	for (i < 8) {
+		if ((a & 1) == 1) count++;
+		a >>= 1;
+	}
+	return count;
+}
+// Adapters
+def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
+	return u32.view(f(float.view(a), float.view(b)));
+}
+def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
+	return u32.view(f(float.view(a)));
+}
+def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
+	return u64.view(f(double.view(a), double.view(b)));
+}
+def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
+	return u64.view(f(double.view(a)));
+}
+def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
+	return u8.view(f(i8.view(a), i8.view(b)));
+}
+def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
+	return u8.view(f(i8.view(a)));
+}
+def i16_s_binop(a: u16, b: u16, f: (i16, i16) -> i16) -> u16 {  // Adapts a signed i16 binop to a u16 binop
+	return u16.view(f(i16.view(a), i16.view(b)));
+}
+def i16_s_unop(a: u16, f: i16 -> i16) -> u16 {  // Adapts a signed i16 unop to a u16 unop
+	return u16.view(f(i16.view(a)));
+}
+def i32_s_binop(a: u32, b: u32, f: (i32, i32) -> i32) -> u32 {  // Adapts a signed i32 binop to a u32 binop
+	return u32.view(f(i32.view(a), i32.view(b)));
+}
+def i32_s_unop(a: u32, f: i32 -> i32) -> u32 {  // Adapts a signed i32 unop to a u32 unop
+	return u32.view(f(i32.view(a)));
+}
+def i64_s_binop(a: u64, b: u64, f: (i64, i64) -> i64) -> u64 {  // Adapts a signed i64 binop to a u64 binop
+	return u64.view(f(i64.view(a), i64.view(b)));
+}
+def i64_s_unop(a: u64, f: i64 -> i64) -> u64 {  // Adapts a signed i64 unop to a u64 unop
+	return u64.view(f(i64.view(a)));
+}
+// Unary v128 ops
+def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
+	var r0 = f(a.0);
+	var r1 = f(a.1);
+	return (r0, r1);
+}
+def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-lane unop
+	var r0 = f(u32.view(a.0));
+	var r1 = f(u32.view(a.0 >> 32));
+	var r2 = f(u32.view(a.1));
+	var r3 = f(u32.view(a.1 >> 32));
+	return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
+}
+def do_v_v_x8(a: (u64, u64), f: (u16) -> u16) -> (u64, u64) { // Performs an 8-lane unop
+	var low: u64 = 0;
+	var high: u64 = 0;
+
+	for (shift: byte = 0; shift < 64; shift += 16) {
+		var r_a = u16.view((a.0 >> shift) & 0xFFFF);
+		var res = f(r_a);
+		low |= (u64.view(res) << shift);
+		
+		r_a = u16.view((a.1 >> shift) & 0xFFFF);
+		res = f(r_a);
+		high |= (u64.view(res) << shift);
+	}
+
+	return (low, high);
+}
+def do_v_v_x16(a: (u64, u64), f: (u8) -> u8) -> (u64, u64) { // Performs a 16-lane unop
+	var low: u64 = 0;
+	var high: u64 = 0;
+
+	for (shift: byte = 0; shift < 64; shift += 8) {
+		var r_a = u8.view((a.0 >> shift) & 0xFF);
+		var res = f(r_a);
+		low |= (u64.view(res) << shift);
+		
+		r_a = u8.view((a.1 >> shift) & 0xFF);
+		res = f(r_a);
+		high |= (u64.view(res) << shift);
+	}
+
+	return (low, high);
+}
+// Binary v128 ops
+def do_vv_v_x2(a: (u64, u64), b: (u64, u64), f: (u64, u64) -> u64) -> (u64, u64) { // Performs a 2-lane binop
+	var r0 = f(a.0, b.0);
+	var r1 = f(a.1, b.1);
+	return (r0, r1);
+}
+def do_vv_v_x4(a: (u64, u64), b: (u64, u64), f: (u32, u32) -> u32) -> (u64, u64) { // Performs a 4-lane binop
+	var r0 = f(u32.view(a.0), u32.view(b.0));
+	var r1 = f(u32.view(a.0 >> 32), u32.view(b.0 >> 32));
+	var r2 = f(u32.view(a.1), u32.view(b.1));
+	var r3 = f(u32.view(a.1 >> 32), u32.view(b.1 >> 32));
+	return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
+}
+def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64) { // Performs an 8-lane binop
+	var low: u64 = 0;
+	var high: u64 = 0;
 		for (shift: byte = 0; shift < 64; shift += 16) {
-			var r_a = u16.view((a.0 >> shift) & 0xFFFF);
-			var res = f(r_a);
-			low |= (u64.view(res) << shift);
-			
-			r_a = u16.view((a.1 >> shift) & 0xFFFF);
-			res = f(r_a);
-			high |= (u64.view(res) << shift);
-		}
-
-		return (low, high);
+		var r_a = u16.view((a.0 >> shift) & 0xFFFF);
+		var r_b = u16.view((b.0 >> shift) & 0xFFFF);
+		var res = f(r_a, r_b);
+		low |= (u64.view(res) << shift);
+		
+		r_a = u16.view((a.1 >> shift) & 0xFFFF);
+		r_b = u16.view((b.1 >> shift) & 0xFFFF);
+		res = f(r_a, r_b);
+		high |= (u64.view(res) << shift);
 	}
-	def do_v_v_x16(a: (u64, u64), f: (u8) -> u8) -> (u64, u64) { // Performs a 16-lane unop
-		var low: u64 = 0;
-		var high: u64 = 0;
-
+		return (low, high);
+}
+def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) { // Performs a 16-lane binop
+	var low: u64 = 0;
+	var high: u64 = 0;
 		for (shift: byte = 0; shift < 64; shift += 8) {
-			var r_a = u8.view((a.0 >> shift) & 0xFF);
-			var res = f(r_a);
-			low |= (u64.view(res) << shift);
-			
-			r_a = u8.view((a.1 >> shift) & 0xFF);
-			res = f(r_a);
-			high |= (u64.view(res) << shift);
-		}
-
+		var r_a = u8.view((a.0 >> shift) & 0xFF);
+		var r_b = u8.view((b.0 >> shift) & 0xFF);
+		var res = f(r_a, r_b);
+		low |= (u64.view(res) << shift);
+		
+		r_a = u8.view((a.1 >> shift) & 0xFF);
+		r_b = u8.view((b.1 >> shift) & 0xFF);
+		res = f(r_a, r_b);
+		high |= (u64.view(res) << shift);
+	}
 		return (low, high);
-	}
-	// Binary v128 ops
-	def do_vv_v_x2(a: (u64, u64), b: (u64, u64), f: (u64, u64) -> u64) -> (u64, u64) { // Performs a 2-lane binop
-		var r0 = f(a.0, b.0);
-		var r1 = f(a.1, b.1);
-		return (r0, r1);
-	}
-	def do_vv_v_x4(a: (u64, u64), b: (u64, u64), f: (u32, u32) -> u32) -> (u64, u64) { // Performs a 4-lane binop
-		var r0 = f(u32.view(a.0), u32.view(b.0));
-		var r1 = f(u32.view(a.0 >> 32), u32.view(b.0 >> 32));
-		var r2 = f(u32.view(a.1), u32.view(b.1));
-		var r3 = f(u32.view(a.1 >> 32), u32.view(b.1 >> 32));
-		return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
-	}
-	def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64) { // Performs an 8-lane binop
-		var low: u64 = 0;
-		var high: u64 = 0;
-			for (shift: byte = 0; shift < 64; shift += 16) {
-			var r_a = u16.view((a.0 >> shift) & 0xFFFF);
-			var r_b = u16.view((b.0 >> shift) & 0xFFFF);
-			var res = f(r_a, r_b);
-			low |= (u64.view(res) << shift);
-			
-			r_a = u16.view((a.1 >> shift) & 0xFFFF);
-			r_b = u16.view((b.1 >> shift) & 0xFFFF);
-			res = f(r_a, r_b);
-			high |= (u64.view(res) << shift);
-		}
-			return (low, high);
-	}
-	def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) { // Performs a 16-lane binop
-		var low: u64 = 0;
-		var high: u64 = 0;
-			for (shift: byte = 0; shift < 64; shift += 8) {
-			var r_a = u8.view((a.0 >> shift) & 0xFF);
-			var r_b = u8.view((b.0 >> shift) & 0xFF);
-			var res = f(r_a, r_b);
-			low |= (u64.view(res) << shift);
-			
-			r_a = u8.view((a.1 >> shift) & 0xFF);
-			r_b = u8.view((b.1 >> shift) & 0xFF);
-			res = f(r_a, r_b);
-			high |= (u64.view(res) << shift);
-		}
-			return (low, high);
-	}
-	def canonf(a: float) -> float {
-		return if(a == a, a, float.nan);
-	}
-	def canond(a: double) -> double {
-		return if(a == a, a, double.nan);
-	}
-	def truncF32<T>(min: float, max: float, trunc: float -> T, a: float) -> (T, TrapReason) {
-		var d: T;
-		if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-		if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-		if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-		return (trunc(a), TrapReason.NONE);
-	}
-	def truncF64<T>(min: double, max: double, trunc: double -> T, a: double) -> (T, TrapReason) {
-		var d: T;
-		if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-		if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-		if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-		return (trunc(a), TrapReason.NONE);
-	}
+}
+def canonf(a: float) -> float {
+	return if(a == a, a, float.nan);
+}
+def canond(a: double) -> double {
+	return if(a == a, a, double.nan);
+}
+def truncF32<T>(min: float, max: float, trunc: float -> T, a: float) -> (T, TrapReason) {
+	var d: T;
+	if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+	if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+	if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+	return (trunc(a), TrapReason.NONE);
+}
+def truncF64<T>(min: double, max: double, trunc: double -> T, a: double) -> (T, TrapReason) {
+	var d: T;
+	if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+	if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+	if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+	return (trunc(a), TrapReason.NONE);
 }

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -338,6 +338,24 @@ component V3Eval {
 	def I16X8_NEG(a: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x8((0, 0), a, u16.-);
 	}
+	def I16X8_MIN_S(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x8(a, b, V128_I16_MIN_S);
+	}
+	def I16X8_MIN_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x8(a, b, I16_MIN_U);
+	}
+	def I16X8_MAX_S(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x8(a, b, V128_I16_MAX_S);
+	}
+	def I16X8_MAX_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x8(a, b, I16_MAX_U);
+	}
+	def I16X8_AVGR_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x8(a, b, I16_AVGR_U);
+	}
+	def I16X8_ABS(a: (u64, u64)) -> (u64, u64) {
+		return do_v_v_x8(a, V128_I16_ABS);
+	}
 	def I8X16_ADD(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x16(a, b, u8.+);
 	}
@@ -405,6 +423,86 @@ component V3Eval {
 		return do_v_v_x2(a, F64_SQRT_U);
 	}
 
+	// ---- v128 arithmetic helpers ----------------------------------------
+	private def V128_I8_MIN_S = i8_s_binop(_, _, I8_MIN_S);
+	private def V128_I16_MIN_S = i16_s_binop(_, _, I16_MIN_S);
+	private def V128_I8_MAX_S = i8_s_binop(_, _, I8_MAX_S);
+	private def V128_I16_MAX_S = i16_s_binop(_, _, I16_MAX_S);
+	private def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
+	private def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
+	
+	private def I8_MIN_S(a: i8, b: i8) -> i8 {
+		if (a <= b) return a;
+		else return b;
+	}
+	private def I16_MIN_S(a: i16, b: i16) -> i16 {
+		if (a <= b) return a;
+		else return b;
+	}
+	private def I8_MAX_S(a: i8, b: i8) -> i8 {
+		if (a >= b) return a;
+		else return b;
+	}
+	private def I16_MAX_S(a: i16, b: i16) -> i16 {
+		if (a >= b) return a;
+		else return b;
+	}
+	private def I8_MIN_U(a: u8, b: u8) -> u8 {
+		if (a <= b) return a;
+		else return b;
+	}
+	private def I16_MIN_U(a: u16, b: u16) -> u16 {
+		if (a <= b) return a;
+		else return b;
+	}
+	private def I8_MAX_U(a: u8, b: u8) -> u8 {
+		if (a >= b) return a;
+		else return b;
+	}
+	private def I16_MAX_U(a: u16, b: u16) -> u16 {
+		if (a >= b) return a;
+		else return b;
+	}
+	private def I8_AVGR_U(a: u8, b: u8) -> u8 {
+		// rounding average
+		var sum = u16.view(a) + u16.view(b);
+		return u8.view((sum + 1) / 2);
+	}
+	private def I16_AVGR_U(a: u16, b: u16) -> u16 {
+		// rounding average
+		var sum = u32.view(a) + u32.view(b);
+		return u16.view((sum + 1) / 2);
+	}
+	private def I8_ABS_S(a: i8) -> i8 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	private def I16_ABS_S(a: i16) -> i16 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	private def I8_POPCNT(a: u8) -> u8 {
+		var count:byte = 0;
+		for (i < 8) {
+			if ((a & 1) == 1) count++;
+			a >>= 1;
+		}
+		return count;
+	}
+
+	private def F32_ADD_U = float_binop(_, _, float.+);
+	private def F32_SUB_U = float_binop(_, _, float.-);
+	private def F32_MUL_U = float_binop(_, _, float.*);
+	private def F32_DIV_U = float_binop(_, _, float./);
+	private def F32_NEG_U = float_unop(_, F32_NEG);
+	private def F32_SQRT_U = float_unop(_, float.sqrt);
+	private def F64_ADD_U = double_binop(_, _, double.+);
+	private def F64_SUB_U = double_binop(_, _, double.-);
+	private def F64_MUL_U = double_binop(_, _, double.*);
+	private def F64_DIV_U = double_binop(_, _, double./);
+	private def F64_NEG_U = double_unop(_, F64_NEG);
+	private def F64_SQRT_U = double_unop(_, double.sqrt);
+
 	// ---- rounding and conversion ----------------------------------------
 	def I32_WRAP_I64	= u32.view<u64>;
 	def I32_TRUNC_F32_S	= truncF32(-2.1474839E9f, 2147483648f, i32.truncf, _);
@@ -461,6 +559,140 @@ component V3Eval {
 			PACKED_I16 => return Value.I32(u16.view(Values.v_i(val)));
 			_ => return val;
 		}
+	}
+	private def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
+		return u8.view(f(i8.view(a), i8.view(b)));
+	}
+	private def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
+		return u8.view(f(i8.view(a)));
+	}
+	private def i16_s_binop(a: u16, b: u16, f: (i16, i16) -> i16) -> u16 {  // Adapts a signed i16 binop to a u16 binop
+		return u16.view(f(i16.view(a), i16.view(b)));
+	}
+	private def i16_s_unop(a: u16, f: i16 -> i16) -> u16 {  // Adapts a signed i16 unop to a u16 unop
+		return u16.view(f(i16.view(a)));
+	}
+	private def i32_s_binop(a: u32, b: u32, f: (i32, i32) -> i32) -> u32 {  // Adapts a signed i32 binop to a u32 binop
+		return u32.view(f(i32.view(a), i32.view(b)));
+	}
+	private def i32_s_unop(a: u32, f: i32 -> i32) -> u32 {  // Adapts a signed i32 unop to a u32 unop
+		return u32.view(f(i32.view(a)));
+	}
+	private def i64_s_binop(a: u64, b: u64, f: (i64, i64) -> i64) -> u64 {  // Adapts a signed i64 binop to a u64 binop
+		return u64.view(f(i64.view(a), i64.view(b)));
+	}
+	private def i64_s_unop(a: u64, f: i64 -> i64) -> u64 {  // Adapts a signed i64 unop to a u64 unop
+		return u64.view(f(i64.view(a)));
+	}
+	private def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
+		return u32.view(f(float.view(a), float.view(b)));
+	}
+	private def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
+		return u32.view(f(float.view(a)));
+	}
+	private def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
+		return u64.view(f(double.view(a), double.view(b)));
+	}
+	private def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
+		return u64.view(f(double.view(a)));
+	}
+	private def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
+		var r0 = f(a.0);
+		var r1 = f(a.1);
+		return (r0, r1);
+	}
+	private def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-lane unop
+		var r0 = f(u32.view(a.0));
+		var r1 = f(u32.view(a.0 >> 32));
+		var r2 = f(u32.view(a.1));
+		var r3 = f(u32.view(a.1 >> 32));
+		return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
+	}
+	private def do_v_v_x8(a: (u64, u64), f: (u16) -> u16) -> (u64, u64) { // Performs an 8-lane unop
+		var low: u64 = 0;
+		var high: u64 = 0;
+
+		for (shift: byte = 0; shift < 64; shift += 16) {
+			var r_a = u16.view((a.0 >> shift) & 0xFFFF);
+			var res = f(r_a);
+			low |= (u64.view(res) << shift);
+			
+			r_a = u16.view((a.1 >> shift) & 0xFFFF);
+			res = f(r_a);
+			high |= (u64.view(res) << shift);
+		}
+
+		return (low, high);
+	}
+	private def do_v_v_x16(a: (u64, u64), f: (u8) -> u8) -> (u64, u64) { // Performs a 16-lane unop
+		var low: u64 = 0;
+		var high: u64 = 0;
+
+		for (shift: byte = 0; shift < 64; shift += 8) {
+			var r_a = u8.view((a.0 >> shift) & 0xFF);
+			var res = f(r_a);
+			low |= (u64.view(res) << shift);
+			
+			r_a = u8.view((a.1 >> shift) & 0xFF);
+			res = f(r_a);
+			high |= (u64.view(res) << shift);
+		}
+
+		return (low, high);
+	}
+	private def do_vv_v_x2(a: (u64, u64), b: (u64, u64), f: (u64, u64) -> u64) -> (u64, u64) { // Performs a 2-lane binop
+		var r0 = f(a.0, b.0);
+		var r1 = f(a.1, b.1);
+		return (r0, r1);
+	}
+	private def do_vv_v_x4(a: (u64, u64), b: (u64, u64), f: (u32, u32) -> u32) -> (u64, u64) { // Performs a 4-lane binop
+		var r0 = f(u32.view(a.0), u32.view(b.0));
+		var r1 = f(u32.view(a.0 >> 32), u32.view(b.0 >> 32));
+		var r2 = f(u32.view(a.1), u32.view(b.1));
+		var r3 = f(u32.view(a.1 >> 32), u32.view(b.1 >> 32));
+		return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
+	}
+	private def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64) { // Performs an 8-lane binop
+		var low: u64 = 0;
+		var high: u64 = 0;
+
+		for (shift: byte = 0; shift < 64; shift += 16) {
+			var r_a = u16.view((a.0 >> shift) & 0xFFFF);
+			var r_b = u16.view((b.0 >> shift) & 0xFFFF);
+			var res = f(r_a, r_b);
+			low |= (u64.view(res) << shift);
+			
+			r_a = u16.view((a.1 >> shift) & 0xFFFF);
+			r_b = u16.view((b.1 >> shift) & 0xFFFF);
+			res = f(r_a, r_b);
+			high |= (u64.view(res) << shift);
+		}
+
+		return (low, high);
+	}
+	private def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) { // Performs a 16-lane binop
+		var low: u64 = 0;
+		var high: u64 = 0;
+
+		for (shift: byte = 0; shift < 64; shift += 8) {
+			var r_a = u8.view((a.0 >> shift) & 0xFF);
+			var r_b = u8.view((b.0 >> shift) & 0xFF);
+			var res = f(r_a, r_b);
+			low |= (u64.view(res) << shift);
+			
+			r_a = u8.view((a.1 >> shift) & 0xFF);
+			r_b = u8.view((b.1 >> shift) & 0xFF);
+			res = f(r_a, r_b);
+			high |= (u64.view(res) << shift);
+		}
+
+		return (low, high);
+	}
+	private def canonf(a: float) -> float {
+		return if(a == a, a, float.nan);
+	}
+	private def canond(a: double) -> double {
+		return if(a == a, a, double.nan);
 	}
 }
 

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -441,114 +441,6 @@ component V3Eval {
 		return do_v_v_x2(a, F64_SQRT_U);
 	}
 
-	// ---- v128 arithmetic helpers ----------------------------------------
-	private def V128_I8_MIN_S = i8_s_binop(_, _, I8_MIN_S);
-	private def V128_I16_MIN_S = i16_s_binop(_, _, I16_MIN_S);
-	private def V128_I32_MIN_S = i32_s_binop(_, _, I32_MIN_S);
-	private def V128_I8_MAX_S = i8_s_binop(_, _, I8_MAX_S);
-	private def V128_I16_MAX_S = i16_s_binop(_, _, I16_MAX_S);
-	private def V128_I32_MAX_S = i32_s_binop(_, _, I32_MAX_S);
-	private def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
-	private def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
-	private def V128_I32_ABS = i32_s_unop(_, I32_ABS_S);
-	private def V128_I64_ABS = i64_s_unop(_, I64_ABS_S);
-
-	private def I8_MIN_S(a: i8, b: i8) -> i8 {
-		if (a <= b) return a;
-		else return b;
-	}
-	private def I16_MIN_S(a: i16, b: i16) -> i16 {
-		if (a <= b) return a;
-		else return b;
-	}
-	private def I32_MIN_S(a: i32, b: i32) -> i32 {
-		if (a <= b) return a;
-		else return b;
-	}
-	private def I8_MAX_S(a: i8, b: i8) -> i8 {
-		if (a >= b) return a;
-		else return b;
-	}
-	private def I16_MAX_S(a: i16, b: i16) -> i16 {
-		if (a >= b) return a;
-		else return b;
-	}
-	private def I32_MAX_S(a: i32, b: i32) -> i32 {
-		if (a >= b) return a;
-		else return b;
-	}
-	private def I8_MIN_U(a: u8, b: u8) -> u8 {
-		if (a <= b) return a;
-		else return b;
-	}
-	private def I16_MIN_U(a: u16, b: u16) -> u16 {
-		if (a <= b) return a;
-		else return b;
-	}
-	private def I32_MIN_U(a: u32, b: u32) -> u32 {
-		if (a <= b) return a;
-		else return b;
-	}
-	private def I8_MAX_U(a: u8, b: u8) -> u8 {
-		if (a >= b) return a;
-		else return b;
-	}
-	private def I16_MAX_U(a: u16, b: u16) -> u16 {
-		if (a >= b) return a;
-		else return b;
-	}
-	private def I32_MAX_U(a: u32, b: u32) -> u32 {
-		if (a >= b) return a;
-		else return b;
-	}
-	private def I8_AVGR_U(a: u8, b: u8) -> u8 {
-		// rounding average
-		var sum = u16.view(a) + u16.view(b);
-		return u8.view((sum + 1) / 2);
-	}
-	private def I16_AVGR_U(a: u16, b: u16) -> u16 {
-		// rounding average
-		var sum = u32.view(a) + u32.view(b);
-		return u16.view((sum + 1) / 2);
-	}
-	private def I8_ABS_S(a: i8) -> i8 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	private def I16_ABS_S(a: i16) -> i16 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	private def I32_ABS_S(a: i32) -> i32 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	private def I64_ABS_S(a: i64) -> i64 {
-		if (a < 0) return -a;
-		else return a;
-	}
-	private def I8_POPCNT(a: u8) -> u8 {
-		var count:byte = 0;
-		for (i < 8) {
-			if ((a & 1) == 1) count++;
-			a >>= 1;
-		}
-		return count;
-	}
-
-	private def F32_ADD_U = float_binop(_, _, float.+);
-	private def F32_SUB_U = float_binop(_, _, float.-);
-	private def F32_MUL_U = float_binop(_, _, float.*);
-	private def F32_DIV_U = float_binop(_, _, float./);
-	private def F32_NEG_U = float_unop(_, F32_NEG);
-	private def F32_SQRT_U = float_unop(_, float.sqrt);
-	private def F64_ADD_U = double_binop(_, _, double.+);
-	private def F64_SUB_U = double_binop(_, _, double.-);
-	private def F64_MUL_U = double_binop(_, _, double.*);
-	private def F64_DIV_U = double_binop(_, _, double./);
-	private def F64_NEG_U = double_unop(_, F64_NEG);
-	private def F64_SQRT_U = double_unop(_, double.sqrt);
-
 	// ---- rounding and conversion ----------------------------------------
 	def I32_WRAP_I64	= u32.view<u64>;
 	def I32_TRUNC_F32_S	= truncF32(-2.1474839E9f, 2147483648f, i32.truncf, _);
@@ -606,55 +498,165 @@ component V3Eval {
 			_ => return val;
 		}
 	}
-	private def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
-		return u8.view(f(i8.view(a), i8.view(b)));
+	// Private (i.e. file-scoped) utilities.
+	// ---- v128 arithmetic helpers ----------------------------------------
+	def F32_ADD_U = float_binop(_, _, float.+);
+	def F32_SUB_U = float_binop(_, _, float.-);
+	def F32_MUL_U = float_binop(_, _, float.*);
+	def F32_DIV_U = float_binop(_, _, float./);
+	def F32_NEG_U = float_unop(_, V3Eval.F32_NEG);
+	def F32_SQRT_U = float_unop(_, float.sqrt);
+	def F64_ADD_U = double_binop(_, _, double.+);
+	def F64_SUB_U = double_binop(_, _, double.-);
+	def F64_MUL_U = double_binop(_, _, double.*);
+	def F64_DIV_U = double_binop(_, _, double./);
+	def F64_NEG_U = double_unop(_, V3Eval.F64_NEG);
+	def F64_SQRT_U = double_unop(_, double.sqrt);
+
+	def V128_I8_MIN_S = i8_s_binop(_, _, I8_MIN_S);
+	def V128_I16_MIN_S = i16_s_binop(_, _, I16_MIN_S);
+	def V128_I32_MIN_S = i32_s_binop(_, _, I32_MIN_S);
+	def V128_I8_MAX_S = i8_s_binop(_, _, I8_MAX_S);
+	def V128_I16_MAX_S = i16_s_binop(_, _, I16_MAX_S);
+	def V128_I32_MAX_S = i32_s_binop(_, _, I32_MAX_S);
+	def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
+	def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
+	def V128_I32_ABS = i32_s_unop(_, I32_ABS_S);
+	def V128_I64_ABS = i64_s_unop(_, I64_ABS_S);
+
+	def I8_MIN_S(a: i8, b: i8) -> i8 {
+		if (a <= b) return a;
+		else return b;
 	}
-	private def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
-		return u8.view(f(i8.view(a)));
+	def I16_MIN_S(a: i16, b: i16) -> i16 {
+		if (a <= b) return a;
+		else return b;
 	}
-	private def i16_s_binop(a: u16, b: u16, f: (i16, i16) -> i16) -> u16 {  // Adapts a signed i16 binop to a u16 binop
-		return u16.view(f(i16.view(a), i16.view(b)));
+	def I32_MIN_S(a: i32, b: i32) -> i32 {
+		if (a <= b) return a;
+		else return b;
 	}
-	private def i16_s_unop(a: u16, f: i16 -> i16) -> u16 {  // Adapts a signed i16 unop to a u16 unop
-		return u16.view(f(i16.view(a)));
+ 	def I8_MAX_S(a: i8, b: i8) -> i8 {
+		if (a >= b) return a;
+		else return b;
 	}
-	private def i32_s_binop(a: u32, b: u32, f: (i32, i32) -> i32) -> u32 {  // Adapts a signed i32 binop to a u32 binop
-		return u32.view(f(i32.view(a), i32.view(b)));
+	def I16_MAX_S(a: i16, b: i16) -> i16 {
+		if (a >= b) return a;
+		else return b;
 	}
-	private def i32_s_unop(a: u32, f: i32 -> i32) -> u32 {  // Adapts a signed i32 unop to a u32 unop
-		return u32.view(f(i32.view(a)));
+	def I32_MAX_S(a: i32, b: i32) -> i32 {
+		if (a >= b) return a;
+		else return b;
 	}
-	private def i64_s_binop(a: u64, b: u64, f: (i64, i64) -> i64) -> u64 {  // Adapts a signed i64 binop to a u64 binop
-		return u64.view(f(i64.view(a), i64.view(b)));
+	def I8_MIN_U(a: u8, b: u8) -> u8 {
+		if (a <= b) return a;
+		else return b;
 	}
-	private def i64_s_unop(a: u64, f: i64 -> i64) -> u64 {  // Adapts a signed i64 unop to a u64 unop
-		return u64.view(f(i64.view(a)));
+	def I16_MIN_U(a: u16, b: u16) -> u16 {
+		if (a <= b) return a;
+		else return b;
 	}
-	private def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
+	def I32_MIN_U(a: u32, b: u32) -> u32 {
+		if (a <= b) return a;
+		else return b;
+	}
+	def I8_MAX_U(a: u8, b: u8) -> u8 {
+		if (a >= b) return a;
+		else return b;
+	}
+	def I16_MAX_U(a: u16, b: u16) -> u16 {
+		if (a >= b) return a;
+		else return b;
+	}
+	def I32_MAX_U(a: u32, b: u32) -> u32 {
+		if (a >= b) return a;
+		else return b;
+	}
+	def I8_AVGR_U(a: u8, b: u8) -> u8 {
+		// rounding average
+		var sum = u16.view(a) + u16.view(b);
+		return u8.view((sum + 1) / 2);
+	}
+	def I16_AVGR_U(a: u16, b: u16) -> u16 {
+		// rounding average
+		var sum = u32.view(a) + u32.view(b);
+		return u16.view((sum + 1) / 2);
+	}
+	def I8_ABS_S(a: i8) -> i8 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	def I16_ABS_S(a: i16) -> i16 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	def I32_ABS_S(a: i32) -> i32 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	def I64_ABS_S(a: i64) -> i64 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	def I8_POPCNT(a: u8) -> u8 {
+		var count:byte = 0;
+		for (i < 8) {
+			if ((a & 1) == 1) count++;
+			a >>= 1;
+		}
+		return count;
+	}
+	// Adapters
+	def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
 		return u32.view(f(float.view(a), float.view(b)));
 	}
-	private def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
+	def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
 		return u32.view(f(float.view(a)));
 	}
-	private def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
+	def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
 		return u64.view(f(double.view(a), double.view(b)));
 	}
-	private def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
+	def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
 		return u64.view(f(double.view(a)));
 	}
-	private def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
+	def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
+		return u8.view(f(i8.view(a), i8.view(b)));
+	}
+	def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
+		return u8.view(f(i8.view(a)));
+	}
+	def i16_s_binop(a: u16, b: u16, f: (i16, i16) -> i16) -> u16 {  // Adapts a signed i16 binop to a u16 binop
+		return u16.view(f(i16.view(a), i16.view(b)));
+	}
+	def i16_s_unop(a: u16, f: i16 -> i16) -> u16 {  // Adapts a signed i16 unop to a u16 unop
+		return u16.view(f(i16.view(a)));
+	}
+	def i32_s_binop(a: u32, b: u32, f: (i32, i32) -> i32) -> u32 {  // Adapts a signed i32 binop to a u32 binop
+		return u32.view(f(i32.view(a), i32.view(b)));
+	}
+	def i32_s_unop(a: u32, f: i32 -> i32) -> u32 {  // Adapts a signed i32 unop to a u32 unop
+		return u32.view(f(i32.view(a)));
+	}
+	def i64_s_binop(a: u64, b: u64, f: (i64, i64) -> i64) -> u64 {  // Adapts a signed i64 binop to a u64 binop
+		return u64.view(f(i64.view(a), i64.view(b)));
+	}
+	def i64_s_unop(a: u64, f: i64 -> i64) -> u64 {  // Adapts a signed i64 unop to a u64 unop
+		return u64.view(f(i64.view(a)));
+	}
+	// Unary v128 ops
+	def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
 		var r0 = f(a.0);
 		var r1 = f(a.1);
 		return (r0, r1);
 	}
-	private def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-lane unop
+	def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-lane unop
 		var r0 = f(u32.view(a.0));
 		var r1 = f(u32.view(a.0 >> 32));
 		var r2 = f(u32.view(a.1));
 		var r3 = f(u32.view(a.1 >> 32));
 		return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
 	}
-	private def do_v_v_x8(a: (u64, u64), f: (u16) -> u16) -> (u64, u64) { // Performs an 8-lane unop
+	def do_v_v_x8(a: (u64, u64), f: (u16) -> u16) -> (u64, u64) { // Performs an 8-lane unop
 		var low: u64 = 0;
 		var high: u64 = 0;
 
@@ -670,7 +672,7 @@ component V3Eval {
 
 		return (low, high);
 	}
-	private def do_v_v_x16(a: (u64, u64), f: (u8) -> u8) -> (u64, u64) { // Performs a 16-lane unop
+	def do_v_v_x16(a: (u64, u64), f: (u8) -> u8) -> (u64, u64) { // Performs a 16-lane unop
 		var low: u64 = 0;
 		var high: u64 = 0;
 
@@ -686,23 +688,23 @@ component V3Eval {
 
 		return (low, high);
 	}
-	private def do_vv_v_x2(a: (u64, u64), b: (u64, u64), f: (u64, u64) -> u64) -> (u64, u64) { // Performs a 2-lane binop
+	// Binary v128 ops
+	def do_vv_v_x2(a: (u64, u64), b: (u64, u64), f: (u64, u64) -> u64) -> (u64, u64) { // Performs a 2-lane binop
 		var r0 = f(a.0, b.0);
 		var r1 = f(a.1, b.1);
 		return (r0, r1);
 	}
-	private def do_vv_v_x4(a: (u64, u64), b: (u64, u64), f: (u32, u32) -> u32) -> (u64, u64) { // Performs a 4-lane binop
+	def do_vv_v_x4(a: (u64, u64), b: (u64, u64), f: (u32, u32) -> u32) -> (u64, u64) { // Performs a 4-lane binop
 		var r0 = f(u32.view(a.0), u32.view(b.0));
 		var r1 = f(u32.view(a.0 >> 32), u32.view(b.0 >> 32));
 		var r2 = f(u32.view(a.1), u32.view(b.1));
 		var r3 = f(u32.view(a.1 >> 32), u32.view(b.1 >> 32));
 		return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
 	}
-	private def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64) { // Performs an 8-lane binop
+	def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64) { // Performs an 8-lane binop
 		var low: u64 = 0;
 		var high: u64 = 0;
-
-		for (shift: byte = 0; shift < 64; shift += 16) {
+			for (shift: byte = 0; shift < 64; shift += 16) {
 			var r_a = u16.view((a.0 >> shift) & 0xFFFF);
 			var r_b = u16.view((b.0 >> shift) & 0xFFFF);
 			var res = f(r_a, r_b);
@@ -713,14 +715,12 @@ component V3Eval {
 			res = f(r_a, r_b);
 			high |= (u64.view(res) << shift);
 		}
-
-		return (low, high);
+			return (low, high);
 	}
-	private def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) { // Performs a 16-lane binop
+	def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) { // Performs a 16-lane binop
 		var low: u64 = 0;
 		var high: u64 = 0;
-
-		for (shift: byte = 0; shift < 64; shift += 8) {
+			for (shift: byte = 0; shift < 64; shift += 8) {
 			var r_a = u8.view((a.0 >> shift) & 0xFF);
 			var r_b = u8.view((b.0 >> shift) & 0xFF);
 			var res = f(r_a, r_b);
@@ -731,136 +731,26 @@ component V3Eval {
 			res = f(r_a, r_b);
 			high |= (u64.view(res) << shift);
 		}
-
-		return (low, high);
+			return (low, high);
 	}
-	private def canonf(a: float) -> float {
+	def canonf(a: float) -> float {
 		return if(a == a, a, float.nan);
 	}
-	private def canond(a: double) -> double {
+	def canond(a: double) -> double {
 		return if(a == a, a, double.nan);
 	}
-}
-
-// Private (i.e. file-scoped) utilities.
-// ---- v128 arithmetic helpers ----------------------------------------
-def F32_ADD_U = float_binop(_, _, float.+);
-def F32_SUB_U = float_binop(_, _, float.-);
-def F32_MUL_U = float_binop(_, _, float.*);
-def F32_DIV_U = float_binop(_, _, float./);
-def F32_NEG_U = float_unop(_, V3Eval.F32_NEG);
-def F32_SQRT_U = float_unop(_, float.sqrt);
-def F64_ADD_U = double_binop(_, _, double.+);
-def F64_SUB_U = double_binop(_, _, double.-);
-def F64_MUL_U = double_binop(_, _, double.*);
-def F64_DIV_U = double_binop(_, _, double./);
-def F64_NEG_U = double_unop(_, V3Eval.F64_NEG);
-def F64_SQRT_U = double_unop(_, double.sqrt);
-
-def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
-	return u32.view(f(float.view(a), float.view(b)));
-}
-def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
-	return u32.view(f(float.view(a)));
-}
-def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
-	return u64.view(f(double.view(a), double.view(b)));
-}
-def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
-	return u64.view(f(double.view(a)));
-}
-def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
-	return u8.view(f(i8.view(a), i8.view(b)));
-}
-def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
-	return u8.view(f(i8.view(a)));
-}
-def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
-	return u32.view(f(float.view(a), float.view(b)));
-}
-def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
-	return u32.view(f(float.view(a)));
-}
-def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
-	return u64.view(f(double.view(a), double.view(b)));
-}
-def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
-	return u64.view(f(double.view(a)));
-}
-def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
-	var r0 = f(a.0);
-	var r1 = f(a.1);
-	return (r0, r1);
-}
-def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-lane unop
-	var r0 = f(u32.view(a.0));
-	var r1 = f(u32.view(a.0 >> 32));
-	var r2 = f(u32.view(a.1));
-	var r3 = f(u32.view(a.1 >> 32));
-	return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
-}
-def do_vv_v_x2(a: (u64, u64), b: (u64, u64), f: (u64, u64) -> u64) -> (u64, u64) { // Performs a 2-lane binop
-	var r0 = f(a.0, b.0);
-	var r1 = f(a.1, b.1);
-	return (r0, r1);
-}
-def do_vv_v_x4(a: (u64, u64), b: (u64, u64), f: (u32, u32) -> u32) -> (u64, u64) { // Performs a 4-lane binop
-	var r0 = f(u32.view(a.0), u32.view(b.0));
-	var r1 = f(u32.view(a.0 >> 32), u32.view(b.0 >> 32));
-	var r2 = f(u32.view(a.1), u32.view(b.1));
-	var r3 = f(u32.view(a.1 >> 32), u32.view(b.1 >> 32));
-	return ((u64.view(r1) << 32) | r0, (u64.view(r3) << 32) | r2);
-}
-def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64) { // Performs an 8-lane binop
-	var low: u64 = 0;
-	var high: u64 = 0;
-		for (shift: byte = 0; shift < 64; shift += 16) {
-		var r_a = u16.view((a.0 >> shift) & 0xFFFF);
-		var r_b = u16.view((b.0 >> shift) & 0xFFFF);
-		var res = f(r_a, r_b);
-		low |= (u64.view(res) << shift);
-		
-		r_a = u16.view((a.1 >> shift) & 0xFFFF);
-		r_b = u16.view((b.1 >> shift) & 0xFFFF);
-		res = f(r_a, r_b);
-		high |= (u64.view(res) << shift);
+	def truncF32<T>(min: float, max: float, trunc: float -> T, a: float) -> (T, TrapReason) {
+		var d: T;
+		if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+		if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+		if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+		return (trunc(a), TrapReason.NONE);
 	}
-		return (low, high);
-}
-def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) { // Performs a 16-lane binop
-	var low: u64 = 0;
-	var high: u64 = 0;
-		for (shift: byte = 0; shift < 64; shift += 8) {
-		var r_a = u8.view((a.0 >> shift) & 0xFF);
-		var r_b = u8.view((b.0 >> shift) & 0xFF);
-		var res = f(r_a, r_b);
-		low |= (u64.view(res) << shift);
-		
-		r_a = u8.view((a.1 >> shift) & 0xFF);
-		r_b = u8.view((b.1 >> shift) & 0xFF);
-		res = f(r_a, r_b);
-		high |= (u64.view(res) << shift);
+	def truncF64<T>(min: double, max: double, trunc: double -> T, a: double) -> (T, TrapReason) {
+		var d: T;
+		if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+		if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+		if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
+		return (trunc(a), TrapReason.NONE);
 	}
-		return (low, high);
 }
-def canonf(a: float) -> float {
-	return if(a == a, a, float.nan);
-}
-def canond(a: double) -> double {
-	return if(a == a, a, double.nan);
-}
-def truncF32<T>(min: float, max: float, trunc: float -> T, a: float) -> (T, TrapReason) {
-	var d: T;
-	if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-	if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-	if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-	return (trunc(a), TrapReason.NONE);
-}
-def truncF64<T>(min: double, max: double, trunc: double -> T, a: double) -> (T, TrapReason) {
-	var d: T;
-	if (a >= max) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-	if (a <= min) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-	if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
-	return (trunc(a), TrapReason.NONE);
-}
-

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -347,6 +347,27 @@ component V3Eval {
 	def I8X16_NEG(a: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x16((0, 0), a, u8.-);
 	}
+	def I8X16_MIN_S(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x16(a, b, V128_I8_MIN_S);
+	}
+	def I8X16_MIN_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x16(a, b, I8_MIN_U);
+	}
+	def I8X16_MAX_S(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x16(a, b, V128_I8_MAX_S);
+	}
+	def I8X16_MAX_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x16(a, b, I8_MAX_U);
+	}
+	def I8X16_AVGR_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x16(a, b, I8_AVGR_U);
+	}
+	def I8X16_ABS(a: (u64, u64)) -> (u64, u64) {
+		return do_v_v_x16(a, V128_I8_ABS);
+	}
+	def I8X16_POPCNT(a: (u64, u64)) -> (u64, u64) {
+		return do_v_v_x16(a, I8_POPCNT);
+	}
 	def F32X4_ADD(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x4(a, b, F32_ADD_U);
 	}
@@ -470,6 +491,24 @@ def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Ada
 def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
 	return u64.view(f(double.view(a)));
 }
+def i8_s_binop(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
+	return u8.view(f(i8.view(a), i8.view(b)));
+}
+def i8_s_unop(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
+	return u8.view(f(i8.view(a)));
+}
+def float_binop(a: u32, b: u32, f: (float, float) -> float) -> u32 {  // Adapts a floating point binop to a u32 binop
+	return u32.view(f(float.view(a), float.view(b)));
+}
+def float_unop(a: u32, f: float -> float) -> u32 {  // Adapts a floating point unop to a u32 unop
+	return u32.view(f(float.view(a)));
+}
+def double_binop(a: u64, b: u64, f: (double, double) -> double) -> u64 {  // Adapts a floating point binop to a u64 binop
+	return u64.view(f(double.view(a), double.view(b)));
+}
+def double_unop(a: u64, f: double -> double) -> u64 {  // Adapts a floating point unop to a u64 unop
+	return u64.view(f(double.view(a)));
+}
 def do_v_v_x2(a: (u64, u64), f: (u64) -> u64) -> (u64, u64) { // Performs a 2-lane unop
 	var r0 = f(a.0);
 	var r1 = f(a.1);
@@ -546,3 +585,4 @@ def truncF64<T>(min: double, max: double, trunc: double -> T, a: double) -> (T, 
 	if (!(a == a)) return (d, TrapReason.FLOAT_UNREPRESENTABLE);
 	return (trunc(a), TrapReason.NONE);
 }
+

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -314,6 +314,9 @@ component V3Eval {
 	def I64X2_NEG(a: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x2((0, 0), a, u64.-);
 	}
+	def I64X2_ABS(a: (u64, u64)) -> (u64, u64) {
+		return do_v_v_x2(a, V128_I64_ABS);
+	}
 	def I32X4_ADD(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x4(a, b, u32.+);
 	}
@@ -448,6 +451,7 @@ component V3Eval {
 	private def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
 	private def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
 	private def V128_I32_ABS = i32_s_unop(_, I32_ABS_S);
+	private def V128_I64_ABS = i64_s_unop(_, I64_ABS_S);
 
 	private def I8_MIN_S(a: i8, b: i8) -> i8 {
 		if (a <= b) return a;
@@ -516,6 +520,10 @@ component V3Eval {
 		else return a;
 	}
 	private def I32_ABS_S(a: i32) -> i32 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	private def I64_ABS_S(a: i64) -> i64 {
 		if (a < 0) return -a;
 		else return a;
 	}

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -326,6 +326,21 @@ component V3Eval {
 	def I32X4_NEG(a: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x4((0, 0), a, u32.-);
 	}
+	def I32X4_MIN_S(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x4(a, b, V128_I32_MIN_S);
+	}
+	def I32X4_MIN_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x4(a, b, I32_MIN_U);
+	}
+	def I32X4_MAX_S(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x4(a, b, V128_I32_MAX_S);
+	}
+	def I32X4_MAX_U(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
+		return do_vv_v_x4(a, b, I32_MAX_U);
+	}
+	def I32X4_ABS(a: (u64, u64)) -> (u64, u64) {
+		return do_v_v_x4(a, V128_I32_ABS);
+	}
 	def I16X8_ADD(a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
 		return do_vv_v_x8(a, b, u16.+);
 	}
@@ -426,16 +441,23 @@ component V3Eval {
 	// ---- v128 arithmetic helpers ----------------------------------------
 	private def V128_I8_MIN_S = i8_s_binop(_, _, I8_MIN_S);
 	private def V128_I16_MIN_S = i16_s_binop(_, _, I16_MIN_S);
+	private def V128_I32_MIN_S = i32_s_binop(_, _, I32_MIN_S);
 	private def V128_I8_MAX_S = i8_s_binop(_, _, I8_MAX_S);
 	private def V128_I16_MAX_S = i16_s_binop(_, _, I16_MAX_S);
+	private def V128_I32_MAX_S = i32_s_binop(_, _, I32_MAX_S);
 	private def V128_I8_ABS = i8_s_unop(_, I8_ABS_S);
 	private def V128_I16_ABS = i16_s_unop(_, I16_ABS_S);
-	
+	private def V128_I32_ABS = i32_s_unop(_, I32_ABS_S);
+
 	private def I8_MIN_S(a: i8, b: i8) -> i8 {
 		if (a <= b) return a;
 		else return b;
 	}
 	private def I16_MIN_S(a: i16, b: i16) -> i16 {
+		if (a <= b) return a;
+		else return b;
+	}
+	private def I32_MIN_S(a: i32, b: i32) -> i32 {
 		if (a <= b) return a;
 		else return b;
 	}
@@ -447,6 +469,10 @@ component V3Eval {
 		if (a >= b) return a;
 		else return b;
 	}
+	private def I32_MAX_S(a: i32, b: i32) -> i32 {
+		if (a >= b) return a;
+		else return b;
+	}
 	private def I8_MIN_U(a: u8, b: u8) -> u8 {
 		if (a <= b) return a;
 		else return b;
@@ -455,11 +481,19 @@ component V3Eval {
 		if (a <= b) return a;
 		else return b;
 	}
+	private def I32_MIN_U(a: u32, b: u32) -> u32 {
+		if (a <= b) return a;
+		else return b;
+	}
 	private def I8_MAX_U(a: u8, b: u8) -> u8 {
 		if (a >= b) return a;
 		else return b;
 	}
 	private def I16_MAX_U(a: u16, b: u16) -> u16 {
+		if (a >= b) return a;
+		else return b;
+	}
+	private def I32_MAX_U(a: u32, b: u32) -> u32 {
 		if (a >= b) return a;
 		else return b;
 	}
@@ -478,6 +512,10 @@ component V3Eval {
 		else return a;
 	}
 	private def I16_ABS_S(a: i16) -> i16 {
+		if (a < 0) return -a;
+		else return a;
+	}
+	private def I32_ABS_S(a: i32) -> i32 {
 		if (a < 0) return -a;
 		else return a;
 	}

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -941,6 +941,13 @@ component V3Interpreter {
 			I8X16_ADD => do_vv_v(V3Eval.I8X16_ADD);
 			I8X16_SUB => do_vv_v(V3Eval.I8X16_SUB);
 			I8X16_NEG => do_v_v(V3Eval.I8X16_NEG);
+			I8X16_MIN_S => do_vv_v(V3Eval.I8X16_MIN_S);
+			I8X16_MIN_U => do_vv_v(V3Eval.I8X16_MIN_U);
+			I8X16_MAX_S => do_vv_v(V3Eval.I8X16_MAX_S);
+			I8X16_MAX_U => do_vv_v(V3Eval.I8X16_MAX_U);
+			I8X16_AVGR_U => do_vv_v(V3Eval.I8X16_AVGR_U);
+			I8X16_ABS => do_v_v(V3Eval.I8X16_ABS);
+			I8X16_POPCNT => do_v_v(V3Eval.I8X16_POPCNT);
 			F32X4_ADD => do_vv_v(V3Eval.F32X4_ADD);
 			F32X4_SUB => do_vv_v(V3Eval.F32X4_SUB);
 			F32X4_MUL => do_vv_v(V3Eval.F32X4_MUL);

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -930,6 +930,7 @@ component V3Interpreter {
 			I64X2_SUB => do_vv_v(V3Eval.I64X2_SUB);
 			I64X2_MUL => do_vv_v(V3Eval.I64X2_MUL);
 			I64X2_NEG => do_v_v(V3Eval.I64X2_NEG);
+			I64X2_ABS => do_v_v(V3Eval.I64X2_ABS);
 			I32X4_ADD => do_vv_v(V3Eval.I32X4_ADD);
 			I32X4_SUB => do_vv_v(V3Eval.I32X4_SUB);
 			I32X4_MUL => do_vv_v(V3Eval.I32X4_MUL);

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -938,6 +938,12 @@ component V3Interpreter {
 			I16X8_SUB => do_vv_v(V3Eval.I16X8_SUB);
 			I16X8_MUL => do_vv_v(V3Eval.I16X8_MUL);
 			I16X8_NEG => do_v_v(V3Eval.I16X8_NEG);
+			I16X8_MIN_S => do_vv_v(V3Eval.I16X8_MIN_S);
+			I16X8_MIN_U => do_vv_v(V3Eval.I16X8_MIN_U);
+			I16X8_MAX_S => do_vv_v(V3Eval.I16X8_MAX_S);
+			I16X8_MAX_U => do_vv_v(V3Eval.I16X8_MAX_U);
+			I16X8_AVGR_U => do_vv_v(V3Eval.I16X8_AVGR_U);
+			I16X8_ABS => do_v_v(V3Eval.I16X8_ABS);
 			I8X16_ADD => do_vv_v(V3Eval.I8X16_ADD);
 			I8X16_SUB => do_vv_v(V3Eval.I8X16_SUB);
 			I8X16_NEG => do_v_v(V3Eval.I8X16_NEG);

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -934,6 +934,11 @@ component V3Interpreter {
 			I32X4_SUB => do_vv_v(V3Eval.I32X4_SUB);
 			I32X4_MUL => do_vv_v(V3Eval.I32X4_MUL);
 			I32X4_NEG => do_v_v(V3Eval.I32X4_NEG);
+			I32X4_MIN_S => do_vv_v(V3Eval.I32X4_MIN_S);
+			I32X4_MIN_U => do_vv_v(V3Eval.I32X4_MIN_U);
+			I32X4_MAX_S => do_vv_v(V3Eval.I32X4_MAX_S);
+			I32X4_MAX_U => do_vv_v(V3Eval.I32X4_MAX_U);
+			I32X4_ABS => do_v_v(V3Eval.I32X4_ABS);
 			I16X8_ADD => do_vv_v(V3Eval.I16X8_ADD);
 			I16X8_SUB => do_vv_v(V3Eval.I16X8_SUB);
 			I16X8_MUL => do_vv_v(V3Eval.I16X8_MUL);


### PR DESCRIPTION
Tested by:
```
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_i64x2_arith2.bin.wast
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_i32x4_arith2.bin.wast
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_i16x8_arith2.bin.wast
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_i8x16_arith2.bin.wast
```