### PR TITLE
Refactor memory to use Range<byte>

### DIFF
--- a/src/engine/Memory.v3
+++ b/src/engine/Memory.v3
@@ -2,33 +2,99 @@
 // See LICENSE for details of Apache 2.0 license.
 
 // An instantiated Wasm memory.
+def OOB_RANGE = MaybeTrap<Range<byte>>(null, TrapReason.MEM_OUT_OF_BOUNDS);
 class Memory(decl: MemoryDecl) extends Exportable {
+	private var data: Range<byte>;
 	var oom = false;  // set if allocation fails due to out-of-memory
-	def size() -> u32; // size in pages
-	def length() -> u64; // length in bytes
-	def deallocate() {
-		// default: do nothing
+
+	def size() -> u32 {
+		return u32.!(length() >> 16);
 	}
-	def grow(pages: u32) -> int {
-		return -1; // default: growing always fails
+	def length() -> u64 {
+		return u64.!(data.length);
 	}
-	def read1(offset: u32, index: u32) -> (TrapReason, u8);
-	def read1w(address: u64) -> (TrapReason, u8);
-	def read_u16(offset: u32, index: u32) -> (TrapReason, u16);
-	def read_u32(offset: u32, index: u32) -> (TrapReason, u32);
-	def read_u64(offset: u32, index: u32) -> (TrapReason, u64);
-	def read_u128(offset: u32, index: u32) -> (TrapReason, (u64, u64));
-	def write_u8(offset: u32, index: u32, val: u8) -> TrapReason;
-	def write_u16(offset: u32, index: u32, val: u16) -> TrapReason;
-	def write_u32(offset: u32, index: u32, val: u32) -> TrapReason;
-	def write_u64(offset: u32, index: u32, val: u64) -> TrapReason;
-	def write_u128(offset: u32, index: u32, val: (u64, u64)) -> TrapReason;
-	def extract(offset: u32, len: u32) -> Array<byte>;
-	def copyIn(dst_offset: u32, src: Array<byte>, src_offset: u32, size: u32) -> TrapReason;
-	def readIn(fd: int, dst_offset: u32, size: u32) -> int;
-	def writeOut(fd: int, src_offset: u32, size: u32) -> int;
-	def fill(dest: u32, val: u8, size: u32) -> TrapReason;
-	def copyM(dst_offset: u32, src: Memory, src_offset: u32, size: u32) -> TrapReason;
+
+	// Get a range of memory from [offset ..+ size], if possible (32-bit)
+	def range_ol_32(index: u32, size: u32) -> MaybeTrap<Range<byte>> {
+		var pos = u64.!(index);
+		var end = pos + u64.!(size);
+		if (end > u64.view(data.length)) return OOB_RANGE;
+		return MaybeTrap(data[pos ..+ size], TrapReason.NONE);
+	}
+	// Get a range of memory from [offset ..+ size], if possible (64-bit)
+	def range_ol_64(offset: u64, size: u64) -> MaybeTrap<Range<byte>> {
+		if (size == 0) return MaybeTrap<Range<byte>>(null, TrapReason.NONE);
+		if (offset >= data.length) return OOB_RANGE;
+		if (size >= data.length) return OOB_RANGE;
+		var pos = u64.!(offset);
+		var end = pos + u64.!(size);
+		if (end > u64.view(data.length)) return OOB_RANGE;
+		return MaybeTrap(data[pos ..+ size], TrapReason.NONE);
+	}
+	// Get a range of memory from [(offset + index) ..+ size], if possible (32-bit)
+	def range_oil_32(offset: u32, index: u32, size: u32) -> MaybeTrap<Range<byte>> {
+		var pos = u64.!(offset) + u64.!(index);
+		var end = pos + u64.!(size);
+		if (end > u64.view(data.length)) return OOB_RANGE;
+		return MaybeTrap(data[pos ..+ size], TrapReason.NONE);
+	}
+	// Get a range of memory from [(offset + index) ..+ size], if possible (64-bit)
+	def range_oil_64(offset: u64, index: u64, size: u64) -> MaybeTrap<Range<byte>> {
+		if (size == 0) return MaybeTrap<Range<byte>>(null, TrapReason.NONE);
+		if (offset >= data.length) return OOB_RANGE;
+		if (index >= data.length) return OOB_RANGE;
+		if (size >= data.length) return OOB_RANGE;
+		var pos = offset + index;
+		var end = pos + u64.!(size);
+		if (end > u64.view(data.length)) return OOB_RANGE;
+		return MaybeTrap(data[pos ..+ size], TrapReason.NONE);
+	}
+
+	// Fill in the range [dest ..+ size] with {val}.
+	def fill(dest: u32, val: u8, size: u32) -> TrapReason {
+		var r = range_ol_32(dest, size);
+		if (!r.ok()) return r.reason;
+		for (i < size) r.result[i] = val; // XXX: use word copy
+		return TrapReason.NONE;
+	}
+	// Memory copy.
+	def copyM(dst_offset: u32, src: Memory, src_offset: u32, size: u32) -> TrapReason {
+		var dst = this.range_ol_32(dst_offset, size);
+		if (!dst.ok()) return dst.reason;
+		var src = src.range_ol_32(src_offset, size);
+		if (!src.ok()) return src.reason;
+		if (src_offset > dst_offset) for (i < size) dst.result[i] = src.result[i]; // forwards copy
+		else for (i = size - 1; i < size; i--) dst.result[i] = src.result[i]; // backwards copy
+		return TrapReason.NONE;
+	}
+	def copyIn(dst_offset: u32, src: Array<byte>, src_offset: u32, size: u32) -> TrapReason {
+		var dst = this.range_ol_32(dst_offset, size);
+		if (!dst.ok()) return dst.reason;
+		var j = ArrayUtil.boundsCheck(src, src_offset, 0, size);
+		if (j < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
+		var src_range = src[src_offset ..+ size];
+		for (i < size) dst.result[i] = src_range[i]; // forwards copy
+		return TrapReason.NONE;
+	}
+	def readIn(fd: int, dst_offset: u32, size: u32) -> int {
+		var dst = range_ol_32(dst_offset, size);
+		if (!dst.ok()) return -1;
+		return System.read(fd, dst.result);
+	}
+	def writeOut(fd: int, src_offset: u32, size: u32) -> int {
+		var src = range_ol_32(src_offset, size);
+		if (!src.ok()) return -1;
+		System.write(fd, src.result);
+		return int.!(size);
+	}
+	def extract(src_offset: u32, size: u32) -> Array<byte> {
+		var src = range_ol_32(src_offset, size);
+		if (!src.ok()) return null;
+		var result = Array<byte>.new(src.result.length);
+		for (i < result.length) result[i] = src.result[i];
+		return result;
+	}
+
 	def boundsCheck(offset: u32, index: u32, len: u32) -> i64 {
 		var i = i64.view(offset) + index;
 		if ((i + len) > length()) return -1;
@@ -38,9 +104,71 @@ class Memory(decl: MemoryDecl) extends Exportable {
 		def OUT = Trace.OUT;
 		OUT.put1("@%d[", offset);
 		for (i < size) {
-			OUT.putx_8(read1(offset, i).1);
+			OUT.putx_8(read_u8(offset, i).result);
 		}
 		OUT.puts("]").outln();
 	}
-}
+	// NOTE: only used by subclasses to get/set the {data} field, other code should not use directly.
+	def platform_specific_getData() -> Range<byte> {
+		return this.data;
+	}
+	def platform_specific_setData(ndata: Range<byte>) {
+		this.data = ndata;
+	}
 
+	// =============================================================================
+	// Utility methods for reading individual scalar values
+	def read_u8(offset: u32, index: u32) -> MaybeTrap<u8> {
+		return range_oil_32(offset, index, 1).then(DataReaders.read_range_u8);
+	}
+	def read_u16(offset: u32, index: u32) -> MaybeTrap<u16> {
+		return range_oil_32(offset, index, 2).then(DataReaders.read_range_u16);
+	}
+	def read_u32(offset: u32, index: u32) -> MaybeTrap<u32> {
+		return range_oil_32(offset, index, 4).then(DataReaders.read_range_u32);
+	}
+	def read_u64(offset: u32, index: u32) -> MaybeTrap<u64> {
+		return range_oil_32(offset, index, 8).then(DataReaders.read_range_u64);
+	}
+	def read_float(offset: u32, index: u32) -> MaybeTrap<float> {
+		return range_oil_32(offset, index, 4).then(DataReaders.read_range_float);
+	}
+	def read_double(offset: u32, index: u32) -> MaybeTrap<double> {
+		return range_oil_32(offset, index, 8).then(DataReaders.read_range_double);
+	}
+	def read_u128(offset: u32, index: u32) -> MaybeTrap<(u64, u64)> {
+		return range_oil_32(offset, index, 16).then(DataReaders.read_range_u128);
+	}
+
+	// =============================================================================
+	// Utility methods for writing individual scalar values
+	def write_u8(offset: u32, index: u32, val: u8) -> TrapReason {
+		return range_oil_32(offset, index, 1).thenP(DataWriters.write_range_u8, val).reason;
+	}
+	def write_u16(offset: u32, index: u32, val: u16) -> TrapReason {
+		return range_oil_32(offset, index, 2).thenP(DataWriters.write_range_u16, val).reason;
+	}
+	def write_u32(offset: u32, index: u32, val: u32) -> TrapReason {
+		return range_oil_32(offset, index, 4).thenP(DataWriters.write_range_u32, val).reason;
+	}
+	def write_u64(offset: u32, index: u32, val: u64) -> TrapReason {
+		return range_oil_32(offset, index, 8).thenP(DataWriters.write_range_u64, val).reason;
+	}
+	def write_float(offset: u32, index: u32, val: float) -> TrapReason {
+		return range_oil_32(offset, index, 4).thenP(DataWriters.write_range_float, val).reason;
+	}
+	def write_double(offset: u32, index: u32, val: double) -> TrapReason {
+		return range_oil_32(offset, index, 8).thenP(DataWriters.write_range_double, val).reason;
+	}
+	def write_u128(offset: u32, index: u32, val: (u64, u64)) -> TrapReason {
+		return range_oil_32(offset, index, 16).thenP(DataWriters.write_range_u128, val).reason;
+	}
+
+	// =============================================================================
+	// Target-specific implementation
+	def deallocate() { }				// default: do nothing
+	def grow(pages: u32) -> int {
+		return -1; // default: growing always fails
+	}
+
+}

--- a/src/engine/Trap.v3
+++ b/src/engine/Trap.v3
@@ -27,6 +27,26 @@ enum TrapReason {
 	ERROR
 }
 
+// An unboxed result type representing a <T> or a trap. XXX: use an ADT?
+type MaybeTrap<T>(result: T, reason: TrapReason) #unboxed {
+	// Check if this represents a trap.
+	def ok() -> bool { return reason == TrapReason.NONE; }
+	// If this result doesn't represent a trap, call {f} and wrap that also in a {MaybeTrap<R>}.
+	def then<R>(f: T -> R) -> MaybeTrap<R> {
+		return MaybeTrap<R>(if(reason == TrapReason.NONE, f(result)), reason);
+	}
+	// If this result doesn't represent a trap, call {f} and wrap that also in a {MaybeTrap<R>}.
+	def thenP<P, R>(f: (T, P) -> R, p: P) -> MaybeTrap<R> {
+		return MaybeTrap<R>(if(reason == TrapReason.NONE, f(result, p)), reason);
+	}
+	// If this result represents a trap, call {f} and return {true}. Otherwise return {false}.
+	def trap<R>(f: TrapReason -> R) -> bool {
+		if (reason == TrapReason.NONE) return false;
+		f(reason);
+		return true;
+	}
+}
+
 component Traps {
 	def result(reason: TrapReason) -> Result.Throw {
 		return Result.Throw(Trap.new(reason, null, null));

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -327,29 +327,29 @@ component V3Interpreter {
 				}
 			}
 
-			I32_LOAD => doLoad(do_i32_load);
-			I64_LOAD => doLoad(do_i64_load);
-			F32_LOAD => doLoad(do_f32_load);
-			F64_LOAD => doLoad(do_f64_load);
-			I32_LOAD8_S => doLoad(do_i32_load8_s);
-			I32_LOAD8_U => doLoad(do_i32_load8_u);
-			I32_LOAD16_S => doLoad(do_i32_load16_s);
-			I32_LOAD16_U => doLoad(do_i32_load16_u);
-			I64_LOAD8_S => doLoad(do_i64_load8_s);
-			I64_LOAD8_U => doLoad(do_i64_load8_u);
-			I64_LOAD16_S => doLoad(do_i64_load16_s);
-			I64_LOAD16_U => doLoad(do_i64_load16_u);
-			I64_LOAD32_S => doLoad(do_i64_load32_s);
-			I64_LOAD32_U => doLoad(do_i64_load32_u);
-			I32_STORE => doStore(do_i32_store);
-			I64_STORE => doStore(do_i64_store);
-			F32_STORE => doStore(do_f32_store);
-			F64_STORE => doStore(do_f64_store);
-			I32_STORE8 => doStore(do_i32_store8);
-			I32_STORE16 => doStore(do_i32_store16);
-			I64_STORE8 => doStore(do_i64_store8);
-			I64_STORE16 => doStore(do_i64_store16);
-			I64_STORE32 => doStore(do_i64_store32);
+			I32_LOAD 	=> doLoad2(4, DataReaders.read_range_u32, Value.I32);
+			I64_LOAD 	=> doLoad2(8, DataReaders.read_range_u64, Value.I64);
+			F32_LOAD 	=> doLoad2(4, DataReaders.read_range_u32, Value.F32);
+			F64_LOAD 	=> doLoad2(8, DataReaders.read_range_u64, Value.F64);
+			I32_LOAD8_S	=> doLoad2(1, DataReaders.read_range_u32_i8, Value.I32);
+			I32_LOAD8_U	=> doLoad2(1, DataReaders.read_range_u32_u8, Value.I32);
+			I32_LOAD16_S	=> doLoad2(2, DataReaders.read_range_u32_i16, Value.I32);
+			I32_LOAD16_U	=> doLoad2(2, DataReaders.read_range_u32_u16, Value.I32);
+			I64_LOAD8_S	=> doLoad2(1, DataReaders.read_range_u64_i8, Value.I64);
+			I64_LOAD8_U	=> doLoad2(1, DataReaders.read_range_u64_u8, Value.I64);
+			I64_LOAD16_S	=> doLoad2(2, DataReaders.read_range_u64_i16, Value.I64);
+			I64_LOAD16_U	=> doLoad2(2, DataReaders.read_range_u64_u16, Value.I64);
+			I64_LOAD32_S	=> doLoad2(4, DataReaders.read_range_u64_i32, Value.I64);
+			I64_LOAD32_U	=> doLoad2(4, DataReaders.read_range_u64_u32, Value.I64);
+			I32_STORE	=> doStore(do_i32_store);
+			I64_STORE	=> doStore(do_i64_store);
+			F32_STORE	=> doStore(do_f32_store);
+			F64_STORE	=> doStore(do_f64_store);
+			I32_STORE8	=> doStore(do_i32_store8);
+			I32_STORE16	=> doStore(do_i32_store16);
+			I64_STORE8	=> doStore(do_i64_store8);
+			I64_STORE16	=> doStore(do_i64_store16);
+			I64_STORE32	=> doStore(do_i64_store32);
 
 			MEMORY_SIZE => {
 				var index = codeptr.read_uleb32();
@@ -962,15 +962,25 @@ component V3Interpreter {
 		}
 		if (frame != null) frame.pc = codeptr.pos;
 	}
-	def doLoad(load: (Memory, u32, u32) -> (TrapReason, Value)) {
+	def doLoad2<T>(size: byte, read: Range<byte> -> T, box: T -> Value) {
+		var memarg = codeptr.read_MemArg();
+		var memory = frame.func.instance.memories[memarg.memory_index];
+		var index = popm(memory);
+		if (!u32.?(index)) return trap(TrapReason.MEM_OUT_OF_BOUNDS);
+		if (!u32.?(memarg.offset)) return trap(TrapReason.MEM_OUT_OF_BOUNDS);
+		var t = memory.range_oil_32(u32.!(memarg.offset), u32.!(index), size);
+		if (t.reason != TrapReason.NONE) trap(t.reason);
+		else push(box(read(t.result)));
+	}
+	def doLoad(load: (Memory, u32, u32) -> MaybeTrap<Value>) {
 		var memarg = codeptr.read_MemArg();
 		var memory = frame.func.instance.memories[memarg.memory_index];
 		var index = popm(memory);
 		if (!u32.?(index)) return trap(TrapReason.MEM_OUT_OF_BOUNDS);
 		if (!u32.?(memarg.offset)) return trap(TrapReason.MEM_OUT_OF_BOUNDS);
 		var t = load(memory, u32.!(memarg.offset), u32.!(index));
-		if (t.0 != TrapReason.NONE) trap(t.0);
-		else push(t.1);
+		if (t.reason != TrapReason.NONE) trap(t.reason);
+		else push(t.result);
 	}
 	def doStore(store: (Memory, u32, u32, Value) -> TrapReason) {
 		// XXX: factor load/store logic for better polymorphic specialization
@@ -982,62 +992,6 @@ component V3Interpreter {
 		if (!u32.?(memarg.offset)) return trap(TrapReason.MEM_OUT_OF_BOUNDS);
 		var t = store(memory, u32.!(memarg.offset), u32.!(index), val);
 		if (t != TrapReason.NONE) trap(t);
-	}
-	def do_i32_load(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u32(offset, index);
-		return (t.0, Value.I32(t.1));
-	}
-	def do_i64_load(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u64(offset, index);
-		return (t.0, Value.I64(t.1));
-	}
-	def do_f32_load(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u32(offset, index);
-		return (t.0, Value.F32(t.1));
-	}
-	def do_f64_load(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u64(offset, index);
-		return (t.0, Value.F64(t.1));
-	}
-	def do_i32_load8_s(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read1(offset, index);
-		return (t.0, Value.I32(u32.view(i8.view(t.1))));
-	}
-	def do_i32_load8_u(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read1(offset, index);
-		return (t.0, Value.I32(t.1));
-	}
-	def do_i32_load16_s(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u16(offset, index);
-		return (t.0, Value.I32(u32.view(i16.view(t.1))));
-	}
-	def do_i32_load16_u(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u16(offset, index);
-		return (t.0, Value.I32(t.1));
-	}
-	def do_i64_load8_s(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read1(offset, index);
-		return (t.0, Value.I64(u64.view(i8.view(t.1))));
-	}
-	def do_i64_load8_u(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read1(offset, index);
-		return (t.0, Value.I64(t.1));
-	}
-	def do_i64_load16_s(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u16(offset, index);
-		return (t.0, Value.I64(u64.view(i16.view(t.1))));
-	}
-	def do_i64_load16_u(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u16(offset, index);
-		return (t.0, Value.I64(t.1));
-	}
-	def do_i64_load32_s(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u32(offset, index);
-		return (t.0, Value.I64(u64.view(i32.view(t.1))));
-	}
-	def do_i64_load32_u(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u32(offset, index);
-		return (t.0, Value.I64(t.1));
 	}
 	def do_i32_store(memory: Memory, offset: u32, index: u32, val: Value) -> TrapReason {
 		return memory.write_u32(offset, index, Value.I32.!(val).val);
@@ -1070,9 +1024,8 @@ component V3Interpreter {
 	def do_i64_store32(memory: Memory, offset: u32, index: u32, val: Value) -> TrapReason {
 		return memory.write_u32(offset, index, u32.view(Value.I64.!(val).val));
 	}
-	def do_v128_load(memory: Memory, offset: u32, index: u32) -> (TrapReason, Value) {
-		var t = memory.read_u128(offset, index);
-		return (t.0, Value.V128(t.1));
+	def do_v128_load(memory: Memory, offset: u32, index: u32) -> MaybeTrap<Value> {
+		return memory.read_u128(offset, index).then(Value.V128);
 	}
 	def doFallthru() {
 		frame.stp += 4;

--- a/src/engine/v3/V3Memory.v3
+++ b/src/engine/v3/V3Memory.v3
@@ -3,23 +3,16 @@
 
 // An instantiated Wasm memory implemented using a Virgil byte array.
 class V3Memory extends Memory {
-	var data: Array<byte>;
 	new(decl: MemoryDecl) super(decl) {
 		var bytes = u64.!(decl.initial) * PAGE_SIZE;
 		if (bytes > int.max || decl.initial > Target.limit_memory_pages) {
 			oom = true;
 		} else {
-			data = Array<byte>.new(int.!(bytes));
+			platform_specific_setData(Array<byte>.new(int.!(bytes)));
 		}
 	}
-	def size() -> u32 {
-		return if(data != null, u32.!(data.length) / PAGE_SIZE);
-	}
-	def length() -> u64 {
-		return if(data != null, u32.view(data.length));
-	}
 	def deallocate() {
-		data = null;
+		platform_specific_setData(null);
 	}
 	def grow(pages: u32) -> int {
 		var current = u64.!(size());
@@ -27,149 +20,11 @@ class V3Memory extends Memory {
 		var nsize = current + pages;
 		var limit = decl.maximum.min(Target.limit_memory_pages);
 		if (nsize > limit) return -1;
+		var data = platform_specific_getData();
 		var ndata = Array<byte>.new(int.!(nsize * PAGE_SIZE));
-		for (i < data.length) ndata[i] = data[i];
-		data = ndata;
+		for (i < data.length) ndata[i] = data[i]; // TODO: use word copy
+		platform_specific_setData(ndata);
 		return int.!(current);
-	}
-	def read1(offset: u32, index: u32) -> (TrapReason, u8) {
-		var i = boundsCheckI(offset, index, 1);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var val = data[i];
-		return (TrapReason.NONE, val);
-	}
-	def read1w(address: u64) -> (TrapReason, u8) {
-		if (address >= length()) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		return (TrapReason.NONE, data[address]);
-	}
-	def read_u16(offset: u32, index: u32) -> (TrapReason, u16) {
-		var i = boundsCheckI(offset, index, 2);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var b0 = data[i], b1 = data[i+1];
-		var val = u16.!(b1) << 8 | b0;
-		return (TrapReason.NONE, val);
-	}
-	def read_u32(offset: u32, index: u32) -> (TrapReason, u32) {
-		var i = boundsCheckI(offset, index, 4);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var b0 = data[i], b1 = data[i+1], b2 = data[i+2], b3 = data[i+3];
-		var val = (u32.!(b3) << 24) | (u32.!(b2) << 16) | (u32.!(b1) << 8) | b0;
-		return (TrapReason.NONE, val);
-	}
-	def read_u64(offset: u32, index: u32) -> (TrapReason, u64) {
-		var i = boundsCheckI(offset, index, 8);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		return (TrapReason.NONE, read8(i));
-	}
-	def read_u128(offset: u32, index: u32) -> (TrapReason, (u64, u64)) {
-		var i = boundsCheckI(offset, index, 16);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, (0, 0));
-		return (TrapReason.NONE, (read8(i), read8(i + 8)));
-	}
-	private def read8(i: int) -> u64 {
-		var b0 = data[i], b1 = data[i+1], b2 = data[i+2], b3 = data[i+3];
-		var w0 = (u32.!(b3) << 24) | (u32.!(b2) << 16) | (u32.!(b1) << 8) | b0;
-		var b4 = data[i+4], b5 = data[i+5], b6 = data[i+6], b7 = data[i+7];
-		var w1 = (u32.!(b7) << 24) | (u32.!(b6) << 16) | (u32.!(b5) << 8) | u32.!(b4);
-		return (u64.!(w1) << 32) | w0;
-	}
-	def write_u8(offset: u32, index: u32, val: u8) -> TrapReason {
-		var i = boundsCheckI(offset, index, 1);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		data[i] = val;
-		return TrapReason.NONE;
-	}
-	def write_u16(offset: u32, index: u32, val: u16) -> TrapReason {
-		var i = boundsCheckI(offset, index, 2);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		data[i] = u8.view(val);
-		data[i+1] = u8.view(val >> 8);
-		return TrapReason.NONE;
-	}
-	def write_u32(offset: u32, index: u32, val: u32) -> TrapReason {
-		var i = boundsCheckI(offset, index, 4);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		data[i] = u8.view(val);
-		data[i+1] = u8.view(val >> 8);
-		data[i+2] = u8.view(val >> 16);
-		data[i+3] = u8.view(val >> 24);
-		return TrapReason.NONE;
-	}
-	def write_u64(offset: u32, index: u32, val: u64) -> TrapReason {
-		var i = boundsCheckI(offset, index, 8);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		data[i] = u8.view(val);
-		data[i+1] = u8.view(val >> 8);
-		data[i+2] = u8.view(val >> 16);
-		data[i+3] = u8.view(val >> 24);
-		data[i+4] = u8.view(val >> 32);
-		data[i+5] = u8.view(val >> 40);
-		data[i+6] = u8.view(val >> 48);
-		data[i+7] = u8.view(val >> 56);
-		return TrapReason.NONE;
-	}
-	def write_u128(offset: u32, index: u32, val: (u64, u64)) -> TrapReason {
-		var i = boundsCheckI(offset, index, 16);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		data[i]    = u8.view(val.0);
-		data[i+1]  = u8.view(val.0 >> 8);
-		data[i+2]  = u8.view(val.0 >> 16);
-		data[i+3]  = u8.view(val.0 >> 24);
-		data[i+4]  = u8.view(val.0 >> 32);
-		data[i+5]  = u8.view(val.0 >> 40);
-		data[i+6]  = u8.view(val.0 >> 48);
-		data[i+7]  = u8.view(val.0 >> 56);
-		data[i+8]  = u8.view(val.1);
-		data[i+9]  = u8.view(val.1 >> 8);
-		data[i+10] = u8.view(val.1 >> 16);
-		data[i+11] = u8.view(val.1 >> 24);
-		data[i+12] = u8.view(val.1 >> 32);
-		data[i+13] = u8.view(val.1 >> 40);
-		data[i+14] = u8.view(val.1 >> 48);
-		data[i+15] = u8.view(val.1 >> 56);
-		return TrapReason.NONE;
-	}
-	def extract(offset: u32, len: u32) -> Array<byte> {
-		var i = boundsCheckI(0, offset, len);
-		if (i < 0) return null;
-		return Arrays.range(data, i, i + int.!(len));
-	}
-	def copyIn(dst_offset: u32, src: Array<byte>, src_offset: u32, size: u32) -> TrapReason {
-		var r = ArrayUtil.safeCopy(data, dst_offset, src, src_offset, size);
-		return if(r, TrapReason.NONE, TrapReason.MEM_OUT_OF_BOUNDS);
-	}
-	def readIn(fd: int, dst_offset: u32, size: u32) -> int {
-		var t = this.alias(dst_offset, size);
-		if (t.0 == null) return -1;
-		return System.fileReadK(fd, t.0, t.1, t.2);
-	}
-	def writeOut(fd: int, src_offset: u32, size: u32) -> int {
-		var t = this.alias(src_offset, size);
-		if (t.0 == null) return -1;
-		System.fileWriteK(fd, t.0, t.1, t.2);
-		return int.!(size);
-	}
-	def alias(offset: u32, len: u32) -> (Array<byte>, int, int) {
-		var i = boundsCheckI(0, offset, len);
-		if (i < 0) return (null, 0, 0);
-		return (data, i, int.!(len));
-	}
-	def boundsCheckI(offset: u32, index: u32, len: u32) -> i32 {
-		var i = i64.view(offset) + index;
-		if ((i + len) > length()) return -1;
-		return i32.view(i);
-	}
-	def fill(dest: u32, val: u8, size: u32) -> TrapReason {
-		var i = boundsCheckI(0, dest, size);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		for (j < int.!(size)) {
-			data[i + j] = val;
-		}
-		return TrapReason.NONE;
-	}
-	def copyM(dst_offset: u32, src: Memory, src_offset: u32, size: u32) -> TrapReason {
-		var r = ArrayUtil.safeCopy(data, dst_offset, V3Memory.!(src).data, src_offset, size);
-		return if(r, TrapReason.NONE, TrapReason.MEM_OUT_OF_BOUNDS);
 	}
 }
 def PAGE_SIZE = 65536u;

--- a/src/engine/x86-64/X86_64Memory.v3
+++ b/src/engine/x86-64/X86_64Memory.v3
@@ -24,6 +24,7 @@ class X86_64Memory extends Memory {
 			start = mapping.range.start;
 			end = mapping.range.end;
 			limit = start + long.view(bytes);
+			platform_specific_setData(CiRuntime.forgeRange<byte>(start, int.!(bytes)));
 			// adjust permissions on guard region pages
 			if (!Mmap.protect(start, bytes, Mmap.PROT_READ | Mmap.PROT_WRITE)) {
 				deallocate();
@@ -37,174 +38,28 @@ class X86_64Memory extends Memory {
 				.outln();
 		}
 	}
-	def size() -> u32 {
-		return u32.view((limit - start) >> PAGE_SHIFT);
-	}
-	def length() -> u64 {
-		return u64.view(limit - start);
-	}
 	def deallocate() {
 		mapping.range.unmap();
 		mapping = null;
 		start = limit = end = Pointer.NULL;
 	}
 	def grow(pages: u32) -> int {
-		var current = u64.!(size());
-		if (pages == 0) return int.!(current); // degenerate case
-		var nsize = current + pages;
-		if (nsize > decl.maximum.min(Target.limit_memory_pages)) return -1; // exceeded maximum
+		var cur_bytes = this.length();
+		var cur_pages = cur_bytes >> PAGE_SHIFT;
+		if (Trace.memory) {
+			Trace.OUT
+				.put3("grow memory [0x%x ..+ (%d pages)] by %d pages", start - Pointer.NULL, cur_pages, pages)
+				.outln();
+		}
+		if (pages == 0) return int.!(cur_pages); // degenerate case
+		var new_pages = cur_pages + pages;
+		if (new_pages > decl.maximum.min(Target.limit_memory_pages)) return -1; // exceeded maximum
 		// adjust permissions on guard region pages
-		var bytes = u64.view(pages) << PAGE_SHIFT;
-		if (!Mmap.protect(limit, bytes, Mmap.PROT_READ | Mmap.PROT_WRITE)) return -1;
-		limit += i64.view(bytes);
-		return int.!(current);
-	}
-	def read1(offset: u32, index: u32) -> (TrapReason, u8) {
-		var i = boundsCheck(offset, index, 1);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var val = (start + i).load<u8>();
-		return (TrapReason.NONE, val);
-	}
-	def read1w(address: u64) -> (TrapReason, u8) {
-		if (address >= length()) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var val = (start + i64.view(address)).load<u8>();
-		return (TrapReason.NONE, val);
-	}
-	def read_u16(offset: u32, index: u32) -> (TrapReason, u16) {
-		var i = boundsCheck(offset, index, 2);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var val = (start + i).load<u16>();
-		return (TrapReason.NONE, val);
-	}
-	def read_u32(offset: u32, index: u32) -> (TrapReason, u32) {
-		var i = boundsCheck(offset, index, 4);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var val = (start + i).load<u32>();
-		return (TrapReason.NONE, val);
-	}
-	def read_u64(offset: u32, index: u32) -> (TrapReason, u64) {
-		var i = boundsCheck(offset, index, 8);
-		if (i < 0) return (TrapReason.MEM_OUT_OF_BOUNDS, 0);
-		var val = (start + i).load<u64>();
-		return (TrapReason.NONE, val);
-	}
-	def write_u8(offset: u32, index: u32, val: u8) -> TrapReason {
-		var i = boundsCheck(offset, index, 8);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		(start + i).store<u8>(val);
-		return TrapReason.NONE;
-	}
-	def write_u16(offset: u32, index: u32, val: u16) -> TrapReason {
-		var i = boundsCheck(offset, index, 2);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		(start + i).store<u16>(val);
-		return TrapReason.NONE;
-	}
-	def write_u32(offset: u32, index: u32, val: u32) -> TrapReason {
-		var i = boundsCheck(offset, index, 4);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		(start + i).store<u32>(val);
-		return TrapReason.NONE;
-	}
-	def write_u64(offset: u32, index: u32, val: u64) -> TrapReason {
-		var i = boundsCheck(offset, index, 8);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		(start + i).store<u64>(val);
-		return TrapReason.NONE;
-	}
-	def extract(offset: u32, len: u32) -> Array<byte> {
-		var i = boundsCheck(0, offset, len);
-		if (i < 0) return null;
-		var r = Array<byte>.new(int.view(len));
-		for (j < len) r[j] = (start + i + j).load<u8>(); // XXX: word-by-word copy
-		return r;
-	}
-	def copyIn(dst_offset: u32, src: Array<byte>, src_offset: u32, size: u32) -> TrapReason {
-		var i = boundsCheck(0, dst_offset, size);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		var j = ArrayUtil.boundsCheck(src, src_offset, 0, size);
-		if (j < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		for (k < size) {
-			(start + i + k).store<u8>(src[u32.view(j) + k]);
-		}
-		return TrapReason.NONE;
-	}
-	def readIn(fd: int, dst_offset: u32, size: u32) -> int {
-		var i = boundsCheck(0, dst_offset, size);
-		if (i < 0) return -1;
-		var r = Linux.syscall(LinuxConst.SYS_read, (fd, start + i, size));
-		return if(r.0 < 0, -1, int.!(r.0));
-	}
-	def writeOut(fd: int, src_offset: u32, size: u32) -> int {
-		var i = boundsCheck(0, src_offset, size);
-		if (i < 0) return -1;
-		var r = Linux.syscall(LinuxConst.SYS_write, (fd, start + i, size));
-		if (r.0 == 0) return int.!(r.1);
-		return int.!(r.0);
-	}
-	def fill(dest: u32, val: u8, size: u32) -> TrapReason {
-		var i = boundsCheck(0, dest, size);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		var p = start + i, e = p + size;
-		if (size >= 8) {
-			var val64: u64 = val;
-			val64 = (val64 << 8) | val64;
-			val64 = (val64 << 16) | val64;
-			val64 = (val64 << 32) | val64;
-			var ea = e + -(long.view(size) & 0x7);
-			while (p < ea) {
-				p.store<u64>(val64); // word-by-word fill
-				p += 8;
-			}
-		}
-		while (p < e) {
-			p.store<u8>(val); // byte-by-byte fill
-			p++;
-		}
-		return TrapReason.NONE;
-	}
-	def copyM(dst_offset: u32, src: Memory, src_offset: u32, size: u32) -> TrapReason {
-		if (src == null) return TrapReason.MEM_OUT_OF_BOUNDS;
-		var that = X86_64Memory.!(src);
-		var i = this.boundsCheck(0, dst_offset, size);
-		if (i < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		var j = that.boundsCheck(0, src_offset, size);
-		if (j < 0) return TrapReason.MEM_OUT_OF_BOUNDS;
-		if (this == that && i > j) { // potentially overlapping, copy in reverse
-			var s = this.start + i;
-			var p = this.start + (i + size - 1u);
-			var q = that.start + (j + size - 1u);
-			while (p >= s) {
-				p.store<u8>(q.load<u8>());
-				p += -1;
-				q += -1;
-			}
-		} else {
-			memcopy(this.start + i, that.start + j, size);
-		}
-		return TrapReason.NONE;
-	}
-	def range(ptr: u32, len: u32) -> (Pointer, Pointer) {
-		var offset = boundsCheck(0, ptr, len);
-		if (offset < 0) return (Pointer.NULL, Pointer.NULL);
-		var r = start + ptr;
-		return (r, r + len);
-	}
-	private def memcopy(p: Pointer, q: Pointer, size: u32) {
-		var end = p + size;
-		if (size >= 8 && u64.view(q - p) >= 8) {
-			var ea = end + -(long.view(size) & 0x7);
-			while (p < ea) {
-				p.store<u64>(q.load<u64>()); // word-by-word copy
-				p += 8;
-				q += 8;
-			}
-		}
-		while (p < end) {
-			p.store<u8>(q.load<u8>());
-			p++;
-			q++;
-		}
+		var add_bytes = u64.view(pages) << PAGE_SHIFT;
+		if (!Mmap.protect(limit, add_bytes, Mmap.PROT_READ | Mmap.PROT_WRITE)) return -1;
+		limit += i64.view(add_bytes);
+		platform_specific_setData(CiRuntime.forgeRange<byte>(start, int.!(cur_bytes + add_bytes)));
+		return int.!(cur_pages);
 	}
 }
 def PAGE_SIZE = 65536u;

--- a/src/modules/wasi/WspOneModule.v3
+++ b/src/modules/wasi/WspOneModule.v3
@@ -247,8 +247,8 @@ class WspOneModule extends HostModule("wasi_snapshot_preview1") {
 		
 		var total = 0;
 		for (j < iovs_len) {
-			var iov_ptr = memory.read_u32(0, u32.view(iovbuf)).1;
-			var iov_len = memory.read_u32(0, u32.view(iovbuf + 4)).1;
+			var iov_ptr = memory.read_u32(0, u32.view(iovbuf)).result;
+			var iov_len = memory.read_u32(0, u32.view(iovbuf + 4)).result;
 			var iobuf = getRegion2(memory, iov_ptr, iov_len);
 			if (iobuf < 0) return i(wasi_errno.INVAL.code); // Invalid memory
 			var out = memory.readIn(wfd.sysfd, u32.view(iobuf), iov_len);
@@ -279,8 +279,8 @@ class WspOneModule extends HostModule("wasi_snapshot_preview1") {
 
 		var total = 0;
 		for (j < iovs_len) {
-			var iov_ptr = memory.read_u32(0, u32.view(iovbuf)).1;
-			var iov_len = memory.read_u32(0, u32.view(iovbuf + 4)).1;
+			var iov_ptr = memory.read_u32(0, u32.view(iovbuf)).result;
+			var iov_len = memory.read_u32(0, u32.view(iovbuf + 4)).result;
 			var iobuf = getRegion2(memory, iov_ptr, iov_len);
 			if (iobuf < 0) return i(wasi_errno.INVAL.code); // Invalid memory
 			var out = memory.writeOut(wfd.sysfd, u32.view(iobuf), iov_len);

--- a/src/modules/wasi/x86-64-linux/WspOneModule-x86-64-linux.v3
+++ b/src/modules/wasi/x86-64-linux/WspOneModule-x86-64-linux.v3
@@ -43,9 +43,9 @@ class X86_64Linux_WspOneModule extends WspOneModule {
 
 	def random_get(args: Array<Value>) -> HostResult {
 		var ptr = Values.v_u(args[0]), len = Values.v_u(args[1]);
-		var range = getRegion3(ptr, len);
-		if (range.0 == Pointer.NULL) return HostResult.Throw(Trap.new(TrapReason.MEM_OUT_OF_BOUNDS, null, null));
-		var t = Linux.syscall(SYS_getrandom, (range.0, len, 0));
+		var range = memory.range_ol_32(ptr, len);
+		if (range.reason != TrapReason.NONE) return HostResult.Throw(Trap.new(range.reason, null, null));
+		var t = Linux.syscall(SYS_getrandom, (Pointer.atContents(range.result), len, 0));
 		if (t.0 < 0) return i(mapErrno(t.0));
 		return HostResult.Value1(Values.I32_0);
 	}
@@ -53,11 +53,11 @@ class X86_64Linux_WspOneModule extends WspOneModule {
 		var clock_id = mapClockId(Values.v_u(args[0]));
 		if (clock_id < 0) return HostResult.Value1(Values.i_v(wasi_errno.INVAL.code));
 		var ptr = Values.v_u(args[1]);
-		var range = getRegion3(ptr, 8);
-		if (range.0 == Pointer.NULL) return HostResult.Throw(Trap.new(TrapReason.MEM_OUT_OF_BOUNDS, null, null));
+		var range = memory.range_ol_32(ptr, 8);
+		if (range.reason != TrapReason.NONE) return HostResult.Throw(Trap.new(range.reason, null, null));
 		var t = Linux.syscall(SYS_clock_get_res, (clock_id, Pointer.atContents(timespec)));
 		if (t.0 < 0) return i(mapErrno(t.0));
-		range.0.store<i64>(timespec[0] * 1000000000L + timespec[1]);
+		DataWriters.write_range_i64(range.result, timespec[0] * 1000000000L + timespec[1]);
 		return HostResult.Value1(Values.I32_0);
 	}
 	def clock_time_get(args: Array<Value>) -> HostResult {
@@ -65,11 +65,11 @@ class X86_64Linux_WspOneModule extends WspOneModule {
 		if (clock_id < 0) return HostResult.Value1(Values.i_v(wasi_errno.INVAL.code));
 		var lag = Values.v_l(args[1]);
 		var ptr = Values.v_u(args[2]);
-		var range = getRegion3(ptr, 8);
-		if (range.0 == Pointer.NULL) return HostResult.Throw(Trap.new(TrapReason.MEM_OUT_OF_BOUNDS, null, null));
+		var range = memory.range_ol_32(ptr, 8);
+		if (range.reason != TrapReason.NONE) return HostResult.Throw(Trap.new(range.reason, null, null));
 		var t = Linux.syscall(SYS_clock_get_time, (clock_id, Pointer.atContents(timespec)));
 		if (t.0 < 0) return i(mapErrno(t.0));
-		range.0.store<i64>(timespec[0] * 1000000000L + timespec[1]);
+		DataWriters.write_range_i64(range.result, timespec[0] * 1000000000L + timespec[1]);
 		return HostResult.Value1(Values.I32_0);
 	}
 	def mapClockId(clock_id: u32) -> int {
@@ -78,9 +78,5 @@ class X86_64Linux_WspOneModule extends WspOneModule {
 	}
 	def mapErrno(errno: i64) -> int {
 		return int.!(errno);
-	}
-	def getRegion3(ptr: u32, len: u32) -> (Pointer, Pointer) {
-		if (!X86_64Memory.?(memory)) return (Pointer.NULL, Pointer.NULL);
-		return X86_64Memory.!(memory).range(ptr, len);
 	}
 }

--- a/src/monitors/MemoryMonitor.v3
+++ b/src/monitors/MemoryMonitor.v3
@@ -41,13 +41,13 @@ class MemoryMonitor extends Monitor {
 		    .putc(' ');
 		putMemIndexAndAddress(mem.decl.memory_index, address);
 		OUT.putc(' ').puts(Palette.DEFAULT);
-		for (i < size) {
-			var b = mem.read1w(address + i);
-			if (b.0 != TrapReason.NONE) {
+		for (i < u32.!(size)) { // TODO: memory64
+			var b = mem.read_u8(u32.!(address), i); // TODO: memory64
+			if (!b.ok()) {
 				OUT.putc('!');
 				break;
 			}
-			OUT.putx_8(b.1);
+			OUT.putx_8(b.result);
 		}
 		OUT.rjustify(' ', 8, 10)
 		    .outln();

--- a/src/util/Decoder.v3
+++ b/src/util/Decoder.v3
@@ -3,7 +3,9 @@
 
 // This classes marries the utility {DataWriter} with an {ErrorGen}.
 class Decoder extends DataReader {
-	new(data: Array<byte>, error: ErrorGen) super(data) {
+	def error: ErrorGen;
+
+	new(data: Array<byte>, error) super(data) {
 		onError = error.onDataReaderError;
 	}
 }

--- a/test/unittest/ExeTest.v3
+++ b/test/unittest/ExeTest.v3
@@ -1131,7 +1131,7 @@ class ExeTester(t: Tester, tiering: ExecutionStrategy) extends ModuleBuilder {
 		if (mem == null) return t.fail("memory is null");
 		for (i < expected.length) {
 			var addr = int.!(offset) + i;
-			var got = mem.read1(0, u32.view(addr)).1;
+			var got = mem.read_u8(0, u32.view(addr)).result;
 			if (expected[i] != got) return t.fail3("expected mem[%x] = %x, got %x", addr, expected[i], got);
 		}
 	}

--- a/test/unittest/MemoryTest.v3
+++ b/test/unittest/MemoryTest.v3
@@ -32,7 +32,7 @@ class MemoryTester(t: Tester) {
 		if (mem == null) return t.fail("memory is null");
 		for (i < expected.length) {
 			var addr = int.!(offset) + i;
-			var got = mem.read1(0, u32.view(addr)).1;
+			var got = mem.read_u8(0, u32.view(addr)).result;
 			if (expected[i] != got) return t.fail3("expected mem[%x] = %x, got %x", addr, expected[i], got);
 		}
 	}
@@ -42,9 +42,9 @@ class MemoryTester(t: Tester) {
 	def assert_ok(reason: TrapReason) {
 		if (reason != TrapReason.NONE) t.fail1("expected no trap, got %s", reason.name);
 	}
-	def assert_ok2<T>(tu: (TrapReason, T)) -> T {
-		if (tu.0 != TrapReason.NONE) t.fail1("expected no trap, got %s", tu.0.name);
-		return tu.1;
+	def assert_ok2<T>(tu: MaybeTrap<T>) -> T {
+		if (tu.reason != TrapReason.NONE) t.fail1("expected no trap, got %s", tu.reason.name);
+		return tu.result;
 	}
 	def deallocate() {
 		if (mem != null) mem.deallocate();
@@ -79,7 +79,7 @@ def test_access_u8(t: MemoryTester) {
 
 		t.mem.write_u8(0, i + 200, v1);
 		t.assert_mem(i + 200, d1);
-		t.t.asserteq(v1, t.mem.read1(5, i + 195).1);
+		t.t.asserteq(v1, t.mem.read_u8(5, i + 195).result);
 	}
 	t.deallocate();
 }
@@ -250,7 +250,7 @@ def test_grow1(t: MemoryTester) {
 		t.t.asserteq(size, m1.size());
 		for (j < size) {
 			t.assert_ok(m1.write_u8(0, j * PAGE_SIZE, v8));
-			t.t.asserteq(v8, t.assert_ok2(m1.read1(0, j * PAGE_SIZE)));
+			t.t.asserteq(v8, t.assert_ok2(m1.read_u8(0, j * PAGE_SIZE)));
 			v8++;
 		}
 		var r = m1.grow(1);

--- a/test/unittest/ModuleBuilder.v3
+++ b/test/unittest/ModuleBuilder.v3
@@ -79,22 +79,21 @@ class ModuleBuilder {
 	}
 	def code_op(opcode: Opcode) -> this {
 		sig(opcode.sig);
-		code(wrap_opcode(opcode));
+		code(wrap_opcode(opcode)); // XXX: can save a BinBuilder copy here
 	}
 	def wrap_opcode(opcode: Opcode) -> Array<byte> {
-		match (opcode.sig.params.length) {
-			0 => return if(opcode.prefix != 0,
-				[opcode.prefix, opcode.code],
-				[opcode.code]);
-			1 => return if(opcode.prefix != 0,
-				[Opcode.LOCAL_GET.code, 0, opcode.prefix, opcode.code],
-				[Opcode.LOCAL_GET.code, 0, opcode.code]);
-			2 => return if(opcode.prefix != 0,
-				[Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_GET.code, 1, opcode.prefix, opcode.code],
-				[Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_GET.code, 1, opcode.code]);
-			_ => System.error("InterpreterTester", "too many params to opcode");
+		var code = BinBuilder.new();
+		for (i < opcode.sig.params.length) {
+			code.put(Opcode.LOCAL_GET.code);
+			code.put(byte.view(i));
 		}
-		return null;
+		if (opcode.prefix != 0) {
+			code.put(opcode.prefix);
+			code.put_u32leb(opcode.code);
+		} else {
+			code.put(opcode.code);
+		}
+		return code.extract();
 	}
 	def validate() -> bool {
 		var v = CodeValidator.new(extensions,


### PR DESCRIPTION
This moves most of the memory functionality into the base class `Memory.v3` and makes use of the new off-heap `Range<byte>` feature to targets that use `mmap`ed memory to also use Ranges. That saves code and moves more into the safe core Virgil language. It also makes use of some new utility methods in Virgil's libraries to do multi-byte store/load using layouts underneath, which speeds up the `x86-linux` target anywhere from 2-7%.