### PR TITLE
[stack-switching] `resume_throw` Implementation

### DIFF
--- a/src/engine/Debug.v3
+++ b/src/engine/Debug.v3
@@ -4,7 +4,7 @@
 component Debug {
 	def paranoid = false;
 	def verbose = false;
-	def interpreter = false;
+	def interpreter = true;
 	def runtime = false;
 	def compiler = false;
 	def pregen = false;

--- a/src/engine/Debug.v3
+++ b/src/engine/Debug.v3
@@ -4,7 +4,7 @@
 component Debug {
 	def paranoid = false;
 	def verbose = false;
-	def interpreter = true;
+	def interpreter = false;
 	def runtime = false;
 	def compiler = false;
 	def pregen = false;

--- a/src/engine/x86-64/V3Offsets.v3
+++ b/src/engine/x86-64/V3Offsets.v3
@@ -60,6 +60,7 @@ class V3Offsets {
 	def X86_64Stack_func		= int.view(Pointer.atField(vs.func) - Pointer.atObject(vs));
 	def X86_64Stack_parent_rsp_ptr	= int.view(Pointer.atField(vs.parent_rsp_ptr) - Pointer.atObject(vs));
 	def X86_64Stack_parent		= int.view(Pointer.atField(vs.parent) - Pointer.atObject(vs));
+	def X86_64Stack_throw_on_resume		= int.view(Pointer.atField(vs.throw_on_resume) - Pointer.atObject(vs));
 	def X86_64FrameAccessor_metaRef	= int.view(Pointer.atField(acc.metaRef) - Pointer.atObject(acc));
 	def X86_64Stack_state		= int.view(Pointer.atField(vs.state_) - Pointer.atObject(vs));
 	def X86_64Stack_return_results	= int.view(Pointer.atField(vs.return_results) - Pointer.atObject(vs));

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2239,8 +2239,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 			// read info and rewind %ip (need %ip at start of opcode during call)
 			asm.movq_r_r(ip_store, r_ip);
-			// read signature index
-			genReadUleb32(cont_id);
+			genReadUleb32(cont_id); // read signature index
 			asm.movq_r_r(r_ip, ip_store);
 
 			saveCallerIVars();
@@ -2254,6 +2253,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
 
+			// read info and rewind %ip (need %ip at start of opcode during call)
 			asm.movq_r_r(ip_store, r_ip);
 			genReadUleb32(cont_id); // read signature index
 			genReadUleb32(tag_index); // read tag index

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2291,6 +2291,128 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 				masm.emit_jump_r(xenv.scratch);
 			}
 		}
+		// TODO[ss]: merge
+		bindHandler(Opcode.RESUME_THROW); {
+			var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
+			var cont_id = r_tmp0, ip_store = r_tmp1, tag_index = r_tmp3;
+			computeCurIpForTrap(-1);
+			computePcFromCurIp();
+
+			asm.movq_r_r(ip_store, r_ip);
+			genReadUleb32(cont_id); // read signature index
+			genReadUleb32(tag_index); // read tag index
+			asm.movq_r_r(r_ip, ip_store);
+
+			var r_stack = r_tmp1;
+			asm.movq_r_m(r_stack, m_curStack);
+
+			// mov [%stack.vsp], %vsp
+			asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
+
+			saveCallerIVars();
+			callRuntime(refRuntimeCall(RT.runtime_process_resume_throw), [r_instance, cont_id, tag_index], true);
+			restoreCallerIVars();
+			asm.movq_r_m(r_stack, m_curStack);
+
+			var r_cont = r_tmp0;
+			decrementVsp(); // pop cont ref from stack
+			asm.movq_r_m(r_cont, vsph[0].value);
+
+			var resume_stub = X86_64Label.new(), done = X86_64Label.new();
+			saveCallerIVars();
+			asm.call_rel_far(resume_stub);
+			// check for error (in %rax)
+			if (FeatureDisable.stackUnwind) {
+				genAbruptRetCheck();
+			} else {
+				asm.q.cmp_r_i(r_ret_throw, 0);
+				asm.jc_rel_near(X86_64Conds.Z, done);
+				callRuntime(refRuntimeCall(RT.runtime_THROW_REF), [r_ret_throw], true);
+			}
+
+			asm.bind(done);
+			restoreDispatchTableReg();
+			restoreCallerIVars();
+			// load %stack
+			asm.movq_r_m(r_stack, m_curStack);
+			// mov %vsp, [%stack.vsp]
+			asm.movq_r_m(r_vsp, r_stack.plus(offsets.X86_64Stack_vsp));
+
+			// skip the handler table
+			var handler_length = r_tmp1;
+			genSkipLeb(); // skip cont signature
+			genSkipLeb(); // skip tag index
+			genReadUleb32(handler_length); // read handler length
+			
+			// skip handler table
+			var cnt = r_tmp3;
+			asm.movq_r_r(cnt, handler_length);
+			// loop for `cnt` times
+			var read_start = X86_64Label.new(), read_done = X86_64Label.new(), read_switch = X86_64Label.new();
+			asm.bind(read_start);
+			// while (--cnt >= 0)
+			asm.d.dec_r(cnt);
+			// goto read_done
+			asm.jc_rel_near(C.S, read_done);
+			// read handler type
+			genReadUleb32(r_scratch);
+			asm.q.cmp_r_i(r_scratch, 0);
+			// if {handler_type} is 0x01, read switch handler
+			asm.jc_rel_near(X86_64Conds.NZ, read_switch);
+			// read normal handler
+			genSkipLeb();
+			genSkipLeb();
+			asm.jmp_rel_near(read_start);
+			// read switch handler
+			asm.bind(read_switch);
+			genSkipLeb();
+			asm.jmp_rel_near(read_start);
+			asm.bind(read_done);
+
+			// adjust sidetable
+			asm.q.add_r_i(r_stp, Sidetable_ResumeEntry.size);
+			// calculate length of handler entries in sidetable
+			asm.q.imul_r_i(handler_length, Sidetable_SuspendHandlerEntry.size);
+			asm.q.add_r_r(r_stp, handler_length);
+
+			endHandler();
+
+			{
+				asm.bind(resume_stub);
+				var r_bottom = r_tmp3;
+				asm.movq_r_m(r_bottom, r_cont.plus(offsets.Continuation_bottom));
+				// mov [%r_bottom.parent_rsp_ptr], rsp
+				asm.movq_r_m(r_scratch, r_bottom.plus(offsets.X86_64Stack_parent_rsp_ptr));
+				asm.movq_m_r(r_scratch.plus(0), r_sp);
+
+				var r_new = r_tmp0;
+				asm.movq_r_m(r_new, r_cont.plus(offsets.Continuation_top));
+
+				// mov [%curStack, %new]
+				asm.movq_m_r(m_curStack, r_new);
+
+				// save before switching to new stack pointer
+				// mov [%stack.vsp], %vsp
+				asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
+				// mov [%stack.rsp], %rsp
+				asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_rsp), r_sp);
+
+				// mov %rsp, [%newStack.rsp]
+				asm.movq_r_m(r_sp, r_new.plus(offsets.X86_64Stack_rsp));
+				// mov %vsp, [%newStack.vsp]
+				asm.movq_r_m(r_vsp, r_new.plus(offsets.X86_64Stack_vsp));
+
+				// mov %ret_throw, [%newStack.throw_on_resume]
+				asm.movq_r_m(r_ret_throw, r_new.plus(offsets.X86_64Stack_throw_on_resume));
+				// mov [%newStack.throw_on_resume], 0
+				asm.movq_m_i(r_new.plus(offsets.X86_64Stack_throw_on_resume), 0);
+
+				// pop return address and jump to it
+				masm.emit_pop_r(ValueKind.REF, xenv.scratch);
+				// jump *%tmp
+				masm.emit_jump_r(xenv.scratch);
+			}
+		}
 		bindHandler(Opcode.SUSPEND); {
 			var tag_index = r_tmp0;
 			var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -511,11 +511,54 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		ic.header.hostCallStubEnd = w.pos;
 	}
 	def genStackSwitchStubs() {
+		var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
+
 		ic.header.resumeStubOffset = w.pos;
+		asm.bind(resumeStub); {
+			var r_cont = r_tmp0, r_stack = r_tmp1;
+			// pop cont ref from stack
+			decrementVsp();
+			asm.movq_r_m(r_cont, vsph[0].value);
+			// mov %stack, [%curStack]
+			asm.movq_r_m(r_stack, m_curStack);
+
+			var r_bottom = r_tmp3;
+			asm.movq_r_m(r_bottom, r_cont.plus(offsets.Continuation_bottom));
+			// mov [%r_bottom.parent_rsp_ptr], rsp
+			asm.movq_r_m(r_scratch, r_bottom.plus(offsets.X86_64Stack_parent_rsp_ptr));
+			asm.movq_m_r(r_scratch.plus(0), r_sp);
+
+			var r_new = r_tmp0;
+			asm.movq_r_m(r_new, r_cont.plus(offsets.Continuation_top));
+
+			// mov [%curStack, %new]
+			asm.movq_m_r(m_curStack, r_new);
+
+			// save before switching to new stack pointer
+			// mov [%stack.vsp], %vsp
+			asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
+			// mov [%stack.rsp], %rsp
+			asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_rsp), r_sp);
+
+			// mov %rsp, [%newStack.rsp]
+			asm.movq_r_m(r_sp, r_new.plus(offsets.X86_64Stack_rsp));
+			// mov %vsp, [%newStack.vsp]
+			asm.movq_r_m(r_vsp, r_new.plus(offsets.X86_64Stack_vsp));
+
+			// mov %ret_throw, [%newStack.throw_on_resume]
+			asm.movq_r_m(r_ret_throw, r_new.plus(offsets.X86_64Stack_throw_on_resume));
+			// mov [%newStack.throw_on_resume], 0
+			asm.movq_m_i(r_new.plus(offsets.X86_64Stack_throw_on_resume), 0);
+
+			// pop return address and jump to it
+			masm.emit_pop_r(ValueKind.REF, xenv.scratch);
+			// jump *%tmp
+			masm.emit_jump_r(xenv.scratch);
+		}
 		ic.header.resumeStubEnd = w.pos;
 
