### PR TITLE
ErrorGen case for errors in Whamm! probes

### DIFF
--- a/src/util/ErrorGen.v3
+++ b/src/util/ErrorGen.v3
@@ -555,6 +555,11 @@ class ErrorGen(filename: string) {
 	def InvalidPreopenPath(path: string) {
 		setc(WasmError.INVALID_PREOPEN_PATH, Strings.format1("preopen path is invalid: %s", path));
 	}
+
+	// Whamm! probe errors
+	def WhammProbeError(whammFn: string, msg: string) {
+		setc(WasmError.WHAMM_PROBE_ERROR, Strings.format2("error inserting Whamm! probe %s: %s", whammFn, msg));
+	}
 }
 
 // Wasm errors are enumerated to allow programmatic matching in unit tests.
@@ -623,5 +628,7 @@ enum WasmError {
 	// Engine errors
 	JIT_ERROR,
 	// Wasi errors
-	INVALID_PREOPEN_PATH
+	INVALID_PREOPEN_PATH,
+	// Whamm! errors
+	WHAMM_PROBE_ERROR
 }


### PR DESCRIPTION
ErrorGen for cases in which a probe function cannot be added in the Whamm monitor (e.g. type error at match time)