### PR TITLE
[monitors] Use CountProbe and CountMoreProbe for fuel calculation

### DIFF
--- a/src/monitors/BytecodeProfilingMonitor.v3
+++ b/src/monitors/BytecodeProfilingMonitor.v3
@@ -21,7 +21,7 @@ var MAX_OPERAND_LEN = 6;
 
 class BytecodeProfilingMonitor extends Monitor {
 	var visitor: DispatchFunctionBytecodeVisitor;
-	def fuel_counter = FuelCounter.new();
+	def fuel_counter = CountProbe.new();
 	// The GuestProfileState of all functions that could be the dispatch function.
 	var potential_dispatch_functions: List<GuestProfileState>;
 	var output_folder: string; // output folder for the profiling results, if unset, print to terminal.
@@ -120,7 +120,7 @@ class BytecodeProfilingMonitor extends Monitor {
 
 // Iterates over all wasm functions to detect possible dispatch functions using simple heuristics,
 // and to calculate size of basic blocks.
-private class DispatchFunctionBytecodeVisitor(module: Module, bi: BytecodeIterator, counter: FuelCounter) extends BytecodeVisitor {
+private class DispatchFunctionBytecodeVisitor(module: Module, bi: BytecodeIterator, counter: CountProbe) extends BytecodeVisitor {
 	var opcode_read_pc = -1;
 	var basic_block_start_pc = 0;
 	var basic_block_size: u32 = 0;
@@ -149,7 +149,7 @@ private class DispatchFunctionBytecodeVisitor(module: Module, bi: BytecodeIterat
 			BR_ON_CAST, BR_ON_CAST_FAIL, BR_ON_NULL, BR_ON_NON_NULL,
 			RETURN_CALL_REF, RETURN_CALL_INDIRECT => { // end of basic block
 				if (basic_block_size > 0) {
-					var basic_block_probe = BasicBlockProbe.new(basic_block_size, counter);
+					var basic_block_probe = CountMoreProbe.new(counter, basic_block_size);
 					Instrumentation.insertLocalProbe(module, bi.func.func_index, basic_block_start_pc, basic_block_probe);
 					basic_block_start_pc = bi.nextPc();
 					basic_block_size = 0;
@@ -166,7 +166,7 @@ private class DispatchFunctionBytecodeVisitor(module: Module, bi: BytecodeIterat
 	}
 }
 
-private class GuestProfileState(counter: FuelCounter, dispatch_func_id: int, output_prefix: string) {
+private class GuestProfileState(counter: CountProbe, dispatch_func_id: int, output_prefix: string) {
 	var call_stack = ListStack<u32>.new();
 	// Complete execution trace.
 	var trace: List<TraceEntry>;
@@ -174,12 +174,12 @@ private class GuestProfileState(counter: FuelCounter, dispatch_func_id: int, out
 	var recovered_bytecodes = HashMap<u32, HashMap<u32, u8>>.new(int.!<u32>, u32.==);
 	// Address of the last read bytecode.
 	var last_opcode_addr: u32;
-	var fuel_count: u32 = 0;
+	var fuel_count: u64 = 0;
 	// Total costs of each bytecode execution.
 	def hotness: BytecodeHotness = BytecodeHotness.new(output_prefix);
 	var last_probe_event: ProbeEvent = ProbeEvent.RETURN;
-	var last_step_count: u32;
-	var last_probe_event_count: u32;
+	var last_step_count: u64;
+	var last_probe_event_count: u64;
 	var cur_wasm_func_trace: List<WasmFuncTrace>;
 
 	// Updates profiler state upon wasm function invocation/return, during the execution of a
@@ -373,24 +373,24 @@ private class GuestProfileState(counter: FuelCounter, dispatch_func_id: int, out
 		last_probe_event_count = counter.count;
 	}
 
-	private def get_cost() -> u32 {
+	private def get_cost() -> u64 {
 		return counter.count - last_probe_event_count;
 	}
 }
 
 private class BytecodeHotness(output_prefix: string) {
-	def bytecode_hotness: Array<HashMap<u32, u32>> = Array.new(256);
+	def bytecode_hotness: Array<HashMap<u64, u32>> = Array.new(256);
 
-	def record(b: u8, cost: u32) {
+	def record(b: u8, cost: u64) {
 		if (bytecode_hotness[b] == null) {
-			bytecode_hotness[b] = HashMap<u32, u32>.new(int.!<u32>, u32.==);
+			bytecode_hotness[b] = HashMap<u64, u32>.new(int.!<u64>, u64.==);
 		}
 		if (!bytecode_hotness[b].has(cost)) {
 			bytecode_hotness[b][cost] = 0;
 		}
 		bytecode_hotness[b][cost]++;
 	}
-	def update(b: u8, old_cost: u32, new_cost: u32) {
+	def update(b: u8, old_cost: u64, new_cost: u64) {
 		if (bytecode_hotness[b] == null || !bytecode_hotness[b].has(old_cost)) {
 			return;
 		}
@@ -425,33 +425,15 @@ private class BytecodeHotness(output_prefix: string) {
 	}
 }
 
-// Inserted at the start of every basic block, makes fuel calculation faster by avoiding a global
-// probe.
-private class BasicBlockProbe(size: u32, counter: FuelCounter) extends Probe {
-	def fire(dynamicLoc: DynamicLoc) -> Resumption {
-		counter.incrementFuel(size);
-		return Resumption.Continue;
-	}
-}
-
-// Custom fuel counter that aggregates all the BasicBlockProbe counts.
-private class FuelCounter {
-	var count: u32 = 0;
-
-	def incrementFuel(size: u32) {
-		count += size;
-	}
-}
-
 private type TraceEntry {
 	case CALL(func_id: u32);
-	case STEP(bytecode: u8, offset: u32, cost: u32, wasm_func_trace: List<WasmFuncTrace>);
+case STEP(bytecode: u8, offset: u64, cost: u64, wasm_func_trace: List<WasmFuncTrace>);
 	case RETURN(func_id: u32);
-	case SYSTEM(cost: u32, wasm_func_trace: List<WasmFuncTrace>);
+	case SYSTEM(cost: u64, wasm_func_trace: List<WasmFuncTrace>);
 }
 
 // Wasm function call/return events when the dispatch function is executing a valid guest opcode.
-private type WasmFuncTrace(func_id: int, instr_count: u32, is_start: bool) {
+private type WasmFuncTrace(func_id: int, instr_count: u64, is_start: bool) {
 	def toString() -> string {
 		return Strings.format3("%d:%s:%d", func_id, if (is_start, "S", "E"), instr_count);
 	}


### PR DESCRIPTION
Both `CountProbe` and `CountMoreProbe` are intrinsified by the JIT, so this should be more efficient.