-		
 		ic.header.suspendStubOffset = w.pos;
+		asm.bind(suspendStub);
 		ic.header.suspendStubEnd = w.pos;
 	}
 	def genInterpreterEntry() {
@@ -2194,110 +2237,18 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
 
+			// read info and rewind %ip (need %ip at start of opcode during call)
 			asm.movq_r_r(ip_store, r_ip);
-			genReadUleb32(cont_id); // read signature index
+			// read signature index
+			genReadUleb32(cont_id);
 			asm.movq_r_r(r_ip, ip_store);
 
 			saveCallerIVars();
 			callRuntime(refRuntimeCall(RT.runtime_process_resume), [r_instance, cont_id], true);
-			restoreCallerIVars();
-			var r_stack = r_tmp1;
-			asm.movq_r_m(r_stack, m_curStack);
-
-			var r_cont = r_tmp0;
-			decrementVsp(); // pop cont ref from stack
-			asm.movq_r_m(r_cont, vsph[0].value);
-
-			var resume_stub = X86_64Label.new(), done = X86_64Label.new();
-			saveCallerIVars();
-			asm.call_rel_far(resume_stub);
-			// check for error (in %rax)
-			if (FeatureDisable.stackUnwind) {
-				genAbruptRetCheck();
-			} else {
-				asm.q.cmp_r_i(r_ret_throw, 0);
-				asm.jc_rel_near(X86_64Conds.Z, done);
-				callRuntime(refRuntimeCall(RT.runtime_THROW_REF), [r_ret_throw], true);
-			}
-
-			asm.bind(done);
-			restoreDispatchTableReg();
-			restoreCallerIVars();
-			// load %stack
-			asm.movq_r_m(r_stack, m_curStack);
-			// mov %vsp, [%stack.vsp]
-			asm.movq_r_m(r_vsp, r_stack.plus(offsets.X86_64Stack_vsp));
-
-			// skip the handler table
-			var handler_length = r_tmp1;
-			genSkipLeb();
-			genReadUleb32(handler_length); // read handler length
-			
-			// skip handler table
-			var cnt = r_tmp3;
-			asm.movq_r_r(cnt, handler_length);
-			// loop for `cnt` times
-			var read_start = X86_64Label.new(), read_done = X86_64Label.new(), read_switch = X86_64Label.new();
-			asm.bind(read_start);
-			// while (--cnt >= 0)
-			asm.d.dec_r(cnt);
-			// goto read_done
-			asm.jc_rel_near(C.S, read_done);
-			// read handler type
-			genReadUleb32(r_scratch);
-			asm.q.cmp_r_i(r_scratch, 0);
-			// if {handler_type} is 0x01, read switch handler
-			asm.jc_rel_near(X86_64Conds.NZ, read_switch);
-			// read normal handler
-			genSkipLeb();
-			genSkipLeb();
-			asm.jmp_rel_near(read_start);
-			// read switch handler
-			asm.bind(read_switch);
-			genSkipLeb();
-			asm.jmp_rel_near(read_start);
-			asm.bind(read_done);
-
-			// adjust sidetable
-			asm.q.add_r_i(r_stp, Sidetable_ResumeEntry.size);
-			// calculate length of handler entries in sidetable
-			asm.q.imul_r_i(handler_length, Sidetable_SuspendHandlerEntry.size);
-			asm.q.add_r_r(r_stp, handler_length);
-
+			asm.call_rel_far(resumeStub);
+			genOnResumeFinish(false);
 			endHandler();
-
-			{
-				asm.bind(resume_stub);
-				var r_bottom = r_tmp3;
-				asm.movq_r_m(r_bottom, r_cont.plus(offsets.Continuation_bottom));
-				// mov [%r_bottom.parent_rsp_ptr], rsp
-				asm.movq_r_m(r_scratch, r_bottom.plus(offsets.X86_64Stack_parent_rsp_ptr));
-				asm.movq_m_r(r_scratch.plus(0), r_sp);
-
-				var r_new = r_tmp0;
-				asm.movq_r_m(r_new, r_cont.plus(offsets.Continuation_top));
-
-				// mov [%curStack, %new]
-				asm.movq_m_r(m_curStack, r_new);
-
-				// save before switching to new stack pointer
-				// mov [%stack.vsp], %vsp
-				asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
-				// mov [%stack.rsp], %rsp
-				asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_rsp), r_sp);
-
-				// mov %rsp, [%newStack.rsp]
-				asm.movq_r_m(r_sp, r_new.plus(offsets.X86_64Stack_rsp));
-				// mov %vsp, [%newStack.vsp]
-				asm.movq_r_m(r_vsp, r_new.plus(offsets.X86_64Stack_vsp));
-
-				// pop return address and jump to it
-				masm.emit_pop_r(ValueKind.REF, xenv.scratch);
-				// jump *%tmp
-				masm.emit_jump_r(xenv.scratch);
-			}
 		}
