### PR TITLE
[misc] Cleaned up unused function `traceStep`

### DIFF
--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1600,32 +1600,6 @@ class V3Interpreter extends WasmStack {
 		values.top = sp;
 		return result;
 	}
-	def traceStep() { // XXX: make this a debug method
-		var OUT = Trace.OUT;
-		for (i < frame.depth) OUT.sp();
-		OUT.put1("+%d: ", codeptr.pos);  // XXX: fixed width decimal offset
-		var module = if(frame.func.instance != null, frame.func.instance.module);
-		var opcode = codeptr.data[codeptr.pos];
-		if (instrTracer == null) instrTracer = InstrTracer.new();
-		if (opcode == InternalOpcode.PROBE.code || opcode == InternalOpcode.WHAMM_PROBE.code) {
-			OUT.puts("<probe> ");
-			var prev = (codeptr.data, codeptr.pos, codeptr.limit);
-			codeptr.reset(frame.func.decl.orig_bytecode, prev.1, prev.2);
-			instrTracer.putInstr(OUT, module, codeptr);
-			codeptr.reset(prev.0, prev.1, prev.2);
-		} else {
-			instrTracer.putInstr(OUT, module, codeptr);
-		}
-		if (Trace.operands) {
-			var locals_end = frame.fp + frame.func.decl.num_locals - 1;
-			for (i = frame.fp; i < values.top; i++) {
-				var v = values.elems[i];
-				OUT.putv(v).sp();
-				if (i == locals_end) OUT.puts(" | ");
-			}
-		}
-		OUT.ln();
-	}
 	// XXX: reduce duplication of d_xx_x methods
 	def do_dd_d(f: (double, double) -> double) {
 		var y = Values.unbox_d(values.elems[values.top-1]);


### PR DESCRIPTION
Instruction tracing for `V3Interpreter` has been moved to probes, so `traceStep` is unused. This PR removes it.