### PR TITLE
[v3i/simd]: Implement extended pairwise integer addition

### DIFF
--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -309,8 +309,8 @@ component V3Eval {
 	def I32X4_SUB = do_vv_v_x4(_, _, u32.-);
 	def I32X4_MUL = do_vv_v_x4(_, _, u32.*);
 	def I32X4_NEG = do_vv_v_x4((0, 0), _, u32.-);
-	def I32X4_EXTADDPAIRWISE_I16X8_S = do_v_v_x8_pairwis_ext_x4(_, V128_I32X4_EXTADD_16X8_S);
-	def I32X4_EXTADDPAIRWISE_I16X8_U = do_v_v_x8_pairwis_ext_x4(_, I32X4_EXTADD_I16X8_U);
+	def I32X4_EXTADDPAIRWISE_I16X8_S = do_v_v_x8_pairwise_ext_x4(_, V128_I32X4_EXTADD_16X8_S);
+	def I32X4_EXTADDPAIRWISE_I16X8_U = do_v_v_x8_pairwise_ext_x4(_, I32X4_EXTADD_I16X8_U);
 	def I32X4_MIN_S = do_vv_v_x4(_, _, V128_I32_MIN_S);
 	def I32X4_MIN_U = do_vv_v_x4(_, _, I32_MIN_U);
 	def I32X4_MAX_S = do_vv_v_x4(_, _, V128_I32_MAX_S);
@@ -331,8 +331,8 @@ component V3Eval {
 	def I16X8_MUL = do_vv_v_x8(_, _, u16.*);
 	def I16X8_Q15MULRSAT_S = do_vv_v_x8(_, _, V128_I16_Q15_MUL_SAT_S);
 	def I16X8_NEG = do_vv_v_x8((0, 0), _, u16.-);
-	def I16X8_EXTADDPAIRWISE_I8X16_S = do_v_v_x16_pairwis_ext_x8(_, V128_I16X8_EXTADD_I8X16_S);
-	def I16X8_EXTADDPAIRWISE_I8X16_U = do_v_v_x16_pairwis_ext_x8(_, I16X8_EXTADD_I8X16_U);
+	def I16X8_EXTADDPAIRWISE_I8X16_S = do_v_v_x16_pairwise_ext_x8(_, V128_I16X8_EXTADD_I8X16_S);
+	def I16X8_EXTADDPAIRWISE_I8X16_U = do_v_v_x16_pairwise_ext_x8(_, I16X8_EXTADD_I8X16_U);
 	def I16X8_ADD_SAT_S = do_vv_v_x8(_, _, V128_I16_ADD_SAT_S);
 	def I16X8_ADD_SAT_U = do_vv_v_x8(_, _, I16_ADD_SAT_U);
 	def I16X8_SUB_SAT_S = do_vv_v_x8(_, _, V128_I16_SUB_SAT_S);
@@ -897,7 +897,7 @@ convert: u64 -> T, extend: (T) -> Tw, convert_to_u: (Tw) -> Uw) -> u64 {
 	return res;
 }
 // Apply a binary operation to adjacent lanes and put the result into a wider lane
-def do_v_v_x16_pairwis_ext_x8(a: (u64, u64), f: (u8, u8) -> u16) -> (u64, u64) {
+def do_v_v_x16_pairwise_ext_x8(a: (u64, u64), f: (u8, u8) -> u16) -> (u64, u64) {
     var low: u64 = 0;
     var high: u64 = 0;
     
@@ -916,7 +916,7 @@ def do_v_v_x16_pairwis_ext_x8(a: (u64, u64), f: (u8, u8) -> u16) -> (u64, u64) {
 
     return (low, high);
 }
-def do_v_v_x8_pairwis_ext_x4(a: (u64, u64), f: (u16, u16) -> u32) -> (u64, u64) {
+def do_v_v_x8_pairwise_ext_x4(a: (u64, u64), f: (u16, u16) -> u32) -> (u64, u64) {
     var low: u64 = 0;
     var high: u64 = 0;
     

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -686,16 +686,16 @@ def I16_Q15_MUL_SAT_S(a: i16, b: i16) -> i16 {
 	return if(prod > i16.max, i16.max, i16.view(prod));	
 }
 def I16X8_EXTADD_I8X16_S(a: i8, b: i8) -> i16 {
-	return i16.view(a) + i16.view(b);
+	return i16.+(i16.view(a), i16.view(b));
 }
 def I16X8_EXTADD_I8X16_U(a: u8, b: u8) -> u16 {
-	return u16.view(a) + u16.view(b);
+	return u16.+(u16.view(a), u16.view(b));
 }
 def I32X4_EXTADD_I16X8_S(a: i16, b: i16) -> i32 {
-	return i32.view(a) + i32.view(b);
+	return i32.+(i32.view(a), i32.view(b));
 }
 def I32X4_EXTADD_I16X8_U(a: u16, b: u16) -> u32 {
-	return u32.view(a) + u32.view(b);
+	return u32.+(u32.view(a), u32.view(b));
 }
 def F32X4_PMIN(a: float, b: float) -> float {
 	return if (a > b,  b, a);
@@ -718,12 +718,6 @@ def do_uu_z_16(a: u16, b: u16, f: (u16, u16) -> bool) -> u16 {  // Adapts a unsi
 }
 def do_uu_z(a: u32, b: u32, f: (u32, u32) -> bool) -> u32 {  // Adapts a unsigned bool binop to a u32 binop
 	return if (f(a, b), u32.max, u32.view(0));
-}
-def do_uu_u_8_16(a: u8, b: u8, f: (u8, u8) -> u16) -> u16 {  // Adapts a signed i8 binop to a u8 binop
-	return u16.view(f(u8.view(a), u8.view(b)));
-}
-def do_uu_u_16_32(a: u16, b: u16, f: (u16, u16) -> u32) -> u32 {  // Adapts a signed i16 binop to a u16 binop
-	return u32.view(f(u16.view(a), u16.view(b)));
 }
 def do_ww_z(a: u64, b: u64, f: (u64, u64) -> bool) -> u64 {  // Adapts a unsigned bool binop to a u64 binop
 	return if (f(a, b), u64.max, u64.view(0));

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -685,18 +685,6 @@ def I16_Q15_MUL_SAT_S(a: i16, b: i16) -> i16 {
 	var prod = (i32.view(a) * i32.view(b) + 0x4000) >> 15;
 	return if(prod > i16.max, i16.max, i16.view(prod));	
 }
-def F32X4_PMIN(a: float, b: float) -> float {
-	return if (a > b,  b, a);
-}
-def F32X4_PMAX(a: float, b: float) -> float {
-	return if (a < b, b, a);
-}
-def F64X2_PMIN(a: double, b: double) -> double {
-	return if (a > b, b, a);
-}
-def F64X2_PMAX(a: double, b: double) -> double {
-	return if (a < b, b, a);
-}
 def I16X8_EXTADD_I8X16_S(a: i8, b: i8) -> i16 {
 	return i16.view(a) + i16.view(b);
 }
@@ -708,6 +696,18 @@ def I32X4_EXTADD_I16X8_S(a: i16, b: i16) -> i32 {
 }
 def I32X4_EXTADD_I16X8_U(a: u16, b: u16) -> u32 {
 	return u32.view(a) + u32.view(b);
+}
+def F32X4_PMIN(a: float, b: float) -> float {
+	return if (a > b,  b, a);
+}
+def F32X4_PMAX(a: float, b: float) -> float {
+	return if (a < b, b, a);
+}
+def F64X2_PMIN(a: double, b: double) -> double {
+	return if (a > b, b, a);
+}
+def F64X2_PMAX(a: double, b: double) -> double {
+	return if (a < b, b, a);
 }
 // Adapters
 def do_uu_z_8(a: u8, b: u8, f: (u8, u8) -> bool) -> u8 {  // Adapts a unsigned bool binop to a u8 binop
@@ -804,33 +804,29 @@ def do_v_v_x4(a: (u64, u64), f: (u32) -> u32) -> (u64, u64) { // Performs a 4-la
 def do_v_v_x8(a: (u64, u64), f: (u16) -> u16) -> (u64, u64) { // Performs an 8-lane unop
 	var low: u64 = 0;
 	var high: u64 = 0;
-
 	for (shift: byte = 0; shift < 64; shift += 16) {
-		var r_a = u16.view((a.0 >> shift) & 0xFFFF);
+		var r_a = u16.view(a.0 >> shift);
 		var res = f(r_a);
 		low |= (u64.view(res) << shift);
 		
-		r_a = u16.view((a.1 >> shift) & 0xFFFF);
+		r_a = u16.view(a.1 >> shift);
 		res = f(r_a);
 		high |= (u64.view(res) << shift);
 	}
-
 	return (low, high);
 }
 def do_v_v_x16(a: (u64, u64), f: (u8) -> u8) -> (u64, u64) { // Performs a 16-lane unop
 	var low: u64 = 0;
 	var high: u64 = 0;
-
 	for (shift: byte = 0; shift < 64; shift += 8) {
-		var r_a = u8.view((a.0 >> shift) & 0xFF);
+		var r_a = u8.view(a.0 >> shift);
 		var res = f(r_a);
 		low |= (u64.view(res) << shift);
 		
-		r_a = u8.view((a.1 >> shift) & 0xFF);
+		r_a = u8.view(a.1 >> shift);
 		res = f(r_a);
 		high |= (u64.view(res) << shift);
 	}
-
 	return (low, high);
 }
 // Binary v128 ops
@@ -850,13 +846,13 @@ def do_vv_v_x8(a: (u64, u64), b: (u64, u64), f: (u16, u16) -> u16) -> (u64, u64)
 	var low: u64 = 0;
 	var high: u64 = 0;
 		for (shift: byte = 0; shift < 64; shift += 16) {
-		var r_a = u16.view((a.0 >> shift) & 0xFFFF);
-		var r_b = u16.view((b.0 >> shift) & 0xFFFF);
+		var r_a = u16.view(a.0 >> shift);
+		var r_b = u16.view(b.0 >> shift);
 		var res = f(r_a, r_b);
 		low |= (u64.view(res) << shift);
 		
-		r_a = u16.view((a.1 >> shift) & 0xFFFF);
-		r_b = u16.view((b.1 >> shift) & 0xFFFF);
+		r_a = u16.view(a.1 >> shift);
+		r_b = u16.view(b.1 >> shift);
 		res = f(r_a, r_b);
 		high |= (u64.view(res) << shift);
 	}
@@ -866,13 +862,13 @@ def do_vv_v_x16(a: (u64, u64), b: (u64, u64), f: (u8, u8) -> u8) -> (u64, u64) {
 	var low: u64 = 0;
 	var high: u64 = 0;
 		for (shift: byte = 0; shift < 64; shift += 8) {
-		var r_a = u8.view((a.0 >> shift) & 0xFF);
-		var r_b = u8.view((b.0 >> shift) & 0xFF);
+		var r_a = u8.view(a.0 >> shift);
+		var r_b = u8.view(b.0 >> shift);
 		var res = f(r_a, r_b);
 		low |= (u64.view(res) << shift);
 		
-		r_a = u8.view((a.1 >> shift) & 0xFF);
-		r_b = u8.view((b.1 >> shift) & 0xFF);
+		r_a = u8.view(a.1 >> shift);
+		r_b = u8.view(b.1 >> shift);
 		res = f(r_a, r_b);
 		high |= (u64.view(res) << shift);
 	}
@@ -912,14 +908,14 @@ def do_v_v_x16_pairwis_ext_x8(a: (u64, u64), f: (u8, u8) -> u16) -> (u64, u64) {
     var high: u64 = 0;
     
     for (shift: byte = 0; shift < 64; shift += 16) {
-        var r_a1 = u8.view((a.0 >> shift) & 0xFF);
-        var r_a2 = u8.view((a.0 >> byte.view(shift + 8)) & 0xFF);
+        var r_a1 = u8.view(a.0 >> shift);
+        var r_a2 = u8.view(a.0 >> byte.view(shift + 8));
         var res = f(r_a1, r_a2);
         low |= (u64.view(res) << shift);
     }
     for (shift: byte = 0; shift < 64; shift += 16) {
-        var r_a1 = u8.view((a.1 >> shift) & 0xFF);
-        var r_a2 = u8.view((a.1 >> byte.view(shift + 8)) & 0xFF);
+        var r_a1 = u8.view(a.1 >> shift);
+        var r_a2 = u8.view(a.1 >> byte.view(shift + 8));
         var res = f(r_a1, r_a2);
         high |= (u64.view(res) << shift);
     }
@@ -931,14 +927,14 @@ def do_v_v_x8_pairwis_ext_x4(a: (u64, u64), f: (u16, u16) -> u32) -> (u64, u64) 
     var high: u64 = 0;
     
     for (shift: byte = 0; shift < 64; shift += 32) {
-        var r_a1 = u16.view((a.0 >> shift) & 0xFFFF);
-        var r_a2 = u16.view((a.0 >> byte.view(shift + 16)) & 0xFFFF);
+        var r_a1 = u16.view(a.0 >> shift);
+        var r_a2 = u16.view(a.0 >> byte.view(shift + 16));
         var res = f(r_a1, r_a2);
         low |= (u64.view(res) << shift);
     }
     for (shift: byte = 0; shift < 64; shift += 32) {
-        var r_a1 = u16.view((a.1 >> shift) & 0xFFFF);
-        var r_a2 = u16.view((a.1 >> byte.view(shift + 16)) & 0xFFFF);
+        var r_a1 = u16.view(a.1 >> shift);
+        var r_a2 = u16.view(a.1 >> byte.view(shift + 16));
         var res = f(r_a1, r_a2);
         high |= (u64.view(res) << shift);
     }

--- a/src/engine/V3Eval.v3
+++ b/src/engine/V3Eval.v3
@@ -309,6 +309,8 @@ component V3Eval {
 	def I32X4_SUB = do_vv_v_x4(_, _, u32.-);
 	def I32X4_MUL = do_vv_v_x4(_, _, u32.*);
 	def I32X4_NEG = do_vv_v_x4((0, 0), _, u32.-);
+	def I32X4_EXTADDPAIRWISE_I16X8_S = do_v_v_x8_pairwis_ext_x4(_, V128_I32X4_EXTADD_16X8_S);
+	def I32X4_EXTADDPAIRWISE_I16X8_U = do_v_v_x8_pairwis_ext_x4(_, I32X4_EXTADD_I16X8_U);
 	def I32X4_MIN_S = do_vv_v_x4(_, _, V128_I32_MIN_S);
 	def I32X4_MIN_U = do_vv_v_x4(_, _, I32_MIN_U);
 	def I32X4_MAX_S = do_vv_v_x4(_, _, V128_I32_MAX_S);
@@ -329,6 +331,8 @@ component V3Eval {
 	def I16X8_MUL = do_vv_v_x8(_, _, u16.*);
 	def I16X8_Q15MULRSAT_S = do_vv_v_x8(_, _, V128_I16_Q15_MUL_SAT_S);
 	def I16X8_NEG = do_vv_v_x8((0, 0), _, u16.-);
+	def I16X8_EXTADDPAIRWISE_I8X16_S = do_v_v_x16_pairwis_ext_x8(_, V128_I16X8_EXTADD_I8X16_S);
+	def I16X8_EXTADDPAIRWISE_I8X16_U = do_v_v_x16_pairwis_ext_x8(_, I16X8_EXTADD_I8X16_U);
 	def I16X8_ADD_SAT_S = do_vv_v_x8(_, _, V128_I16_ADD_SAT_S);
 	def I16X8_ADD_SAT_U = do_vv_v_x8(_, _, I16_ADD_SAT_U);
 	def I16X8_SUB_SAT_S = do_vv_v_x8(_, _, V128_I16_SUB_SAT_S);
@@ -568,6 +572,9 @@ def V128_F64X2_ABS = do_d_d(_, double.abs);
 def V128_F64X2_PMIN = do_dd_d(_, _, F64X2_PMIN);
 def V128_F64X2_PMAX = do_dd_d(_, _, F64X2_PMAX);
 
+def V128_I16X8_EXTADD_I8X16_S = do_ii_i_8_16(_, _, I16X8_EXTADD_I8X16_S);
+def V128_I32X4_EXTADD_16X8_S = do_ii_i_16_32(_, _, I32X4_EXTADD_I16X8_S);
+
 def I8_MIN_S(a: i8, b: i8) -> i8 {
 	return if (a <= b, a, b);
 }
@@ -690,6 +697,18 @@ def F64X2_PMIN(a: double, b: double) -> double {
 def F64X2_PMAX(a: double, b: double) -> double {
 	return if (a < b, b, a);
 }
+def I16X8_EXTADD_I8X16_S(a: i8, b: i8) -> i16 {
+	return i16.view(a) + i16.view(b);
+}
+def I16X8_EXTADD_I8X16_U(a: u8, b: u8) -> u16 {
+	return u16.view(a) + u16.view(b);
+}
+def I32X4_EXTADD_I16X8_S(a: i16, b: i16) -> i32 {
+	return i32.view(a) + i32.view(b);
+}
+def I32X4_EXTADD_I16X8_U(a: u16, b: u16) -> u32 {
+	return u32.view(a) + u32.view(b);
+}
 // Adapters
 def do_uu_z_8(a: u8, b: u8, f: (u8, u8) -> bool) -> u8 {  // Adapts a unsigned bool binop to a u8 binop
 	return if (f(a, b), u8.max, u8.view(0));
@@ -699,6 +718,12 @@ def do_uu_z_16(a: u16, b: u16, f: (u16, u16) -> bool) -> u16 {  // Adapts a unsi
 }
 def do_uu_z(a: u32, b: u32, f: (u32, u32) -> bool) -> u32 {  // Adapts a unsigned bool binop to a u32 binop
 	return if (f(a, b), u32.max, u32.view(0));
+}
+def do_uu_u_8_16(a: u8, b: u8, f: (u8, u8) -> u16) -> u16 {  // Adapts a signed i8 binop to a u8 binop
+	return u16.view(f(u8.view(a), u8.view(b)));
+}
+def do_uu_u_16_32(a: u16, b: u16, f: (u16, u16) -> u32) -> u32 {  // Adapts a signed i16 binop to a u16 binop
+	return u32.view(f(u16.view(a), u16.view(b)));
 }
 def do_ww_z(a: u64, b: u64, f: (u64, u64) -> bool) -> u64 {  // Adapts a unsigned bool binop to a u64 binop
 	return if (f(a, b), u64.max, u64.view(0));
@@ -735,6 +760,12 @@ def do_d_d(a: u64, f: double -> double) -> u64 {  // Adapts a floating point uno
 }
 def do_ii_i_8(a: u8, b: u8, f: (i8, i8) -> i8) -> u8 {  // Adapts a signed i8 binop to a u8 binop
 	return u8.view(f(i8.view(a), i8.view(b)));
+}
+def do_ii_i_8_16(a: u8, b: u8, f: (i8, i8) -> i16) -> u16 {
+	return u16.view(f(i8.view(a), i8.view(b)));
+}
+def do_ii_i_16_32(a: u16, b: u16, f: (i16, i16) -> i32) -> u32 {
+	return u32.view(f(i16.view(a), i16.view(b)));
 }
 def do_i_i_8(a: u8, f: i8 -> i8) -> u8 {  // Adapts a signed i8 unop to a u8 unop
 	return u8.view(f(i8.view(a)));
@@ -874,6 +905,45 @@ convert: u64 -> T, extend: (T) -> Tw, convert_to_u: (Tw) -> Uw) -> u64 {
 		res |= u64.!(convert_to_u(val)) << res_shift;
 	}
 	return res;
+}
+// Apply a binary operation to adjacent lanes and put the result into a wider lane
+def do_v_v_x16_pairwis_ext_x8(a: (u64, u64), f: (u8, u8) -> u16) -> (u64, u64) {
+    var low: u64 = 0;
+    var high: u64 = 0;
+    
+    for (shift: byte = 0; shift < 64; shift += 16) {
+        var r_a1 = u8.view((a.0 >> shift) & 0xFF);
+        var r_a2 = u8.view((a.0 >> byte.view(shift + 8)) & 0xFF);
+        var res = f(r_a1, r_a2);
+        low |= (u64.view(res) << shift);
+    }
+    for (shift: byte = 0; shift < 64; shift += 16) {
+        var r_a1 = u8.view((a.1 >> shift) & 0xFF);
+        var r_a2 = u8.view((a.1 >> byte.view(shift + 8)) & 0xFF);
+        var res = f(r_a1, r_a2);
+        high |= (u64.view(res) << shift);
+    }
+
+    return (low, high);
+}
+def do_v_v_x8_pairwis_ext_x4(a: (u64, u64), f: (u16, u16) -> u32) -> (u64, u64) {
+    var low: u64 = 0;
+    var high: u64 = 0;
+    
+    for (shift: byte = 0; shift < 64; shift += 32) {
+        var r_a1 = u16.view((a.0 >> shift) & 0xFFFF);
+        var r_a2 = u16.view((a.0 >> byte.view(shift + 16)) & 0xFFFF);
+        var res = f(r_a1, r_a2);
+        low |= (u64.view(res) << shift);
+    }
+    for (shift: byte = 0; shift < 64; shift += 32) {
+        var r_a1 = u16.view((a.1 >> shift) & 0xFFFF);
+        var r_a2 = u16.view((a.1 >> byte.view(shift + 16)) & 0xFFFF);
+        var res = f(r_a1, r_a2);
+        high |= (u64.view(res) << shift);
+    }
+
+    return (low, high);
 }
 // Helper to commute a binary operation
 def commute_binop<T, R>(f: (T, T) -> R) -> (T, T) -> R {

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -945,6 +945,8 @@ component V3Interpreter {
 			I32X4_SUB => do_vv_v(V3Eval.I32X4_SUB);
 			I32X4_MUL => do_vv_v(V3Eval.I32X4_MUL);
 			I32X4_NEG => do_v_v(V3Eval.I32X4_NEG);
+			I32X4_EXTADDPAIRWISE_I16X8_S => do_v_v(V3Eval.I32X4_EXTADDPAIRWISE_I16X8_S);
+			I32X4_EXTADDPAIRWISE_I16X8_U => do_v_v(V3Eval.I32X4_EXTADDPAIRWISE_I16X8_U);
 			I32X4_MIN_S => do_vv_v(V3Eval.I32X4_MIN_S);
 			I32X4_MIN_U => do_vv_v(V3Eval.I32X4_MIN_U);
 			I32X4_MAX_S => do_vv_v(V3Eval.I32X4_MAX_S);
@@ -988,6 +990,8 @@ component V3Interpreter {
 			I8X16_ADD => do_vv_v(V3Eval.I8X16_ADD);
 			I8X16_SUB => do_vv_v(V3Eval.I8X16_SUB);
 			I8X16_NEG => do_v_v(V3Eval.I8X16_NEG);
+			I16X8_EXTADDPAIRWISE_I8X16_S => do_v_v(V3Eval.I16X8_EXTADDPAIRWISE_I8X16_S);
+			I16X8_EXTADDPAIRWISE_I8X16_U => do_v_v(V3Eval.I16X8_EXTADDPAIRWISE_I8X16_U);
 			I8X16_ADD_SAT_S => do_vv_v(V3Eval.I8X16_ADD_SAT_S);
 			I8X16_ADD_SAT_U => do_vv_v(V3Eval.I8X16_ADD_SAT_U);
 			I8X16_SUB_SAT_S => do_vv_v(V3Eval.I8X16_SUB_SAT_S);


### PR DESCRIPTION
Tested by
```
make -j && bin/spectest.x86-linux -tk test/regress/simd/simd_i16x8_extadd_pairwise_i8x16.bin.wast
make -j && bin/spectest.x86-linux -tk test/regress/simd/simd_i32x4_extadd_pairwise_i16x8.bin.wast
```

Added two new helpers.