### PR TITLE
Remove excessive spaces for parsing opcode mnemonics

### DIFF
--- a/src/engine/Opcodes.v3
+++ b/src/engine/Opcodes.v3
@@ -799,10 +799,27 @@ component Opcodes {
 			if (ch >= '0' && ch <= '9') continue;
 			if (ch == '_') continue;
 			if (ch == '.') continue;
-			if (ch == ' ') continue; // TODO: handles ref.test null
 			break;
 		}
-		if (p > 0) return findByName(Ranges.dup(str[0 ... p]));
+		if (p > 0) {
+			def op = findByName(Ranges.dup(str[0 ... p]));
+			// ref.test and ref.cast have null versions with a space in the opcode name,
+			// so we check those opcodes to see if it has null at the end
+			match (op) {
+				REF_TEST => {
+					if (str.length >= p + 4 && Ranges.equal(str[p ... (p + 5)], " null")) {
+						return Opcode.REF_TEST_NULL;
+					}
+				}
+				REF_CAST => {
+					if (str.length >= p + 4 && Ranges.equal(str[p ... (p + 5)], " null")) {
+						return Opcode.REF_CAST_NULL;
+					}
+				}
+				_ => ;
+			}
+			return op;
+		}
 		return Opcode.INVALID;
 	}
 	def isConstant(extensions: Extension.set, op: Opcode) -> bool {


### PR DESCRIPTION
Updated `parseName` to handle `ref.test null` and `ref.cast null` without excessively eating spaces for opcodes which do not need it. I need it to parse opcodes Whamm probes as there can be spaces between the opcode mnemonic and the predicate separator.