### PR TITLE
Refractored suspension handler out of the exception handler lookup

### DIFF
--- a/src/engine/BytecodeIterator.v3
+++ b/src/engine/BytecodeIterator.v3
@@ -745,9 +745,9 @@ class BytecodeIterator {
 
 			CONT_NEW => 			v.visit_CONT_NEW(read_CONT());
 			CONT_BIND => 			v.visit_CONT_BIND(read_CONT(), read_CONT());
-			SUSPEND => 			v.visit_SUSPEND(read_TAG());
-			RESUME => 			v.visit_RESUME(read_CONT()); // TODO
-			RESUME_THROW => 		v.visit_RESUME_THROW(read_CONT(), read_TAG());
+			SUSPEND => 				v.visit_SUSPEND(read_TAG());
+			RESUME => 				v.visit_RESUME(read_CONT(), cp.read_handlers());
+			RESUME_THROW => 	v.visit_RESUME_THROW(read_CONT(), read_TAG(), cp.read_handlers());
 		}
 	}
 	def trace(out: StringBuilder, module: Module, tracer: InstrTracer) {

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -13,7 +13,6 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 	def ctl_stack = ArrayStack<ControlEntry>.new();
 	def ctlxfer = SidetableBuilder.new();
 	def ex_handlers = Vector<ExHandlerEntry>.new();
-	def resume_handlers = Vector<ExHandlerEntry>.new();
 	var ctl_top: ControlEntry;  // FAST: cache of top of control stack
 	var func_start_pos: int;
 	var func: FuncDecl;
@@ -67,7 +66,6 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 
 		if (func.sidetable.entries == null) System.error(null, null); // TODO: keep alive
 		if (ex_handlers.length > 0) func.handlers = ex_handlers.extract();
-		if (resume_handlers.length > 0) func.resume_handlers = resume_handlers.extract();
 
 		// Report metrics and return success.
 		if (err.ok()) {
@@ -117,7 +115,6 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 		ctl_stack.clear();
 		ctlxfer.reset(codeptr.pos);
 		ex_handlers.resize(0);
-		resume_handlers.resize(0);
 	}
 	def readLocals(vec: Vector<ValueType>) -> bool {
 		var start = vec.length, max = limits.max_num_locals;
@@ -1338,7 +1335,6 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 			var info = ExHandlerInfo.Sidetable(false, sidetable_entry);
 			var tag_index = handler.tag.tag_index;
 			var resume_pos = opcode_pos - func_start_pos;
-			resume_handlers.put(ExHandlerEntry(tag_index, resume_pos, resume_pos + 1, info));
 		}
 	}
 	def checkContHandle(i: int, tag: TagDecl, cont: ContDecl, target: ControlEntry) {

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1131,8 +1131,9 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 					checkSignature(ct.sig);
 
 					var n_binds = ct.sig.params.length;
-					ctlxfer.refResume(n_binds);
-					readAndCheckContHandlerTable(ct);
+					var handlers = parser.readContHandlers();
+					ctlxfer.refResume(n_binds, handlers.length);
+					readAndCheckContHandlerTable(ct, handlers);
 				}
 				RESUME_THROW => {
 					var ct = parser.readCont();
@@ -1146,7 +1147,8 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 					// RESUME_THROW doesn't need an entry as it does not bind the stack
 					// var n_binds = ct.sig.params.length;
 					// ctlxfer.refResume(n_binds);
-					readAndCheckContHandlerTable(ct);
+					var handlers = parser.readContHandlers();
+					readAndCheckContHandlerTable(ct, handlers);
 				}
 
 				INVALID => {
@@ -1326,8 +1328,7 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 			if (!ValueTypes.isAssignable(ct[j], p[j])) err_atpc().TypeMismatchInHandler("catch", i, p[i], ct[i]);
 		}
 	}
