### PR TITLE
[stack-switching] Updated bytecode reading to accept switch handling

### DIFF
--- a/src/engine/CodePtr.v3
+++ b/src/engine/CodePtr.v3
@@ -184,11 +184,19 @@ class CodePtr extends DataReader {
 					var count = read_uleb32();
 					for (i < count + 1) skip_leb();
 				}
-				HANDLERS => {
+				EX_HANDLERS => {
 					var count = read_uleb32();
 					for (i < count) {
 						skip_leb();
 						skip_leb();
+					}
+				}
+				SUS_HANDLERS => {
+					var count = read_uleb32();
+					for (i < count) {
+						var kind = read_uleb32();
+						skip_leb();
+						if (kind == 0) skip_leb();
 					}
 				}
 				CATCHES => {

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1325,20 +1325,27 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 		}
 	}
 	def readAndCheckContHandlerTable(cont: ContDecl) {
-		var handlers = parser.readContHandlers();
+		var handlers = parser.readSusHandlers();
 		var sidetable_pos = ctlxfer.sidetable.length;
 		for (i < handlers.length) {
-			var handler = handlers[i];
-			var target = getControl(handler.depth);
-			if (target == null) return;
-			checkContHandle(i, handler.tag, cont, target);
-			ctlxfer.refC(target, handler.tag, false);
+			match (handlers[i]) {
+				Suspend(tag, depth) => {
+					var target = getControl(depth);
+					if (target == null) return;
+					checkContHandle(i, tag, cont, target);
+					ctlxfer.refC(target, tag, false);
 
-			var sidetable_entry = sidetable_pos + (i * Sidetable_CatchEntry.size / 4); // TODO: entry size
-			var info = ExHandlerInfo.Sidetable(false, sidetable_entry);
-			var tag_index = handler.tag.tag_index;
-			var resume_pos = opcode_pos - func_start_pos;
-			resume_handlers.put(ExHandlerEntry(tag_index, resume_pos, resume_pos + 1, info));
+					var sidetable_entry = sidetable_pos + (i * Sidetable_CatchEntry.size / 4); // TODO: entry size
+					var info = ExHandlerInfo.Sidetable(false, sidetable_entry);
+					var tag_index = tag.tag_index;
+					var resume_pos = opcode_pos - func_start_pos;
+					resume_handlers.put(ExHandlerEntry(tag_index, resume_pos, resume_pos + 1, info));
+				}
+				Switch(t) => {
+					err_atpc().setc(WasmError.OOB_LABEL, "unimplemented");
+					return;
+				}
+			}			
 		}
 	}
 	def checkContHandle(i: int, tag: TagDecl, cont: ContDecl, target: ControlEntry) {

--- a/src/engine/Opcodes.v3
+++ b/src/engine/Opcodes.v3
@@ -620,7 +620,8 @@ enum ImmKind {
 	BR_CAST,		// BR_CAST
 	CATCHES,		// CATCH
 	CONT_INDEX,		// CONT
-	HANDLERS		// HANDLERS
+	EX_HANDLERS		// EX_HANDLERS
+	SUS_HANDLERS	// SUS_HANDLERS
 }
 // Cached immediate signatures
 component ImmSigs {
@@ -669,8 +670,8 @@ component ImmSigs {
 	// Continuation operation signatures.
 	def CONT = [ImmKind.CONT_INDEX];
 	def CONT_CONT = [ImmKind.CONT_INDEX, ImmKind.CONT_INDEX];
-	def CONT_HANDLE = [ImmKind.CONT_INDEX, ImmKind.HANDLERS];
-	def CONT_TAG_HANDLE = [ImmKind.CONT_INDEX, ImmKind.TAG_INDEX, ImmKind.HANDLERS];
+	def CONT_HANDLE = [ImmKind.CONT_INDEX, ImmKind.SUS_HANDLERS];
+	def CONT_TAG_HANDLE = [ImmKind.CONT_INDEX, ImmKind.TAG_INDEX, ImmKind.SUS_HANDLERS];
 }
 
 // Internal opcodes used by the interpreter.
@@ -1042,8 +1043,12 @@ class InstrTracer {
 					var labels = parser.readLabels();
 					out.put1("%d...", labels.length);
 				}
-				HANDLERS => {
+				EX_HANDLERS => {
 					var handlers = parser.readHandlers();
+					out.put1("%d...", handlers.length);
+				}
+				SUS_HANDLERS => {
+					var handlers = parser.readSusHandlers();
 					out.put1("%d...", handlers.length);
 				}
 				CATCHES => {

--- a/src/engine/WasmParser.v3
+++ b/src/engine/WasmParser.v3
@@ -347,18 +347,21 @@ class WasmParser(extensions: Extension.set, limits: Limits, module: Module,
 	}
 	def readHandlers() -> Array<(u32, u32)> {
 		var pt = decoder.pos;
-		var count = readU32("handler count", limits.max_func_size);
+		var count = readU32("ex handler count", limits.max_func_size);
 		var result = Array<(u32, u32)>.new(int.!(count));
 		for (i < count) result[i] = (decoder.read_uleb32(), decoder.read_uleb32());
 		return result;
 	}
 	// Reads the same content as readHandlers but with extra checks.
-	def readContHandlers() -> Array<ContHandler> {
+	def readSusHandlers() -> Array<SusHandler> {
 		var pt = decoder.pos;
-		var count = readU32("cont handler count", limits.max_func_size);
-		var result = Array<ContHandler>.new(int.!(count));
+		var count = readU32("sus handler count", limits.max_func_size);
+		var result = Array<SusHandler>.new(int.!(count));
 		for (i < count) {
-			var ch = ContHandler(readTagRef(), readLabel());
+			var kind = readU32("sus handler kind", 1);
+			var ch: SusHandler;
+			if (kind == 0) ch = SusHandler.Suspend(readTagRef(), readLabel());
+			else ch = SusHandler.Switch(readTagRef());
 			result[i] = ch;
 		}
 		return result;
@@ -512,6 +515,7 @@ class WasmParser(extensions: Extension.set, limits: Limits, module: Module,
 }
 type Catch(tag: TagDecl, exnref: bool, depth: u32) {
 }
-type ContHandler(tag: TagDecl, depth: u32) {
-
+type SusHandler {
+	case Suspend(t: TagDecl, depth: u32);
+	case Switch(t: TagDecl);
 }


### PR DESCRIPTION
An update in the stack switching proposal changed the bytecode format for `resume` and `resume_throw`. This PR updates the corresponding parts in Wizard.