-		// TODO[ss]: merge
 		bindHandler(Opcode.RESUME_THROW); {
 			var cont_id = r_tmp0, ip_store = r_tmp1, tag_index = r_tmp3;
 			computeCurIpForTrap(-1);
@@ -2310,108 +2261,9 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 			saveCallerIVars();
 			callRuntime(refRuntimeCall(RT.runtime_process_resume_throw), [r_instance, cont_id, tag_index], true);
-			restoreCallerIVars();
-			var r_stack = r_tmp1;
-			asm.movq_r_m(r_stack, m_curStack);
-
-			var r_cont = r_tmp0;
-			decrementVsp(); // pop cont ref from stack
-			asm.movq_r_m(r_cont, vsph[0].value);
-
-			var resume_stub = X86_64Label.new(), done = X86_64Label.new();
-			saveCallerIVars();
-			asm.call_rel_far(resume_stub);
-			// check for error (in %rax)
-			if (FeatureDisable.stackUnwind) {
-				genAbruptRetCheck();
-			} else {
-				asm.q.cmp_r_i(r_ret_throw, 0);
-				asm.jc_rel_near(X86_64Conds.Z, done);
-				callRuntime(refRuntimeCall(RT.runtime_THROW_REF), [r_ret_throw], true);
-			}
-
-			asm.bind(done);
-			restoreDispatchTableReg();
-			restoreCallerIVars();
-			// load %stack
-			asm.movq_r_m(r_stack, m_curStack);
-			// mov %vsp, [%stack.vsp]
-			asm.movq_r_m(r_vsp, r_stack.plus(offsets.X86_64Stack_vsp));
-
-			// skip the handler table
-			var handler_length = r_tmp1;
-			genSkipLeb(); // skip cont signature
-			genSkipLeb(); // skip tag index
-			genReadUleb32(handler_length); // read handler length
-			
-			// skip handler table
-			var cnt = r_tmp3;
-			asm.movq_r_r(cnt, handler_length);
-			// loop for `cnt` times
-			var read_start = X86_64Label.new(), read_done = X86_64Label.new(), read_switch = X86_64Label.new();
-			asm.bind(read_start);
-			// while (--cnt >= 0)
-			asm.d.dec_r(cnt);
-			// goto read_done
-			asm.jc_rel_near(C.S, read_done);
-			// read handler type
-			genReadUleb32(r_scratch);
-			asm.q.cmp_r_i(r_scratch, 0);
-			// if {handler_type} is 0x01, read switch handler
-			asm.jc_rel_near(X86_64Conds.NZ, read_switch);
-			// read normal handler
-			genSkipLeb();
-			genSkipLeb();
-			asm.jmp_rel_near(read_start);
-			// read switch handler
-			asm.bind(read_switch);
-			genSkipLeb();
-			asm.jmp_rel_near(read_start);
-			asm.bind(read_done);
-
-			// adjust sidetable
-			asm.q.add_r_i(r_stp, Sidetable_ResumeEntry.size);
-			// calculate length of handler entries in sidetable
-			asm.q.imul_r_i(handler_length, Sidetable_SuspendHandlerEntry.size);
-			asm.q.add_r_r(r_stp, handler_length);
-
+			asm.call_rel_far(resumeStub);
+			genOnResumeFinish(true);
 			endHandler();
-
-			{
-				asm.bind(resume_stub);
-				var r_bottom = r_tmp3;
-				asm.movq_r_m(r_bottom, r_cont.plus(offsets.Continuation_bottom));
-				// mov [%r_bottom.parent_rsp_ptr], rsp
-				asm.movq_r_m(r_scratch, r_bottom.plus(offsets.X86_64Stack_parent_rsp_ptr));
-				asm.movq_m_r(r_scratch.plus(0), r_sp);
-
-				var r_new = r_tmp0;
-				asm.movq_r_m(r_new, r_cont.plus(offsets.Continuation_top));
-
-				// mov [%curStack, %new]
-				asm.movq_m_r(m_curStack, r_new);
-
-				// save before switching to new stack pointer
-				// mov [%stack.vsp], %vsp
-				asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
-				// mov [%stack.rsp], %rsp
-				asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_rsp), r_sp);
-
-				// mov %rsp, [%newStack.rsp]
-				asm.movq_r_m(r_sp, r_new.plus(offsets.X86_64Stack_rsp));
-				// mov %vsp, [%newStack.vsp]
-				asm.movq_r_m(r_vsp, r_new.plus(offsets.X86_64Stack_vsp));
-
-				// mov %ret_throw, [%newStack.throw_on_resume]
-				asm.movq_r_m(r_ret_throw, r_new.plus(offsets.X86_64Stack_throw_on_resume));
-				// mov [%newStack.throw_on_resume], 0
-				asm.movq_m_i(r_new.plus(offsets.X86_64Stack_throw_on_resume), 0);
-
-				// pop return address and jump to it
-				masm.emit_pop_r(ValueKind.REF, xenv.scratch);
-				// jump *%tmp
-				masm.emit_jump_r(xenv.scratch);
-			}
 		}
 		bindHandler(Opcode.SUSPEND); {
 			var tag_index = r_tmp0;
@@ -3854,6 +3706,64 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 	def reportOom(w: DataWriter, nlength: int) -> DataWriter {
 		fatal("ran out of buffer space");
 		return w;
+	}
+	private def genOnResumeFinish(skip_tag: bool) {
+		var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
+		var done = X86_64Label.new();
+		// check for error (in %rax)
+		if (FeatureDisable.stackUnwind) {
+			genAbruptRetCheck();
+		} else {
+			asm.q.cmp_r_i(r_ret_throw, 0);
+			asm.jc_rel_near(X86_64Conds.Z, done);
+			callRuntime(refRuntimeCall(RT.runtime_THROW_REF), [r_ret_throw], true);
+		}
+
+		asm.bind(done);
+		restoreDispatchTableReg();
+		restoreCallerIVars();
+		var r_stack = r_tmp1;
+		// load %stack
+		asm.movq_r_m(r_stack, m_curStack);
+		// mov %vsp, [%stack.vsp]
+		asm.movq_r_m(r_vsp, r_stack.plus(offsets.X86_64Stack_vsp));
+
+		// skip the handler table
+		var handler_length = r_tmp1;
+		genSkipLeb(); // skip cont signature
+		if (skip_tag) { genSkipLeb(); } // skip throw tag
+		genReadUleb32(handler_length); // read handler length
+		
+		// skip handler table
+		var cnt = r_tmp3;
+		asm.movq_r_r(cnt, handler_length);
+		// loop for `cnt` times
+		var read_start = X86_64Label.new(), read_done = X86_64Label.new(), read_switch = X86_64Label.new();
+		asm.bind(read_start);
+		// while (--cnt >= 0)
+		asm.d.dec_r(cnt);
+		// goto read_done
+		asm.jc_rel_near(C.S, read_done);
+		// read handler type
+		genReadUleb32(r_scratch);
+		asm.q.cmp_r_i(r_scratch, 0);
+		// if {handler_type} is 0x01, read switch handler
+		asm.jc_rel_near(X86_64Conds.NZ, read_switch);
+		// read normal handler
+		genSkipLeb();
+		genSkipLeb();
+		asm.jmp_rel_near(read_start);
+		// read switch handler
+		asm.bind(read_switch);
+		genSkipLeb();
+		asm.jmp_rel_near(read_start);
+		asm.bind(read_done);
+
+		// adjust sidetable
+		asm.q.add_r_i(r_stp, Sidetable_ResumeEntry.size);
+		// calculate length of handler entries in sidetable
+		asm.q.imul_r_i(handler_length, Sidetable_SuspendHandlerEntry.size);
+		asm.q.add_r_r(r_stp, handler_length);
 	}
 }
 

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -270,6 +270,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 	var tailCallReentryLabel = X86_64Label.new();
 	var hostTailCallStubLabel = masm.newLabel(-1);
 	var hostCallStubLabel = masm.newLabel(-1);