-	def readAndCheckContHandlerTable(cont: ContDecl) {
-		var handlers = parser.readContHandlers();
+	def readAndCheckContHandlerTable(cont: ContDecl, handlers: Array<ContHandler>) {
 		var sidetable_pos = ctlxfer.sidetable.length;
 		for (i < handlers.length) {
 			var handler = handlers[i];
@@ -1614,19 +1615,19 @@ class SidetableBuilder {
 		target.first_ref = stp;
 	}
 	// Emit a sidetable entry for resume.
-	def refResume(n_binds: int) {
+	def refResume(n_binds: int, n_handlers: int) {
 		if (Trace.validation) {
-			OUT.put1("    refResume(n_binds=%d", n_binds);
+			OUT.put2("    refResume(n_binds=%d n_handlers=%d)", n_binds, n_handlers);
 			OUT.ln();
 		}
-		Sidetables.putResumeEntry(sidetable, n_binds);
+		Sidetables.putResumeEntry(sidetable, n_binds, n_handlers);
 	}
 	// Emit a sidetable entry for a suspend handler.
 	def refSuspend(target: ControlEntry, tag: TagDecl) {
 		var handler_pc = 0;
 		var stp = sidetable.length;
 		if (Trace.validation) {
-			OUT.put2("    refSuspend(@+pc tag=%d vsp=%d", if(tag != null, tag.tag_index, -1), target.val_stack_top);
+			OUT.put2("    refSuspend(@+pc tag=%d vsp=%d)", if(tag != null, tag.tag_index, -1), target.val_stack_top);
 			OUT.ln();
 		}
 		Sidetables.putSuspendHandlerEntry(sidetable, handler_pc, tag.tag_index, target.first_ref);

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1130,6 +1130,8 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 					popE(ValueTypes.Ref(true, ct));
 					checkSignature(ct.sig);
 
+					var n_binds = ct.sig.params.length;
+					ctlxfer.refResume(n_binds);
 					readAndCheckContHandlerTable(ct);
 				}
 				RESUME_THROW => {
@@ -1141,6 +1143,9 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 					if (thrown_tag == null) return;
 					checkAndPopArgs(thrown_tag.fields);
 
+					// RESUME_THROW doesn't need an entry as it does not bind the stack
+					// var n_binds = ct.sig.params.length;
+					// ctlxfer.refResume(n_binds);
 					readAndCheckContHandlerTable(ct);
 				}
 
@@ -1329,7 +1334,7 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 			var target = getControl(handler.depth);
 			if (target == null) return;
 			checkContHandle(i, handler.tag, cont, target);
-			ctlxfer.refC(target, handler.tag, false);
+			ctlxfer.refSuspend(target, handler.tag);
 
 			var sidetable_entry = sidetable_pos + (i * Sidetable_CatchEntry.size / 4); // TODO: entry size
 			var info = ExHandlerInfo.Sidetable(false, sidetable_entry);
@@ -1606,6 +1611,25 @@ class SidetableBuilder {
 			OUT.ln();
 		}
 		Sidetables.putCatchEntry(sidetable, handler_pc, target.val_stack_top, target.first_ref);
+		target.first_ref = stp;
+	}
+	// Emit a sidetable entry for resume.
+	def refResume(n_binds: int) {
+		if (Trace.validation) {
+			OUT.put1("    refResume(n_binds=%d", n_binds);
+			OUT.ln();
+		}
+		Sidetables.putResumeEntry(sidetable, n_binds);
+	}
+	// Emit a sidetable entry for a suspend handler.
+	def refSuspend(target: ControlEntry, tag: TagDecl) {
+		var handler_pc = 0;
+		var stp = sidetable.length;
+		if (Trace.validation) {
+			OUT.put2("    refSuspend(@+pc tag=%d vsp=%d", if(tag != null, tag.tag_index, -1), target.val_stack_top);
+			OUT.ln();
+		}
+		Sidetables.putSuspendHandlerEntry(sidetable, handler_pc, tag.tag_index, target.first_ref);
 		target.first_ref = stp;
 	}
 	// Bind the label for {target} at {pos} and {sidetable_pos} and resolve references to it.

--- a/src/engine/Module.v3
+++ b/src/engine/Module.v3
@@ -119,7 +119,6 @@ class FuncDecl(sig_index: int) extends Decl {
 	def var orig_bytecode: Array<byte>;		// unmodified original bytecode
 	var sidetable = Sidetables.NO_SIDETABLE;	// sidetable, including control transfers
 	var handlers = NO_HANDLERS;
-	var resume_handlers = NO_HANDLERS;
 	var target_code: TargetCode;
 	var tierup_trigger: int = int.max;
 
@@ -164,9 +163,6 @@ class FuncDecl(sig_index: int) extends Decl {
 	}
 	def findExHandler(instance: Instance, tag: Tag, throw_pc: int) -> ExHandler {
 		return findHandler("findExHandler", handlers, instance, tag, throw_pc);
-	}
-	def findResumeHandler(instance: Instance, tag: Tag, throw_pc: int) -> ExHandler {
-		return findHandler("findResumeHandler", resume_handlers, instance, tag, throw_pc);
 	}
 	def findHandler(name: string, handlers: Array<ExHandlerEntry>, instance: Instance, tag: Tag, throw_pc: int) -> ExHandler {
 		var i = 0;

--- a/src/engine/Sidetable.v3
+++ b/src/engine/Sidetable.v3
@@ -26,7 +26,7 @@ type Sidetable(entries: Array<int>) #unboxed {
 	}
 	// Get an entry for a suspend handler at the given position.
 	def getSuspendHandlerEntry(stp: int) -> SidetableSuspendHandlerEntry {
-		return SidetableSuspendHandlerEntry(entries[stp + 0], entries[stp + 2], entries[stp + 3]);
+		return SidetableSuspendHandlerEntry(entries[stp + 0], entries[stp + 2], stp + entries[stp + 3]);
 	}
 	def size() -> int {
 		return entries.length * 4;

--- a/src/engine/Sidetable.v3
+++ b/src/engine/Sidetable.v3
@@ -20,6 +20,14 @@ type Sidetable(entries: Array<int>) #unboxed {
 		var sidetable_pos = stp + entries[stp + Sidetables.dstp_pos];
 		return SidetableCatchEntry(entries[stp + Sidetables.dpc_pos], entries[stp + Sidetables.valcount_pos], sidetable_pos);
 	}
+	// Get an entry for a resume at the given position.
+	def getResumeEntry(stp: int) -> SidetableResumeEntry {
+		return SidetableResumeEntry(entries[stp + 0]);
+	}
+	// Get an entry for a suspend handler at the given position.
+	def getSuspendHandlerEntry(stp: int) -> SidetableSuspendHandlerEntry {
+		return SidetableSuspendHandlerEntry(entries[stp + 0], entries[stp + 2], entries[stp + 3]);
+	}
 	def size() -> int {
 		return entries.length * 4;
 	}
@@ -30,6 +38,10 @@ type SidetableBrEntry(dpc: int, valcount: int, popcount: int, dstp: int) #unboxe
 type SidetableRethrowEntry(catch_slot: int) #unboxed;
 // A sidetable entry associated with a catch entry.
 type SidetableCatchEntry(handler_pc: int, val_stack_top: int, sidetable_pos: int) #unboxed;
+// A sidetable entry associated with a resume entry.
+type SidetableResumeEntry(n_binds: int) #unboxed;
+// A sidetable entry associated with a suspend entry.
+type SidetableSuspendHandlerEntry(handler_pc: int, tag: int, sidetable_pos: int) #unboxed;
 
 
 // Global constants associated with sidetables.
@@ -51,6 +63,20 @@ component Sidetables {
 		v.put(handler_pc)
 		 .put(val_stack_top)
 		 .put(0)
+		 .put(sidetable_pos);
+	}
+	// TODO: is this actually necessary?
+	// This is kinda silly but it alleviates the need for get_missing_binds.
+	def putResumeEntry(v: Vector<int>, n_binds: int) {
+		v.put(n_binds)
+		 .put(0)
+		 .put(0)
+		 .put(0);
+	}
+	def putSuspendHandlerEntry(v: Vector<int>, handler_pc: int, tag: int, sidetable_pos: int) {
+		v.put(handler_pc)
+		 .put(0)
+		 .put(tag)
 		 .put(sidetable_pos);
 	}
 }
@@ -104,6 +130,12 @@ private class SidetableMapperVisitor(map: SidetableMap, bi: BytecodeIterator) ex
 	def visit_BR_ON_NON_NULL(label: u31)				{ entry(Sidetable_BrEntry.size); }
 	def visit_BR_ON_CAST(imm: BrOnCastImm)				{ entry(Sidetable_BrEntry.size); }
 	def visit_BR_ON_CAST_FAIL(imm: BrOnCastImm)			{ entry(Sidetable_BrEntry.size); }
+	def visit_RESUME(cont: u31, labels: Array<(u31, u31)>) 	{
+		entry(Sidetable_ResumeEntry.size + labels.length * Sidetable_SuspendHandlerEntry.size);
+	}
+	// def visit_RESUME_THROW(cont: u31, tag: u31, labels: Array<(u31, u31)>) 	{
+	// 	entry(Sidetable_ResumeEntry.size + labels.length * Sidetable_SuspendHandlerEntry.size);
+	// }
 }
 
 // Entries for branches (if, br, br_if, br_table, br_null, etc) contain information for control
@@ -123,6 +155,19 @@ layout Sidetable_BrEntry {
 // Entries for control transfers that don't alter value stack (like a goto).
 layout Sidetable_GotoEntry {
 	+0	pc_delta:	i32;
+	+12	stp_delta:	i32;
+	=16;
+}
+
+layout Sidetable_ResumeEntry {
+	+0	n_args:	i32;
+	=16;
+}
+
+// Entries for suspension handlers.
+layout Sidetable_SuspendHandlerEntry {
+	+0	pc_delta:	i32;
+	+8	tag: i32;
 	+12	stp_delta:	i32;
 	=16;
 }

--- a/src/engine/Sidetable.v3
+++ b/src/engine/Sidetable.v3
@@ -22,7 +22,7 @@ type Sidetable(entries: Array<int>) #unboxed {
 	}
 	// Get an entry for a resume at the given position.
 	def getResumeEntry(stp: int) -> SidetableResumeEntry {
-		return SidetableResumeEntry(entries[stp + 0]);
+		return SidetableResumeEntry(entries[stp + 0], entries[stp + 1]);
 	}
 	// Get an entry for a suspend handler at the given position.
 	def getSuspendHandlerEntry(stp: int) -> SidetableSuspendHandlerEntry {
@@ -39,7 +39,7 @@ type SidetableRethrowEntry(catch_slot: int) #unboxed;
 // A sidetable entry associated with a catch entry.
 type SidetableCatchEntry(handler_pc: int, val_stack_top: int, sidetable_pos: int) #unboxed;
 // A sidetable entry associated with a resume entry.
-type SidetableResumeEntry(n_binds: int) #unboxed;
+type SidetableResumeEntry(n_binds: int, n_handlers: int) #unboxed;
 // A sidetable entry associated with a suspend entry.
 type SidetableSuspendHandlerEntry(handler_pc: int, tag: int, sidetable_pos: int) #unboxed;
 
@@ -67,9 +67,9 @@ component Sidetables {
 	}
 	// TODO: is this actually necessary?
 	// This is kinda silly but it alleviates the need for get_missing_binds.
-	def putResumeEntry(v: Vector<int>, n_binds: int) {
+	def putResumeEntry(v: Vector<int>, n_binds: int, n_handlers: int) {
 		v.put(n_binds)
-		 .put(0)
+		 .put(n_handlers)
 		 .put(0)
 		 .put(0);
 	}
@@ -160,7 +160,8 @@ layout Sidetable_GotoEntry {
 }
 
 layout Sidetable_ResumeEntry {
-	+0	n_args:	i32;
+	+0	n_binds:	i32;
+	+4	n_handlers: i32;
 	=16;
 }
 

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1535,6 +1535,7 @@ class V3Interpreter extends WasmStack {
 	}
 	// ext:typed-continuation
 	def gotoResumeHandlerAndConsume(tag: Tag) -> bool {
+		// TODO: remove this
 		var handler = frame.func.decl.findResumeHandler(frame.func.instance, tag, prev_resume_pc);
 		prev_resume_pc = -1;
 		if (handler.handler_pc >= 0) {

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1535,16 +1535,16 @@ class V3Interpreter extends WasmStack {
 		return thrown = t; // unhandled exception
 	}
 	private def findResumeHandler(tag: Tag) -> int {
+		Trace.OUT.put1("TEST tag %d", tag.decl.tag_index).ln();
 		var sidetable = frame.func.decl.sidetable;
 		var stp = frame.stp; // still points to resume's entry
-		var n_binds = sidetable.getResumeEntry(stp).n_binds;
+		var n_handlers = sidetable.getResumeEntry(stp).n_handlers;
 		stp += Sidetable_ResumeEntry.size / 4;
-		for (i < n_binds) {
+		for (i < n_handlers) {
 			var entry = sidetable.getSuspendHandlerEntry(stp);
 			if (entry.tag == tag.decl.tag_index) return stp;
 			stp += Sidetable_SuspendHandlerEntry.size / 4;
 		}
-
 		return -1;
 	}
 	// ext:typed-continuation

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1479,6 +1479,9 @@ class V3Interpreter extends WasmStack {
 		var code = frame.func.decl.cur_bytecode;
 		codeptr.reset(code, frame.pc, code.length);
 		var opcode = codeptr.read_opcode_and_skip(frame.func.decl);
+
+		// TODO[ss]: resume stp
+
 		match (opcode) {
 			RESUME, RESUME_THROW => ;
 			_ => fail(Strings.format1("expected resume instruction in child terminate, got %s", opcode.name));
@@ -1535,7 +1538,6 @@ class V3Interpreter extends WasmStack {
 		return thrown = t; // unhandled exception
 	}
 	private def findResumeHandler(tag: Tag) -> int {
-		Trace.OUT.put1("TEST tag %d", tag.decl.tag_index).ln();
 		var sidetable = frame.func.decl.sidetable;
 		var stp = frame.stp; // still points to resume's entry
 		var n_handlers = sidetable.getResumeEntry(stp).n_handlers;

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1147,7 +1147,8 @@ class V3Interpreter extends WasmStack {
 				if (cont.used) return void(trap(TrapReason.USED_CONTINUATION));
 
 				cont.used = true;
-				cont.stack.bind(values.peekn(cont.stack.getMissingBinds()));
+				var n_binds = frame.func.decl.sidetable.entries[frame.stp];
+				cont.stack.bind(values.peekn(n_binds));
 
 				prev_resume_pc = frame.pc;
 				state_ = StackState.CALL_CHILD;
@@ -1533,15 +1534,30 @@ class V3Interpreter extends WasmStack {
 		state_ = StackState.THROWING;
 		return thrown = t; // unhandled exception
 	}
+	private def findResumeHandler(tag: Tag) -> int {
+		var sidetable = frame.func.decl.sidetable;
+		var stp = frame.stp; // still points to resume's entry
+		var n_binds = sidetable.getResumeEntry(stp).n_binds;
+		stp += Sidetable_ResumeEntry.size / 4;
+		for (i < n_binds) {
+			var entry = sidetable.getSuspendHandlerEntry(stp);
+			if (entry.tag == tag.decl.tag_index) return stp;
+			stp += Sidetable_SuspendHandlerEntry.size / 4;
+		}
+
+		return -1;
+	}
 	// ext:typed-continuation
 	def gotoResumeHandlerAndConsume(tag: Tag) -> bool {
 		// TODO: remove this
-		var handler = frame.func.decl.findResumeHandler(frame.func.instance, tag, prev_resume_pc);
+		var stp = findResumeHandler(tag);
+		var lookup_pc = prev_resume_pc;
 		prev_resume_pc = -1;
-		if (handler.handler_pc >= 0) {
+
+		if (stp >= 0) {
+			var handler = frame.func.decl.sidetable.getSuspendHandlerEntry(stp);
 			var code = frame.func.decl.cur_bytecode;
 			frame.pc = handler.handler_pc;
-			// TODO[ss]: check that this is correct sidetable placement
 			frame.stp = handler.sidetable_pos;
 			codeptr.reset(code, frame.pc, code.length);
 			return true;

--- a/src/util/BytecodeVisitor.v3
+++ b/src/util/BytecodeVisitor.v3
@@ -625,7 +625,7 @@ class BytecodeVisitor {
 	// stack switching
 	def visit_CONT_NEW					(cont: u31) 	{ visitOp(Opcode.CONT_NEW); }
 	def visit_CONT_BIND					(ct1: u31, ct2: u31) { visitOp(Opcode.CONT_BIND); }
-	def visit_RESUME					(cont: u31) 	{ visitOp(Opcode.RESUME); }
-	def visit_RESUME_THROW				(cont: u31, tag: u31) 	{ visitOp(Opcode.RESUME_THROW); }
-	def visit_SUSPEND					(tag: u31)  	{ visitOp(Opcode.SUSPEND); }
+	def visit_RESUME						(cont: u31, labels: Array<(u31, u31)>) 	{ visitOp(Opcode.RESUME); }
+	def visit_RESUME_THROW			(cont: u31, tag: u31, labels: Array<(u31, u31)>) 	{ visitOp(Opcode.RESUME_THROW); }
+	def visit_SUSPEND						(tag: u31)  	{ visitOp(Opcode.SUSPEND); }
 }

--- a/test/regress.sh
+++ b/test/regress.sh
@@ -28,9 +28,9 @@ function run_tests() {
     for ext in $(find test/regress -type d) ; do
 	if [[ $ext =~ test/regress/(ext:.*) ]]; then
 	    arg="-${BASH_REMATCH[1]}"
-	    # if [ $arg = "-ext:stack-switching" ]; then # TODO: dont skip
-		# continue
-	    # fi
+	    if [ $arg = "-ext:stack-switching" ]; then # TODO: dont skip
+		continue
+	    fi
 	    TESTS="$ext/*.bin.wast"
 	    $CMD $arg $TESTS
 	fi

--- a/test/regress.sh
+++ b/test/regress.sh
@@ -28,9 +28,9 @@ function run_tests() {
     for ext in $(find test/regress -type d) ; do
 	if [[ $ext =~ test/regress/(ext:.*) ]]; then
 	    arg="-${BASH_REMATCH[1]}"
-	    if [ $arg = "-ext:stack-switching" ]; then # TODO: dont skip
-		continue
-	    fi
+	    # if [ $arg = "-ext:stack-switching" ]; then # TODO: dont skip
+		# continue
+	    # fi
 	    TESTS="$ext/*.bin.wast"
 	    $CMD $arg $TESTS
 	fi


### PR DESCRIPTION
This PR refractors suspension handler lookup out of the exception handler lookup routine. I think this makes more sense as this limits the search for a handler to a more limited scope rather than the whole function declaration, and is in general cleaner as the lookup of exception handler and suspension handler aren't really that similar.