### PR TITLE
WasmParser duplicator

### DIFF
--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1527,10 +1527,6 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 		}
 		OUT.ln();
 	}
-	def dupParser() -> WasmParser {
-		def decoder = CodePtr.new(null).reset(Ranges.dup(parser.decoder.data), parser.decoder.pos, parser.decoder.limit);
-		return WasmParser.new(parser.extensions, parser.limits, parser.module, ErrorGen.new(""), decoder);
-	}
 }
 def labelArgs(target: ControlEntry) -> Array<ValueType> {
 	if (target.start_opcode == Opcode.LOOP.code) return target.params;

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1527,6 +1527,10 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 		}
 		OUT.ln();
 	}
+	def dupParser() -> WasmParser {
+		def decoder = CodePtr.new(null).reset(Ranges.dup(parser.decoder.data), parser.decoder.pos, parser.decoder.limit);
+		return WasmParser.new(parser.extensions, parser.limits, parser.module, ErrorGen.new(""), decoder);
+	}
 }
 def labelArgs(target: ControlEntry) -> Array<ValueType> {
 	if (target.start_opcode == Opcode.LOOP.code) return target.params;

--- a/src/engine/WasmParser.v3
+++ b/src/engine/WasmParser.v3
@@ -505,6 +505,12 @@ class WasmParser(extensions: Extension.set, limits: Limits, module: Module,
 		if (b < ' ' || b > 127) b = '.';
 		return b;
 	}
+
+	def dup() -> WasmParser {
+	  // CodePtr should be able to dup itself?
+		def newDecoder = CodePtr.new(null).reset(Ranges.dup(decoder.data), decoder.pos, decoder.limit);
+		return WasmParser.new(extensions, limits, module, ErrorGen.new(""), newDecoder);
+	}
 }
 type Catch(tag: TagDecl, exnref: bool, depth: u32) {
 }


### PR DESCRIPTION
This is a utility for the WhammMonitor, which needs to clone the current position of a CodeValidator as it parses through a wasm module