### PR TITLE
[v3i/simd]: Implement min, max, abs instructions for f32 and f64

### DIFF
--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -385,6 +385,11 @@ component V3Eval {
 	def F32X4_LE = do_vv_v_x4(_, _, V128_F32X4_LE);
 	def F32X4_GT = commute_binop(F32X4_LT);
 	def F32X4_GE = commute_binop(F32X4_LE);
+	def F32X4_MIN = do_vv_v_x4(_, _, V128_F32X4_MIN);
+	def F32X4_MAX = do_vv_v_x4(_, _, V128_F32X4_MAX);
+	def F32X4_ABS = do_v_v_x4(_, V128_F32X4_ABS);
+	def F32X4_PMIN = do_vv_v_x4(_, _, V128_F32X4_PMIN);
+	def F32X4_PMAX = do_vv_v_x4(_, _, V128_F32X4_PMAX);
 	def F64X2_ADD = do_vv_v_x2(_, _, F64_ADD_U);
 	def F64X2_SUB = do_vv_v_x2(_, _, F64_SUB_U);
 	def F64X2_MUL = do_vv_v_x2(_, _, F64_MUL_U);
@@ -397,6 +402,11 @@ component V3Eval {
 	def F64X2_LE = do_vv_v_x2(_, _, V128_F64X2_LE);
 	def F64X2_GT = commute_binop(F64X2_LT);	
 	def F64X2_GE = commute_binop(F64X2_LE);
+	def F64X2_MIN = do_vv_v_x2(_, _, V128_F64X2_MIN);
+	def F64X2_MAX = do_vv_v_x2(_, _, V128_F64X2_MAX);
+	def F64X2_ABS = do_v_v_x2(_, V128_F64X2_ABS);
+	def F64X2_PMIN = do_vv_v_x2(_, _, V128_F64X2_PMIN);
+	def F64X2_PMAX = do_vv_v_x2(_, _, V128_F64X2_PMAX);
 
 	// ---- rounding and conversion ----------------------------------------
 	def I32_WRAP_I64	= u32.view<u64>;
@@ -515,10 +525,20 @@ def V128_F32X4_EQ = do_ff_z(_, _, float.==);
 def V128_F32X4_NE = do_ff_z(_, _, float.!=);
 def V128_F32X4_LT = do_ff_z(_, _, float.<);
 def V128_F32X4_LE = do_ff_z(_, _, float.<=);
+def V128_F32X4_MIN = do_ff_f(_, _, V3Eval.F32_MIN);
+def V128_F32X4_MAX = do_ff_f(_, _, V3Eval.F32_MAX);
+def V128_F32X4_ABS = do_f_f(_, float.abs);
+def V128_F32X4_PMIN = do_ff_f(_, _, F32X4_PMIN);
+def V128_F32X4_PMAX = do_ff_f(_, _, F32X4_PMAX);
 def V128_F64X2_EQ = do_dd_z(_, _, double.==);
 def V128_F64X2_NE = do_dd_z(_, _, double.!=);
 def V128_F64X2_LT = do_dd_z(_, _, double.<);
 def V128_F64X2_LE = do_dd_z(_, _, double.<=);
+def V128_F64X2_MIN = do_dd_d(_, _, V3Eval.F64_MIN);
+def V128_F64X2_MAX = do_dd_d(_, _, V3Eval.F64_MAX);
+def V128_F64X2_ABS = do_d_d(_, double.abs);
+def V128_F64X2_PMIN = do_dd_d(_, _, F64X2_PMIN);
+def V128_F64X2_PMAX = do_dd_d(_, _, F64X2_PMAX);
 
 def I8_MIN_S(a: i8, b: i8) -> i8 {
 	return if (a <= b, a, b);

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -650,6 +650,18 @@ def I16_Q15_MUL_SAT_S(a: i16, b: i16) -> i16 {
 	var prod = (i32.view(a) * i32.view(b) + 0x4000) >> 15;
 	return if(prod > i16.max, i16.max, i16.view(prod));	
 }
+def F32X4_PMIN(a: float, b: float) -> float {
+	return if (a > b,  b, a);
+}
+def F32X4_PMAX(a: float, b: float) -> float {
+	return if (a < b, b, a);
+}
+def F64X2_PMIN(a: double, b: double) -> double {
+	return if (a > b, b, a);
+}
+def F64X2_PMAX(a: double, b: double) -> double {
+	return if (a < b, b, a);
+}
 // Adapters
 def do_uu_z_8(a: u8, b: u8, f: (u8, u8) -> bool) -> u8 {  // Adapts a unsigned bool binop to a u8 binop
 	return if (f(a, b), u8.max, u8.view(0));

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1017,6 +1017,11 @@ component V3Interpreter {
 			F32X4_LE => do_vv_v(V3Eval.F32X4_LE);
 			F32X4_GT => do_vv_v(V3Eval.F32X4_GT);
 			F32X4_GE => do_vv_v(V3Eval.F32X4_GE);
+			F32X4_MIN => do_vv_v(V3Eval.F32X4_MIN);
+			F32X4_MAX => do_vv_v(V3Eval.F32X4_MAX);
+			F32X4_ABS => do_v_v(V3Eval.F32X4_ABS);
+			F32X4_PMIN => do_vv_v(V3Eval.F32X4_PMIN);
+			F32X4_PMAX => do_vv_v(V3Eval.F32X4_PMAX);
 			F64X2_ADD => do_vv_v(V3Eval.F64X2_ADD);
 			F64X2_SUB => do_vv_v(V3Eval.F64X2_SUB);
 			F64X2_MUL => do_vv_v(V3Eval.F64X2_MUL);
@@ -1029,6 +1034,11 @@ component V3Interpreter {
 			F64X2_LE => do_vv_v(V3Eval.F64X2_LE);
 			F64X2_GT => do_vv_v(V3Eval.F64X2_GT);
 			F64X2_GE => do_vv_v(V3Eval.F64X2_GE);
+			F64X2_MIN => do_vv_v(V3Eval.F64X2_MIN);
+			F64X2_MAX => do_vv_v(V3Eval.F64X2_MAX);
+			F64X2_ABS => do_v_v(V3Eval.F64X2_ABS);
+			F64X2_PMIN => do_vv_v(V3Eval.F64X2_PMIN);
+			F64X2_PMAX => do_vv_v(V3Eval.F64X2_PMAX);
 			INVALID => trap(TrapReason.INVALID_OPCODE);
 			CRASH_EXEC => System.error("WizengError", "crash-exec opcode executed");
 			CRASH_COMPILER => System.error("WizengError", "crash-compiler opcode executed");


### PR DESCRIPTION
Tested by:
```
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_f32x4.bin.wast
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_f32x4_pmin_pmax.bin.wast
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_f64x2.bin.wast
make v3i -j && bin/spectest.v3i -tk test/regress/simd/simd_f64x2_pmin_pmax.bin.wast
```