### PR TITLE
[typed-cont] Stricter check for continuation signature in cont.resume

### DIFF
--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1350,10 +1350,47 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 	def checkContHandle(i: int, tag: TagDecl, cont: ContDecl, target: ControlEntry) {
 		var p = labelArgs(target);
 		if (p == null) return;
-		var ct = Arrays.append(ValueType.Ref(true, HeapType.Cont(cont)), tag.fields);
-		if (ct.length != p.length) return err_atpc().ArityMismatchInHandler("resume", i, p.length, ct.length);
-		for (j < p.length) {
-			if (!ValueTypes.isAssignable(p[j], ct[j])) err_atpc().TypeMismatchInHandler("resume", i, ct[i], p[i]);
+		if (p.length == 0) {
+			err_atpc().ZeroArityInContHandler(i);
+			return;
+		}
+
+		var tag_type = module.heaptypes[tag.sig_index];
+		if (!SigDecl.?(tag_type)) return err_atpc().ExpectedSignature(tag_type);
+		var tag_sig = SigDecl.!(tag_type);
+
+		// p := [<output from label>, (ref null? label_cont)]
+		// [<input to tag>] <: [<output from label>]
+		var n_label_res = p.length - 1;
+		if (tag_sig.params.length != n_label_res) {
+			err_atpc().ArityMismatchInHandler("resume", i, n_label_res, tag_sig.params.length);
+			return;
+		}
+		for (j < n_label_res) {
+			if (!ValueTypes.isAssignable(p[j], tag_sig.params[j])) {
+				return err_atpc().TypeMismatchInHandler("resume", i, tag_sig.params[i], p[i]);
+			}
+		}
+
+		// getting continuation receiver type from label
+		var label_cont = p[p.length - 1];
+		var cont_ht: HeapTypeDecl;
+		match(label_cont) {
+			Ref(nullable, heap) => cont_ht = heap.decl();
+			_ => return err_atpc().ExpectedRefType(label_cont);
+		}
+		if (!ContDecl.?(cont_ht)) return err_atpc().ExpectedContinuation(cont_ht);
+		var lcont = ContDecl.!(cont_ht);
+
+		// TODO: verify if structural assignment check is appropriate here
+		// ([tag output] -> [cont output]) <: label_cont
+		var tag_output = tag_sig.results;
+		var cont_output = cont.sig.results;
+		if (
+			!Arrays.allTrue(tag_output, lcont.sig.params, ValueTypes.isCompatibleParamType) ||
+			!Arrays.allTrue(cont_output, lcont.sig.results, ValueTypes.isCompatibleReturnType)
+		) {
+			return err_atpc().IllegalContinuationReceiverInHandler(i);
 		}
 	}
 	def checkAndPopArgs(p: Array<ValueType>) {

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1144,14 +1144,7 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 					popE(ValueTypes.Ref(true, ct));
 					checkSignature(ct.sig);
 
-					var handlers = parser.readContHandlers();
-					for (i < handlers.length) {
-						var handler = handlers[i];
-						var target = getControl(handler.depth);
-						if (target == null) return;
-						checkContHandle(i, handler.tag, target);
-						ctlxfer.refC(target, handler.tag, false);
-					}
+					readAndCheckContHandlerTable(ct);
 				}
 				RESUME_THROW => {
 					var ct = parser.readCont();
@@ -1162,14 +1155,7 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 					if (thrown_tag == null) return;
 					checkAndPopArgs(thrown_tag.fields);
 
-					var handlers = parser.readContHandlers();
-					for (i < handlers.length) {
-						var handler = handlers[i];
-						var target = getControl(handler.depth);
-						if (target == null) return;
-						checkContHandle(i, handler.tag, target);
-						ctlxfer.refC(target, handler.tag, false);
-					}
+					readAndCheckContHandlerTable(ct);
 				}
 
 				INVALID => {
@@ -1351,10 +1337,20 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 			if (!ValueTypes.isAssignable(ct[j], p[j])) err_atpc().TypeMismatchInHandler("catch", i, p[i], ct[i]);
 		}
 	}
-	def checkContHandle(i: int, tag: TagDecl, target: ControlEntry) {
+	def readAndCheckContHandlerTable(cont: ContDecl) {
+		var handlers = parser.readContHandlers();
+		for (i < handlers.length) {
+			var handler = handlers[i];
+			var target = getControl(handler.depth);
+			if (target == null) return;
+			checkContHandle(i, handler.tag, cont, target);
+			ctlxfer.refC(target, handler.tag, false);
+		}
+	}
+	def checkContHandle(i: int, tag: TagDecl, cont: ContDecl, target: ControlEntry) {
 		var p = labelArgs(target);
 		if (p == null) return;
-		var ct = Arrays.append(ValueType.Ref(true, HeapType.Cont(null)), tag.fields);
+		var ct = Arrays.append(ValueType.Ref(true, HeapType.Cont(cont)), tag.fields);
 		if (ct.length != p.length) return err_atpc().ArityMismatchInHandler("resume", i, p.length, ct.length);
 		for (j < p.length) {
 			if (!ValueTypes.isAssignable(p[j], ct[j])) err_atpc().TypeMismatchInHandler("resume", i, ct[i], p[i]);

--- a/src/util/ErrorGen.v3
+++ b/src/util/ErrorGen.v3
@@ -464,6 +464,14 @@ class ErrorGen(filename: string) {
 		setc(WasmError.TYPE_MISMATCH,
 			Strings.format2("expected %d values for fallthru, got %d", e, g));
 	}
+	def ZeroArityInContHandler(i: int) {
+		setc(WasmError.TYPE_MISMATCH,
+			Strings.format1("cont handler resume[%d] cannot be empty", i));
+	}
+	def IllegalContinuationReceiverInHandler(i: int) {
+		setc(WasmError.TYPE_MISMATCH,
+			Strings.format1("resume[%d] does not accept the given continuation type", i));
+	}
 	def ArityMismatchInHandler(handler_type: string, i: int, expected: int, got: int) {
 		var desc: string = Strings.format2("%s[%d]", handler_type, i);
 		setc(WasmError.TYPE_MISMATCH,


### PR DESCRIPTION
This PR adds continuation type checking when validation the handler table for `cont.resume` and `cont.resume_throw`.