### PR TITLE
[gc] Fast interpreter should use curpc to restore start of instruction instead of interior bytecode pointer

### DIFF
--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -89,6 +89,7 @@ class X86_64InterpreterCode extends RiUserCode {
 		if (func == null) buf.puts("(func=null)");
 		else if (instance == null) func.render(null, buf);
 		else func.render(instance.module.names, buf);
+		if (Debug.stack) buf.put2(" [ip=0x%x, sp=0x%x]", ip - Pointer.NULL, sp - Pointer.NULL);
 		buf.ln().send(out);
 		buf.reset();
 	}
@@ -103,6 +104,12 @@ class X86_64InterpreterCode extends RiUserCode {
 	// Called from V3 runtime when the garbage collector needs to scan an interpreter stack frame.
 	def scanFrame(ip: Pointer, sp: Pointer) {
 		// Handle code and interior pointers
+		if (Debug.stack) {
+			var buf = X86_64Runtime.globalFrameDescriptionBuf;
+			buf.put2("scanInterpreterFrame [ip=0x%x, sp=0x%x]", ip - Pointer.NULL, sp - Pointer.NULL).ln().send(Trace.STDOUT);
+			buf.reset();
+		}
+
 		var code_loc = (sp + X86_64InterpreterFrame.code.offset);
 		var code = code_loc.load<Pointer>();
 		var ip_delta = (sp + X86_64InterpreterFrame.ip.offset).load<Pointer>() - code;
@@ -2109,6 +2116,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			genSkipLeb();            	// skip target label
 			genSkipLeb();            	// skip src heaptype
 			genReadSleb32_inline(r_tmp1);	// read dest heaptype
+			computePcFromCurIp();
 			saveCallerIVars();
 			callRuntime(refRuntimeCall(RT.runtime_doCast), [r_instance, nullable_reg, r_tmp1], false);
 			restoreCurPcFromFrame();
@@ -2116,7 +2124,10 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			restoreCallerIVars();
 			var cond = if(t.0, C.Z, C.NZ); // TODO: br_on_cast/fail only differ on condition
 			asm.jc_rel_far(cond, controlSkipSidetableAndDispatchLabel); // XXX: relies on no changes to flags
-			restoreIpFromCurIp(-1); // TODO: sidetable entries are relative to current IP; we are at nextIP
+			asm.movq_r_m(r_tmp1, m_code);
+			// TODO: we recompute the start of the current instruction from the curpc and the code object,
+			//       because the sidetable entry's delta_ip is encoded relative to 1 + curpc
+			asm.lea(r_ip, X86_64Addr.new(r_tmp1, r_curpc, 1, 1 + offsets.Array_contents));
 			asm.jmp_rel_far(controlTransferLabel);
 		}
 		bindHandler(Opcode.REF_AS_NON_NULL); {
@@ -3631,9 +3642,6 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 	}
 	def computeCurIpFromIp(delta: int) {
 		asm.q.lea(r_curpc, X86_64Addr.new(r_ip, null, 1, delta - offsets.Array_contents));
-	}
-	def restoreIpFromCurIp(delta: int) {
-		asm.q.lea(r_ip, r_curpc.plus(0 - (delta - offsets.Array_contents)));
 	}
 	def computePcFromCurIp() {
 		if (!FeatureDisable.stacktraces) asm.q.sub_r_m(r_curpc, m_code);

--- a/test/regress/big/br_on_cast99.wast
+++ b/test/regress/big/br_on_cast99.wast
@@ -1,0 +1,59 @@
+(module
+  (type $t1 (sub (struct)))
+  (type $t2 (sub final (struct)))
+
+
+  (func $make (param i32) (result anyref)
+    (if (i32.eq (i32.const 0) (local.get 0))
+      (then (return (ref.i31 (i32.const 11)))))
+    (if (i32.eq (i32.const 1) (local.get 0))
+      (then (return (struct.new_default $t1))))
+    (if (i32.eq (i32.const 2) (local.get 0))
+      (then (return (struct.new_default $t2))))
+    (ref.null any)
+  )
+
+  (func $casts (param anyref)
+   (block (result anyref)
+    (br_on_cast 0 anyref structref (local.get 0))
+    drop
+    (br_on_cast 0 anyref arrayref (local.get 0))
+    drop
+    (br_on_cast 0 anyref i31ref (local.get 0))
+   )
+   drop
+  )
+
+  (func (export "do") (param i32 i32)
+    (loop
+       (call $casts (call $make (local.get 1)))
+       (br_if 0 (local.tee 0 (i32.sub (local.get 0) (i32.const 1))))
+    )
+    
+  )
+)
+
+(assert_return (invoke "do" (i32.const 100) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 100) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 100) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 100) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 1000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 1000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 1000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 1000) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 10_000_000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 10_000_000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 10_000_000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 10_000_000) (i32.const 3)))

--- a/test/regress/big/ref_cast99.wast
+++ b/test/regress/big/ref_cast99.wast
@@ -1,0 +1,59 @@
+(module
+  (type $t1 (sub (struct)))
+  (type $t2 (sub final (struct)))
+
+
+  (func $make (param i32) (result anyref)
+    (if (i32.eq (i32.const 0) (local.get 0))
+      (then (return (ref.i31 (i32.const 11)))))
+    (if (i32.eq (i32.const 1) (local.get 0))
+      (then (return (struct.new_default $t1))))
+    (if (i32.eq (i32.const 2) (local.get 0))
+      (then (return (struct.new_default $t2))))
+    (ref.null any)
+  )
+
+  (func $casts (param anyref)
+    (if (ref.test structref (local.get 0))
+      (then (drop (ref.cast structref (local.get 0)))))
+    (if (ref.test arrayref (local.get 0))
+      (then (drop (ref.cast arrayref (local.get 0)))))
+    (if (ref.test eqref (local.get 0))
+      (then (drop (ref.cast eqref (local.get 0)))))
+    (if (ref.test i31ref (local.get 0))
+      (then (drop (ref.cast i31ref (local.get 0)))))
+  )
+
+  (func (export "do") (param i32 i32)
+    (loop
+       (call $casts (call $make (local.get 1)))
+       (br_if 0 (local.tee 0 (i32.sub (local.get 0) (i32.const 1))))
+    )
+    
+  )
+)
+
+(assert_return (invoke "do" (i32.const 100) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 100) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 100) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 100) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 1000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 1000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 1000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 1000) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 10_000) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 100_000) (i32.const 3)))
+
+(assert_return (invoke "do" (i32.const 1_000_000) (i32.const 0)))
+(assert_return (invoke "do" (i32.const 1_000_000) (i32.const 1)))
+(assert_return (invoke "do" (i32.const 1_000_000) (i32.const 2)))
+(assert_return (invoke "do" (i32.const 1_000_000) (i32.const 3)))

--- a/test/unittest/ExeTest.v3
+++ b/test/unittest/ExeTest.v3
@@ -2734,10 +2734,10 @@ def test_br_on_cast(t: ExeTester) {
 		Opcode.UNREACHABLE.code
 	]);
 	var fail = TrapReason.UNREACHABLE;
+	t.args_r(x.o2a).assert2_r(x.o2a);
 	t.args_r(null).assert2_trap(fail);
 	t.args_r(x.o1).assert2_trap(fail);
 	t.args_r(x.o1).assert2_trap_at(fail, [9]);
-	t.args_r(x.o2a).assert2_r(x.o2a);
 }
 
 def test_br_on_cast_null(t: ExeTester) {


### PR DESCRIPTION
Fixes #308 