+	var resumeStub = X86_64Label.new();
+	var suspendStub = X86_64Label.new();
 	var spcEntryLabel = X86_64Label.new();
 	var abruptRetLabel = X86_64Label.new();
 	var controlFallThruLabel = X86_64Label.new();
@@ -380,6 +382,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		reserveDispatchTables();
 		// Begin code generation
 		genHostCallStub();
+		genStackSwitchStubs();
 		genInterpreterEntry();
 		genOpcodeHandlers();
 		handlerEndOffset = w.atEnd().pos;
@@ -506,6 +509,14 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			masm.emit_jump_r(xenv.tmp2);
 		}
 		ic.header.hostCallStubEnd = w.pos;
+	}
+	def genStackSwitchStubs() {
+		ic.header.resumeStubOffset = w.pos;
+		ic.header.resumeStubEnd = w.pos;
+
+		
+		ic.header.suspendStubOffset = w.pos;
+		ic.header.suspendStubEnd = w.pos;
 	}
 	def genInterpreterEntry() {
 		var shared_entry = X86_64Label.new();
@@ -2187,15 +2198,10 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			genReadUleb32(cont_id); // read signature index
 			asm.movq_r_r(r_ip, ip_store);
 
-			var r_stack = r_tmp1;
-			asm.movq_r_m(r_stack, m_curStack);
-
-			// mov [%stack.vsp], %vsp
-			asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
-
 			saveCallerIVars();
 			callRuntime(refRuntimeCall(RT.runtime_process_resume), [r_instance, cont_id], true);
 			restoreCallerIVars();
+			var r_stack = r_tmp1;
 			asm.movq_r_m(r_stack, m_curStack);
 
 			var r_cont = r_tmp0;
@@ -2300,17 +2306,12 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			asm.movq_r_r(ip_store, r_ip);
 			genReadUleb32(cont_id); // read signature index
 			genReadUleb32(tag_index); // read tag index
-			// asm.movq_r_r(r_ip, ip_store);
-
-			var r_stack = r_tmp1;
-			asm.movq_r_m(r_stack, m_curStack);
-
-			// mov [%stack.vsp], %vsp
-			asm.movq_m_r(r_stack.plus(offsets.X86_64Stack_vsp), r_vsp);
+			asm.movq_r_r(r_ip, ip_store);
 
 			saveCallerIVars();
 			callRuntime(refRuntimeCall(RT.runtime_process_resume_throw), [r_instance, cont_id, tag_index], true);
 			restoreCallerIVars();
+			var r_stack = r_tmp1;
 			asm.movq_r_m(r_stack, m_curStack);
 
 			var r_cont = r_tmp0;
@@ -2339,8 +2340,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 			// skip the handler table
 			var handler_length = r_tmp1;
-			// genSkipLeb(); // skip cont signature
-			// genSkipLeb(); // skip tag index
+			genSkipLeb(); // skip cont signature
+			genSkipLeb(); // skip tag index
 			genReadUleb32(handler_length); // read handler length
 			
 			// skip handler table

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2099,6 +2099,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		patchDispatchTable(Opcode.EXTERN_CONVERT_ANY, firstDispatchOffset);
 	}
 	def genMisc() {
+		var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
 		bindHandler(Opcode.MEMORY_SIZE); {
 			genReadUleb32(r_tmp1);
 			asm.movq_r_m(r_tmp0, r_instance.plus(offsets.Instance_memories));
@@ -2178,7 +2179,6 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			endHandler();
 		}
 		bindHandler(Opcode.RESUME); {
-			var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
 			var cont_id = r_tmp0, ip_store = r_tmp1;
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
@@ -2293,7 +2293,6 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		}
 		// TODO[ss]: merge
 		bindHandler(Opcode.RESUME_THROW); {
-			var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
 			var cont_id = r_tmp0, ip_store = r_tmp1, tag_index = r_tmp3;
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
@@ -2301,7 +2300,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			asm.movq_r_r(ip_store, r_ip);
 			genReadUleb32(cont_id); // read signature index
 			genReadUleb32(tag_index); // read tag index
-			asm.movq_r_r(r_ip, ip_store);
+			// asm.movq_r_r(r_ip, ip_store);
 
 			var r_stack = r_tmp1;
 			asm.movq_r_m(r_stack, m_curStack);
@@ -2340,8 +2339,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 			// skip the handler table
 			var handler_length = r_tmp1;
-			genSkipLeb(); // skip cont signature
-			genSkipLeb(); // skip tag index
+			// genSkipLeb(); // skip cont signature
+			// genSkipLeb(); // skip tag index
 			genReadUleb32(handler_length); // read handler length
 			
 			// skip handler table
@@ -2415,7 +2414,6 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		}
 		bindHandler(Opcode.SUSPEND); {
 			var tag_index = r_tmp0;
-			var m_curStack = X86_64Addr.new(null, null, 1, int.view(offsets.X86_64Runtime_curStack - Pointer.NULL));
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
 			genReadUleb32(tag_index); // read tag index

--- a/src/engine/x86-64/X86_64PreGenStubs.v3
+++ b/src/engine/x86-64/X86_64PreGenStubs.v3
@@ -31,8 +31,12 @@ layout X86_64PreGenHeader {
 	+48	stackOverflowHandlerOffset:	i32;	// handler for signals caused by (value- or call-) stack overflow
 	+56	hostCallStubOffset:		i32;	// host call stub that calls runtime
 	+60	hostCallStubEnd:		i32;	// host call stub that calls runtime
-	+64	codeEnd:			i32;	// end of all executable code
-	=68;
+	+64 resumeStubOffset:		i32; // stub that handles stack switching during {resume}
+	+68 resumeStubEnd:			i32; // stub that handles stack switching during {resume}
+	+72 suspendStubOffset:	i32; // stub that handles stack switching during {suspend}
+	+76 suspendStubEnd:			i32; // stub that handles stack switching during {suspend}
+	+80	codeEnd:			i32;	// end of all executable code
+	=84;
 }
 
 layout X86_64PreGenStubOffsets {
@@ -112,6 +116,7 @@ component X86_64PreGenStubs {
 	private def ic = X86_64InterpreterCode.new(Pointer.NULL, Pointer.NULL, pregen_header);
 	private def hostCallStub = X86_64SimpleStub.new("host-call", 0);
 	private def resumeStub = X86_64SimpleStub.new("resume", 0);
+	private def suspendStub = X86_64SimpleStub.new("resume", 0);
 
 	def getInterpreterCode() -> X86_64InterpreterCode {
 		return (gen(), I.interpreterCode).last;
@@ -224,11 +229,17 @@ component X86_64PreGenStubs {
 		// The host call stub is part of interpreter code (TODO: does it need to be?)
 		hostCallStub.start = ic.start + ic.header.hostCallStubOffset;
 		hostCallStub.end = ic.start + ic.header.hostCallStubEnd;
+		resumeStub.start = ic.start + ic.header.resumeStubOffset;
+		resumeStub.end = ic.start + ic.header.resumeStubEnd;
+		suspendStub.start = ic.start + ic.header.suspendStubOffset;
+		suspendStub.end = ic.start + ic.header.suspendStubEnd;
 
 		// Register user code objects with the Virgil runtime.
 		RiRuntime.registerUserCode(ic);
 
 		RiRuntime.registerUserCode(hostCallStub);
+		RiRuntime.registerUserCode(resumeStub);
+		RiRuntime.registerUserCode(suspendStub);
 
 		// Register all stubs that have user code with the Virgil runtime.
 		for (l = global_stub_list; l != null; l = l.tail) {
@@ -246,6 +257,8 @@ component X86_64PreGenStubs {
 				.puts("Pregen interpreter and compiler stub addresses:\n")
 				.put1("\tcode start:                0x%x\n", s + ic.header.codeStart)
 				.put1("\thost call stub:     break *0x%x\n", s + ic.header.hostCallStubOffset)
+				.put1("\tresume stub:     break *0x%x\n", s + ic.header.resumeStubOffset)
+				.put1("\tsuspend stub:     break *0x%x\n", s + ic.header.suspendStubOffset)
 				.put1("\tv3->int entry:      break *0x%x\n", s + ic.header.intV3EntryOffset)
 				.put1("\tspc->int entry:     break *0x%x\n", s + ic.header.intSpcEntryOffset)
 				.put1("\tint->int entry:     break *0x%x\n", s + ic.header.intIntEntryOffset)

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -151,7 +151,6 @@ component X86_64Runtime {
 		return Runtime.CONT_BIND(curStack.setRsp(CiRuntime.callerSp()), instance, in_cont_index, out_cont_index);
 	}
 	// Handles all the necessary higher-level stack transfer operations.
-	// Returns the top of the continuation.
 	def runtime_process_resume(instance: Instance, cont_index: u32) -> Throwable {
 		var stack = X86_64Stack.!(curStack.setRsp(CiRuntime.callerSp()));
 		var cont_decl = ContDecl.!(instance.heaptypes[cont_index]);
@@ -162,11 +161,39 @@ component X86_64Runtime {
 		if (cont.used) return stack.trap(TrapReason.USED_CONTINUATION);
 		cont.used = true;
 
+		var top = X86_64Stack.!(cont.top);
 		var vals = stack.popN(cont_decl.sig.params);
-		cont.top.pushN(vals);
+		top.pushN(vals);
 
 		cont.bottom.parent = stack;
-		X86_64Stack.!(cont.top).state_ = StackState.RUNNING;
+		top.state_ = StackState.RUNNING;
+		stack.state_ = StackState.CALL_CHILD;
+
+		// XXX: use a better way to return values back on stack
+		stack.push(Value.Ref(cont));
+		return null;
+	}
+	def runtime_process_resume_throw(instance: Instance, cont_index: u32, tag_index: u32) -> Throwable {
+		var stack = X86_64Stack.!(curStack.setRsp(CiRuntime.callerSp()));
+		var cont_decl = ContDecl.!(instance.heaptypes[cont_index]);
+		var cont_ref = stack.popV(ValueType.Ref(true, HeapType.Cont(cont_decl)));
+		var cont = Continuation.!(Value.Ref.!(cont_ref).val);
+
+		// Trace.OUT.put2("CONT_ID[%d] TAG_ID[%d]", cont_index, tag_index).ln();
+		
+		if (cont == null) return stack.trap(TrapReason.NULL_DEREF);
+		if (cont.used) return stack.trap(TrapReason.USED_CONTINUATION);
+		cont.used = true;
+
+		var top = X86_64Stack.!(cont.top);
+		var tag = instance.tags[tag_index];
+		var ex = Exception.new(tag, [], null);
+		top.rsp += Pointer.SIZE;
+		top.throw(ex);
+		top.throw_on_resume = ex;
+
+		cont.bottom.parent = stack;
+		top.state_ = StackState.RUNNING;
 		stack.state_ = StackState.CALL_CHILD;
 
 		// XXX: use a better way to return values back on stack

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -187,7 +187,8 @@ component X86_64Runtime {
 
 		var top = X86_64Stack.!(cont.top);
 		var tag = instance.tags[tag_index];
-		var ex = Exception.new(tag, [], null);
+		var vals = stack.popN(tag.sig.params);
+		var ex = Exception.new(tag, vals, null);
 		top.rsp += Pointer.SIZE;
 		top.throw(ex);
 		top.throw_on_resume = ex;

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -16,6 +16,9 @@ class X86_64Stack extends WasmStack {
 	// [%parent.rsp]. In case of linking two stacks (due to one resuming the
 	// other, assert that this is {null} on the child stack and manually set it).
 	var parent_rsp_ptr: Pointer;
+	
+	// For {resume_throw}.
+	var throw_on_resume: Throwable;
 
 	var params_arity = -1;
 	var return_results: Array<ValueType>;
@@ -230,6 +233,7 @@ class X86_64Stack extends WasmStack {
 		return_results = null;
 		parent =  null;
 		parent_rsp_ptr = Pointer.NULL;
+		throw_on_resume = null;
 		func = null;
 	}
 	// def pushReenterStub() {


### PR DESCRIPTION
This PR implements `resume_throw`. It also cleans up the previous stack switching code + stack stubs in preparation for JIT implementation.