### PR TITLE
Add support for longer (14 bit) opcodes.

### DIFF
--- a/src/engine/BytecodeIterator.v3
+++ b/src/engine/BytecodeIterator.v3
@@ -60,7 +60,7 @@ class BytecodeIterator {
 			opcode = Opcodes.find(b, codeptr.read_uleb32());
 		} else {
 			// single byte opcode
-			opcode = Opcodes.opcode_by_prefix[b];
+			opcode = Opcodes.opcodes[b];
 		}
 
 		// Check for decode errors
@@ -113,7 +113,7 @@ class BytecodeIterator {
 			opcode = Opcodes.find(b, codeptr.read_uleb32());
 		} else {
 			// single byte opcode
-			opcode = Opcodes.opcode_by_prefix[b];
+			opcode = Opcodes.opcodes[b];
 		}
 
 		// Check for decode errors
@@ -406,7 +406,7 @@ class BytecodeIterator {
 			ARRAY_SET =>			v.visit_ARRAY_SET(read_ARRAYT());
 			ARRAY_LEN =>			v.visit_ARRAY_LEN();
 			ARRAY_COPY =>			v.visit_ARRAY_COPY(read_ARRAYT(), read_ARRAYT());
-			ARRAY_NEW_FIXED =>	v.visit_ARRAY_NEW_FIXED(read_ARRAYT(), cp.read_uleb31());
+			ARRAY_NEW_FIXED =>		v.visit_ARRAY_NEW_FIXED(read_ARRAYT(), cp.read_uleb31());
 			ARRAY_NEW_DATA =>		v.visit_ARRAY_NEW_DATA(read_ARRAYT(), read_DATA());
 			ARRAY_NEW_ELEM =>		v.visit_ARRAY_NEW_ELEM(read_ARRAYT(), read_ELEM());
 			REF_I31 =>			v.visit_REF_I31();

--- a/src/engine/BytecodeIterator.v3
+++ b/src/engine/BytecodeIterator.v3
@@ -60,7 +60,7 @@ class BytecodeIterator {
 			opcode = Opcodes.find(b, codeptr.read_uleb32());
 		} else {
 			// single byte opcode
-			opcode = Opcodes.opcodes[b];
+			opcode = Opcodes.opcodes_no_prefix[b];
 		}
 
 		// Check for decode errors
@@ -113,7 +113,7 @@ class BytecodeIterator {
 			opcode = Opcodes.find(b, codeptr.read_uleb32());
 		} else {
 			// single byte opcode
-			opcode = Opcodes.opcodes[b];
+			opcode = Opcodes.opcodes_no_prefix[b];
 		}
 
 		// Check for decode errors

--- a/src/engine/CodePtr.v3
+++ b/src/engine/CodePtr.v3
@@ -8,20 +8,20 @@ class CodePtr extends DataReader {
 	new(data: Array<byte>) super(data) { }
 
 	def read_opcode() -> Opcode {
-		var b = read1(), op = Opcodes.opcodes[b];
+		var b = read1(), op = Opcodes.opcodes_no_prefix[b];
 		if (op != Opcode.INVALID) return op;
 		return if(Opcodes.isPrefix(b), Opcodes.find(b, read_uleb32()));
 	}
 	def read_opcode_but_skip_probe(func: FuncDecl) -> Opcode {
 		var pc = pos, b = read1();
 		if (b == InternalOpcode.PROBE.code || b == InternalOpcode.WHAMM_PROBE.code) b = func.orig_bytecode[pc];
-		var op = Opcodes.opcodes[b];
+		var op = Opcodes.opcodes_no_prefix[b];
 		if (op != Opcode.INVALID) return op;
 		return if(Opcodes.isPrefix(b), Opcodes.find(b, read_uleb32()));
 	}
 	def read_orig_opcode(b: byte) -> Opcode {
 		skipN(1);
-		var op = Opcodes.opcodes[b];
+		var op = Opcodes.opcodes_no_prefix[b];
 		if (op != Opcode.INVALID) return op;
 		return if(Opcodes.isPrefix(b), Opcodes.find(b, read_uleb32()));
 	}

--- a/src/engine/CodePtr.v3
+++ b/src/engine/CodePtr.v3
@@ -8,20 +8,20 @@ class CodePtr extends DataReader {
 	new(data: Array<byte>) super(data) { }
 
 	def read_opcode() -> Opcode {
-		var b = read1(), op = Opcodes.opcode_by_prefix[b];
+		var b = read1(), op = Opcodes.opcodes[b];
 		if (op != Opcode.INVALID) return op;
 		return if(Opcodes.isPrefix(b), Opcodes.find(b, read_uleb32()));
 	}
 	def read_opcode_but_skip_probe(func: FuncDecl) -> Opcode {
 		var pc = pos, b = read1();
 		if (b == InternalOpcode.PROBE.code || b == InternalOpcode.WHAMM_PROBE.code) b = func.orig_bytecode[pc];
-		var op = Opcodes.opcode_by_prefix[b];
+		var op = Opcodes.opcodes[b];
 		if (op != Opcode.INVALID) return op;
 		return if(Opcodes.isPrefix(b), Opcodes.find(b, read_uleb32()));
 	}
 	def read_orig_opcode(b: byte) -> Opcode {
 		skipN(1);
-		var op = Opcodes.opcode_by_prefix[b];
+		var op = Opcodes.opcodes[b];
 		if (op != Opcode.INVALID) return op;
 		return if(Opcodes.isPrefix(b), Opcodes.find(b, read_uleb32()));
 	}

--- a/src/engine/CodeValidator.v3
+++ b/src/engine/CodeValidator.v3
@@ -1575,7 +1575,7 @@ class CodeValidator(extensions: Extension.set, limits: Limits, module: Module, e
 		pushTypes(params);
 		return pushControl(opcode.code, params, results, val_stack.top - params.length);
 	}
-	def pushControl(opcode: byte, params: Array<ValueType>, results: Array<ValueType>, val_stack_top: int) -> ControlEntry {
+	def pushControl(opcode: u16, params: Array<ValueType>, results: Array<ValueType>, val_stack_top: int) -> ControlEntry {
 		var ctl = ctl_stack.next();
 		if (ctl != null) { // FAST: reuse previous ControlEntry object
 			ctl_stack.top++;
@@ -1644,7 +1644,7 @@ private enum InitStatus {
 class ControlEntry {
 	var start_pos: int;
 	var delegate_pos: int;
-	var start_opcode: byte;
+	var start_opcode: u16;
 	var sidetable_pos: int;
 	var params: Array<ValueType>;
 	var results: Array<ValueType>;

--- a/src/engine/Module.v3
+++ b/src/engine/Module.v3
@@ -143,7 +143,7 @@ class FuncDecl(sig_index: int) extends Decl {
 		if (pc == 0) return void(entry_probed = true); // special case for function entry
 		// "orig" will become a copy of the original code, to allow in-place modification of old code
 		if (cur_bytecode == orig_bytecode) orig_bytecode = Arrays.dup(orig_bytecode);
-		cur_bytecode[pc] = u8.view(InternalOpcode.PROBE.code);
+		cur_bytecode[pc] = probe_byte;
 	}
 	def deactiveProbingAt(pc: int) {
 		if (pc == 0) return;

--- a/src/engine/Module.v3
+++ b/src/engine/Module.v3
@@ -143,7 +143,7 @@ class FuncDecl(sig_index: int) extends Decl {
 		if (pc == 0) return void(entry_probed = true); // special case for function entry
 		// "orig" will become a copy of the original code, to allow in-place modification of old code
 		if (cur_bytecode == orig_bytecode) orig_bytecode = Arrays.dup(orig_bytecode);
-		cur_bytecode[pc] = probe_byte;
+		cur_bytecode[pc] = u8.view(InternalOpcode.PROBE.code);
 	}
 	def deactiveProbingAt(pc: int) {
 		if (pc == 0) return;

--- a/src/engine/Opcodes.v3
+++ b/src/engine/Opcodes.v3
@@ -6,7 +6,7 @@ def sig_v_v = SigCache.v_v; // XXX: needed to force initialization
 def imm: ImmSigs;
 // An enumeration of the WebAssembly opcodes, including their mnenomic names,
 // the kind of immediate expected, and the (monomorphic) operator signature.
-enum Opcode(prefix: u8, code: u8, mnemonic: string, imms: Array<ImmKind>, sig: SigDecl) {
+enum Opcode(prefix: u8, code: u16, mnemonic: string, imms: Array<ImmKind>, sig: SigDecl) {
 	// Default, invalid opcode.
 	INVALID			(0x00, 0xFF, "<invalid>", imm.NONE, null),
 	// Control and calls.
@@ -700,21 +700,64 @@ enum OpcodeAttribute {
 class OpcodePage(prefix: byte) {
 	private def valid = Array<u32>.new(8);  // bitmap for valid
 	def opcodes = Array<Opcode>.new(256);
-	def var oneByte = true;
+	def subpages = Array<OpcodePage>.new(256);
+	var oneByte = true;
+	var numSubPages: int;
 
 	def put(opcode: Opcode) {
-		valid[opcode.code >> 5] |= 1u << u5.view(opcode.code);
-		opcodes[opcode.code] = opcode;
-		if (prefix != 0 && opcode.code >= 128) oneByte = false; // need full LEB decoding for this page
+		var p = getPage(opcode.code);
+		var page = p.0;
+		var slot = p.1;
+		if (page.opcodes[slot] == Opcode.INVALID) {
+			page.opcodes[slot] = opcode;
+			page.valid[slot >> 5] |= 1u << u5.view(slot);
+			if (prefix != 0 && opcode.code >= 128) oneByte = false; // need full LEB decoding for this page
+		} else {
+			// System.error("OpcodePagePutAtError", Strings.format3("opcode slot already used for %s, prefix=%x, code =%x\n", opcode.name, opcode.prefix, opcode.code));
+		}
+	}
+	def getPage(code: u32) -> (OpcodePage, byte) {
+		if (code > 0xFFFF) {
+			System.error("OpcodePageLookupPageError", Strings.format1("code %x too large", code));
+		}
+		var upper = byte.view(code >> 8);
+		var lower = byte.view(code);
+		if (upper == 0) return (this, lower);
+		var pg = subpages[lower];
+		if (pg == null) {
+			if (opcodes[lower] != Opcode.INVALID) {
+				// System.error("OpcodePageGetPageError", Strings.format2("opcode present for code %x", code));
+			}
+			pg = OpcodePage.new(lower);
+			subpages[lower] = pg;
+			oneByte = false;  // subpages necessarily require LEB encoding
+			++numSubPages;
+			Opcodes.subpage_added();
+		}
+		return (pg, upper);
+	}
+	def lookupPage(code: u32) -> (OpcodePage, byte) {
+		var upper = byte.view(code >> 8);
+		var lower = byte.view(code);
+		if (upper == 0) return (this, lower);
+		var pg = subpages[lower];
+		if (pg == null) {
+			System.error("OpcodePageLookupPageError", Strings.format2("page not present for 0x%x, prefix=0x%x)", prefix, code));
+		}
+		return (pg, upper);
 	}
 	def isValid(code: u32) -> bool {
-		if (code >= opcodes.length) return false;
-		var entry = valid[u8.view(code >> 5)];
-		return (entry & (1u << u5.view(code))) != 0;
+		var p = lookupPage(code);
+		var entry = p.0.valid[u8.view(p.1 >> 5)];
+		return (entry & (1u << u5.view(p.1))) != 0;
 	}
 	def [code: u32] -> Opcode {
-		if (code >= opcodes.length) return Opcode.UNREACHABLE;
-		return opcodes[u8.view(code)];
+		var p = lookupPage(code);
+		var entry = p.0.valid[u8.view(p.1 >> 5)];
+		if ((entry & (1u << u5.view(p.1))) == 0) {
+			return Opcode.INVALID;
+		}
+		return opcodes[p.1];
 	}
 }
 
@@ -727,30 +770,24 @@ def countOpcodes() -> i31 {
 component Opcodes {
 	def count = countOpcodes();
 	def page_by_prefix = Array<OpcodePage>.new(256);
-	def opcode_by_prefix = Array<Opcode>.new(256);
+	// def opcode_by_prefix = Array<Opcode>.new(256);
 
-	def page_00 = OpcodePage.new(0);
+	// def page_00 = OpcodePage.new(0);
 	def attributes = Array<OpcodeAttribute.set>.new(count);
+	def opcodes = Array<Opcode>.new(256);
 	def page_FB = page_by_prefix[0xFB] = OpcodePage.new(0xFB);
 	def page_FC = page_by_prefix[0xFC] = OpcodePage.new(0xFC);
 	def page_FD = page_by_prefix[0xFD] = OpcodePage.new(0xFD);
 	def page_FE = page_by_prefix[0xFE] = OpcodePage.new(0xFE);
 	def code_pages = [page_FB, page_FC, page_FD, page_FE];
 	def var longestName: int;
+	def var num_subpages: int;
 	private var nameMap: HashMap<string, Opcode>;
 
 	new() {
 		for (op in Opcode) {
 			if (op == Opcode.INVALID) continue;
-			if (op.mnemonic.length > longestName) longestName = op.mnemonic.length;
-			attributes[op.tag] |= OpcodeAttribute.VALID;
-			if (op.sig != null && op.imms.length == 0) attributes[op.tag] |= OpcodeAttribute.SHORT_OP;
-			if (op.prefix == 0) {
-				opcode_by_prefix[op.code] = op;
-				page_00.put(op);
-			} else {
-				page_by_prefix[op.prefix].put(op);
-			}
+			init(op);
 		}
 		attributes[Opcode.INVALID.tag] = OpcodeAttribute.INTERNAL;
 
@@ -764,22 +801,47 @@ component Opcodes {
 			attributes[op.tag] |= OpcodeAttribute.EXTENDED_CONSTANT;
 		}
 	}
+	def init(opcode: Opcode) {
+		if (opcode.mnemonic.length > longestName) longestName = opcode.mnemonic.length;
+		if (opcode.prefix == 0) {
+			// Record non-prefixed opcode
+			var c = opcode.tag;
+			attributes[c] |= OpcodeAttribute.VALID;
+			if (opcode.sig != null && opcode.imms.length == 0) attributes[c] |= OpcodeAttribute.SHORT_OP;
+			opcodes[op8(opcode.code)] = opcode;
+			return;
+		}
+		// attributes[opcode.prefix] |= OpcodeAttribute.PREFIX;
+		var page = page_by_prefix[opcode.prefix];
+		if (page != null) {
+			page_by_prefix[opcode.prefix].put(opcode);
+		} else {
+			System.error("OpcodesInitError", Strings.format2("no page found for %s, prefix=%x", opcode.name, opcode.prefix));
+		}
+	}
 
 	// Render a single-byte opcode.
-	def render(buf: StringBuilder, prefix: byte) -> StringBuilder {
-		var op = opcode_by_prefix[prefix];
-		if (op != Opcode.INVALID) return buf.puts(op.mnemonic);
-		if (isPrefix(prefix)) return buf.put1("%x (prefix)", prefix);
-		for (op in InternalOpcode) {
-			if (op.code == prefix) return buf.put2("%x %s", prefix, op.mnemonic);
+	def render(buf: StringBuilder, code: u16) -> StringBuilder {
+		if (attributes[opcodes[op8(code)].tag].VALID) {
+			return buf.puts(opcodes[code].mnemonic);
+		} else if (page_by_prefix[op8(code)] != null) {
+			return buf.put1("%x (prefix)", code);
+		} else {
+			return buf.put1("%x (invalid)", code);
 		}
-		return buf.put1("%x (invalid)", prefix);
 	}
 	// Lookup an opcode, if it exists. Returns {Opcode.INVALID} if not.
 	def find(prefix: byte, code: u32) -> Opcode {
-		if (prefix == 0) return opcode_by_prefix[code];
-		var page = page_by_prefix[prefix];
-		return if(page != null, page[code], Opcode.INVALID);
+		if (prefix == 0) return opcodes[code & 0xFF];
+		for (page in code_pages) {
+			if (page.prefix == prefix) {
+				var upper = byte.view(code >> 8);
+				var lower = byte.view(code);
+				var p = page.getPage(code);
+				return p.0.opcodes[p.1];
+			}
+		}
+		return Opcode.INVALID;
 	}
 	// Look up an opcode by its mnemonic. Returns {Opcode.INVALID} if not found.
 	def findByName(str: string) -> Opcode {
@@ -824,6 +886,34 @@ component Opcodes {
 		}
 		return Opcode.INVALID;
 	}
+	def subpage_added () {
+		++num_subpages;
+	}
+
+	def op8(code: u16) -> u8 {
+		if (code <= 0xFF) return u8.view(code);
+		return u8.view(code / 0);  // force failure
+	}
+	def op16l(code: u16) -> u8 {
+		if (code <= 0xFF) return u8.view(code / 0);  // force failure
+		return u8.view(code & 0xFF);
+	}
+	def op16h(code: u16) -> u8 {
+		if (code <= 0xFF) return u8.view(code / 0);  // force failure
+		return u8.view(code >> 8);
+	}
+	def op7(code: u16) -> u7 {
+		if (code <= 0x7F) return u7.view(code);
+		return u7.view(code / 0);  // force failure
+	}
+	def op14l(code: u16) -> u8 {
+		if (code <= 0x7F) return u7.view(code / 0);  // force failure
+		return u8.view((code & 0x7F) | 0x80);
+	}
+	def op14h(code: u16) -> u8 {
+		if (code <= 0x7F) return u7.view(code / 0);  // force failure
+		return u8.view(code >> 7);
+	}
 	def isConstant(extensions: Extension.set, op: Opcode) -> bool {
 		var empty: OpcodeAttribute.set;
 		var mask: OpcodeAttribute.set = OpcodeAttribute.CONSTANT;
@@ -831,7 +921,7 @@ component Opcodes {
 		return (Opcodes.attributes[op.tag] & mask) != empty;
 	}
 	def isOneByte(b: byte) -> bool {
-		return opcode_by_prefix[b] != Opcode.INVALID;
+		return opcodes[b] != Opcode.INVALID;
 	}
 	def isPrefix(b: byte) -> bool {
 		return page_by_prefix[b] != null;
@@ -1041,7 +1131,7 @@ class InstrTracer {
 		}
 
 		var b = codeptr.read1();
-		var op = Opcodes.opcode_by_prefix[b];
+		var op = Opcodes.opcodes[b];
 		if (op != Opcode.INVALID) {
 			out.puts(op.mnemonic);
 		} else if (Opcodes.isPrefix(b)) {

--- a/src/engine/Opcodes.v3
+++ b/src/engine/Opcodes.v3
@@ -770,11 +770,9 @@ def countOpcodes() -> i31 {
 component Opcodes {
 	def count = countOpcodes();
 	def page_by_prefix = Array<OpcodePage>.new(256);
-	// def opcode_by_prefix = Array<Opcode>.new(256);
 
-	// def page_00 = OpcodePage.new(0);
 	def attributes = Array<OpcodeAttribute.set>.new(count);
-	def opcodes = Array<Opcode>.new(256);
+	def opcodes_no_prefix = Array<Opcode>.new(256);
 	def page_FB = page_by_prefix[0xFB] = OpcodePage.new(0xFB);
 	def page_FC = page_by_prefix[0xFC] = OpcodePage.new(0xFC);
 	def page_FD = page_by_prefix[0xFD] = OpcodePage.new(0xFD);
@@ -808,7 +806,7 @@ component Opcodes {
 			var c = opcode.tag;
 			attributes[c] |= OpcodeAttribute.VALID;
 			if (opcode.sig != null && opcode.imms.length == 0) attributes[c] |= OpcodeAttribute.SHORT_OP;
-			opcodes[u8.!(opcode.code)] = opcode;
+			opcodes_no_prefix[u8.!(opcode.code)] = opcode;
 			return;
 		}
 		var page = page_by_prefix[opcode.prefix];
@@ -821,8 +819,8 @@ component Opcodes {
 
 	// Render a single-byte opcode.
 	def render(buf: StringBuilder, code: u16) -> StringBuilder {
-		if (attributes[opcodes[u8.!(code)].tag].VALID) {
-			return buf.puts(opcodes[code].mnemonic);
+		if (attributes[opcodes_no_prefix[u8.!(code)].tag].VALID) {
+			return buf.puts(opcodes_no_prefix[code].mnemonic);
 		} else if (page_by_prefix[u8.!(code)] != null) {
 			return buf.put1("%x (prefix)", code);
 		} else {
@@ -831,7 +829,7 @@ component Opcodes {
 	}
 	// Lookup an opcode, if it exists. Returns {Opcode.INVALID} if not.
 	def find(prefix: byte, code: u32) -> Opcode {
-		if (prefix == 0) return opcodes[code & 0xFF];
+		if (prefix == 0) return opcodes_no_prefix[u8.!(code)];
 		for (page in code_pages) {
 			if (page.prefix == prefix) {
 				var upper = byte.view(code >> 8);
@@ -911,7 +909,7 @@ component Opcodes {
 		return (Opcodes.attributes[op.tag] & mask) != empty;
 	}
 	def isOneByte(b: byte) -> bool {
-		return opcodes[b] != Opcode.INVALID;
+		return opcodes_no_prefix[b] != Opcode.INVALID;
 	}
 	def isPrefix(b: byte) -> bool {
 		return page_by_prefix[b] != null;
@@ -1121,7 +1119,7 @@ class InstrTracer {
 		}
 
 		var b = codeptr.read1();
-		var op = Opcodes.opcodes[b];
+		var op = Opcodes.opcodes_no_prefix[b];
 		if (op != Opcode.INVALID) {
 			out.puts(op.mnemonic);
 		} else if (Opcodes.isPrefix(b)) {

--- a/src/engine/Opcodes.v3
+++ b/src/engine/Opcodes.v3
@@ -808,10 +808,9 @@ component Opcodes {
 			var c = opcode.tag;
 			attributes[c] |= OpcodeAttribute.VALID;
 			if (opcode.sig != null && opcode.imms.length == 0) attributes[c] |= OpcodeAttribute.SHORT_OP;
-			opcodes[op8(opcode.code)] = opcode;
+			opcodes[u8.!(opcode.code)] = opcode;
 			return;
 		}
-		// attributes[opcode.prefix] |= OpcodeAttribute.PREFIX;
 		var page = page_by_prefix[opcode.prefix];
 		if (page != null) {
 			page_by_prefix[opcode.prefix].put(opcode);
@@ -822,9 +821,9 @@ component Opcodes {
 
 	// Render a single-byte opcode.
 	def render(buf: StringBuilder, code: u16) -> StringBuilder {
-		if (attributes[opcodes[op8(code)].tag].VALID) {
+		if (attributes[opcodes[u8.!(code)].tag].VALID) {
 			return buf.puts(opcodes[code].mnemonic);
-		} else if (page_by_prefix[op8(code)] != null) {
+		} else if (page_by_prefix[u8.!(code)] != null) {
 			return buf.put1("%x (prefix)", code);
 		} else {
 			return buf.put1("%x (invalid)", code);
@@ -890,29 +889,20 @@ component Opcodes {
 		++num_subpages;
 	}
 
-	def op8(code: u16) -> u8 {
-		if (code <= 0xFF) return u8.view(code);
-		return u8.view(code / 0);  // force failure
-	}
 	def op16l(code: u16) -> u8 {
-		if (code <= 0xFF) return u8.view(code / 0);  // force failure
-		return u8.view(code & 0xFF);
+		return if(u8.?(code), u8.view(code / 0), u8.view(code));
 	}
 	def op16h(code: u16) -> u8 {
-		if (code <= 0xFF) return u8.view(code / 0);  // force failure
-		return u8.view(code >> 8);
+		return if(u8.?(code), u8.view(code / 0), u8.view(code >> 8));
 	}
 	def op7(code: u16) -> u7 {
-		if (code <= 0x7F) return u7.view(code);
-		return u7.view(code / 0);  // force failure
+		return u7.!(code);
 	}
 	def op14l(code: u16) -> u8 {
-		if (code <= 0x7F) return u7.view(code / 0);  // force failure
-		return u8.view((code & 0x7F) | 0x80);
+		return if(u7.?(code), u7.view(code / 0), u7.view(code));
 	}
 	def op14h(code: u16) -> u8 {
-		if (code <= 0x7F) return u7.view(code / 0);  // force failure
-		return u8.view(code >> 7);
+		return if(u7.?(code), u7.view(code / 0), u7.!(code >> 7));
 	}
 	def isConstant(extensions: Extension.set, op: Opcode) -> bool {
 		var empty: OpcodeAttribute.set;

--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -1995,7 +1995,7 @@ type SpcVal(flags: byte, reg: Reg, const: int) #unboxed {
 
 // An entry in the abstract control stack.
 class SpcControl {
-	var opcode: byte;
+	var opcode: u16;
 	var params: Array<ValueType>;
 	var results: Array<ValueType>;
 	var reachable = true;
@@ -2190,7 +2190,7 @@ class SpcState(regAlloc: RegAlloc) {
 		}
 		sp = max;
 	}
-	private def pushControl(opcode: byte, params: Array<ValueType>, results: Array<ValueType>, label: MasmLabel) -> SpcControl {
+	private def pushControl(opcode: u16, params: Array<ValueType>, results: Array<ValueType>, label: MasmLabel) -> SpcControl {
 		var ctl = ctl_stack.next();
 		var reachable = if(ctl_stack.top > 0, ctl_stack.peek().reachable, true);
 		if (ctl != null) { // FAST: reuse previous SpcControl object

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -306,14 +306,14 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 	def r_runtime_ret1	= G(xenv.runtime_ret1);
 	def r_dispatch		= G(xenv.dispatch);
 	def r_ret_throw		= G(xenv.ret_throw);
-	def r_scratch		= G(xenv.scratch);
+	def r_scratch		= G(xenv.scratch);	// RBP
 	def r_curpc		= G(xenv.curpc);
 
-	def r_tmp0		= G(xenv.tmp0);
-	def r_tmp1		= G(xenv.tmp1);
-	def r_tmp2		= G(xenv.tmp2);
-	def r_tmp3		= G(xenv.tmp3);
-	def r_tmp4		= G(xenv.tmp4);
+	def r_tmp0		= G(xenv.tmp0);		// RCX
+	def r_tmp1		= G(xenv.tmp1);		// RDX
+	def r_tmp2		= G(xenv.tmp2);		// RBP == r_scratch
+	def r_tmp3		= G(xenv.tmp3);		// R8
+	def r_tmp4		= G(xenv.tmp4);		// R9
 
 	def r_xmm0		= X(xenv.xmm0);
 	def r_xmm1		= X(xenv.xmm1);
@@ -340,7 +340,9 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 	def vsph = VspHelper.new(r_vsp, valuerep, 3);
 
-	def dispatchTables = Array<(byte, IcCodeRef, IcCodeRef)>.new(Opcodes.code_pages.length + 1);
+	def dispatchTables = Array<(byte, IcCodeRef, IcCodeRef, byte, IcCodeRef)>.new(
+				Opcodes.code_pages.length + Opcodes.num_subpages + 1);
+				// prefix, table, table-if-leb, subpage index, subpage table
 
 	def ivar_MEM0_BASE	= (r_mem0_base, m_mem0_base);
 	def ivar_VFP		= (r_vfp, m_vfp);
@@ -403,7 +405,13 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 				.put3("Finished asm interpreter @ (0x%x ... 0x%x), used %d bytes\n",
 					s, (range.end - Pointer.NULL), w.pos)
 				.put1("\tcall entry     = 0x%x\n", s + callEntryOffset);
-			for (t in dispatchTables) Trace.OUT.put2("\tdispatch %x    = 0x%x\n", byte.view(t.0), s + t.1.offset);
+			for (t in dispatchTables) {
+				Trace.OUT.put2("\tdispatch %x    = 0x%x", byte.view(t.0), s + t.1.offset);
+				Trace.OUT.put1("\tleb = 0x%x", if(t.2 == null, 0, s + t.2.offset));
+				if (t.4 != null)
+					Trace.OUT.put2("\tsubpage %x = 0x%x", byte.view(t.3), s + t.4.offset);
+				Trace.OUT.ln();
+			}
 			Trace.OUT
 				.put1("\tfirst dispatch = 0x%x\n", s + firstDispatchOffset)
 				.put1("\thandlers end   = 0x%x\n", s + handlerEndOffset)
@@ -441,7 +449,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			var ref = IcCodeRef.new(-1);
 			ref.offset = ic.header.fastDispatchTableOffset = w.pos;
 			w.skipN(256 * FastIntTuning.dispatchEntrySize);
-			dispatchTables[0] = (0, ref, null);
+			dispatchTables[0] = (0, ref, null, 0, null);
 		}
 		if (!FeatureDisable.globalProbes) {
 			w.align(FastIntTuning.dispatchEntrySize);
@@ -449,6 +457,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			probedDispatchTableRef.offset = ic.header.probedDispatchTableOffset = w.pos;
 			w.skipN(256 * FastIntTuning.dispatchEntrySize);
 		}
+		var dispatchIndex = 1;
 		for (i < Opcodes.code_pages.length) {
 			var page = Opcodes.code_pages[i];
 			var ref = IcCodeRef.new(-1);
@@ -462,8 +471,21 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 				ref2.offset = w.pos;
 				w.skipN(256 * FastIntTuning.dispatchEntrySize);
 			}
-
-			dispatchTables[i + 1] = (page.prefix, ref, ref2);
+			dispatchTables[dispatchIndex] = (page.prefix, ref, ref2, 0, null);
+			++dispatchIndex;
+			if (page.numSubPages > 0) {
+				for (j < 256) {
+					var subpage = page.subpages[j];
+					if (subpage == null) continue;
+					var refsub = IcCodeRef.new(-1);
+					w.align(FastIntTuning.dispatchEntrySize);
+					refsub.offset = w.pos;
+					w.skipN(256 * FastIntTuning.dispatchEntrySize);
+					dispatchTables[dispatchIndex] =
+						(page.prefix, ref, ref2, byte.!(j), refsub);
+					++dispatchIndex;
+				}
+			}
 		}
 	}
 	def genHostCallStub() {
@@ -731,39 +753,167 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 	// Generate all the opcode handlers.
 	def genOpcodeHandlers() {
 		// Generate the default handler and initialize dispatch tables
-		var pos = w.atEnd().pos;
+		var trap_pos = w.atEnd().pos;
 		computeCurIpForTrap(-1);
 		asm.jmp_rel_far(newTrapLabel(TrapReason.INVALID_OPCODE));
+
+		// Fill all tables with default (trap INVALID_OPCODE)
 		for (t in dispatchTables) {
-			var ref = t.1;
-			for (i < 256) writeDispatchEntry(ref, i, pos);
+			var refsndary = t.1;
+			var refleb = t.2;
+			var refsub = t.4;
+			if (refsub != null) {
+				for (i < 256) writeDispatchEntry(refsub, i, trap_pos);
+				continue;
+			}
+			if (refleb != null) {
+				for (i < 256) writeDispatchEntry(refleb, i, trap_pos);
+			}
+			for (i < 256) writeDispatchEntry(refsndary, i, trap_pos);
 		}
 
-		// Generate the secondary dispatch tables and point main table at them
-		var ref0 = dispatchTables[0].1;
+		// Generate dispatches to secondary dispatch tables
+		// - Only for non-subpage entries (since they duplicate the main entry)
+		var ref0 = dispatchTables[0].1;		// main dispatch table address
 		for (t in dispatchTables) {
-			if (t.0 == 0) continue; // main dispatch table
+			var prefix = t.0;
+			if (prefix == 0) continue;	// skip main dispatch table
+			if (t.4 != null) continue;	// skip subpage
 			var pos = w.atEnd().pos;
+			var refsndary = t.1;
 			computeCurIpForTrap(-1);
-			genDispatch0(ip_ptr, t.1, true);
-			writeDispatchEntry(ref0, t.0, pos);
+			genDispatch0(ip_ptr, refsndary, true);
+			// main[prefix] = prefix's table
+			writeDispatchEntry(ref0, prefix, pos);
 		}
 
-		// Generate extended LEB landing pads for secondary dispatch tables
-		for (i = 1; i < dispatchTables.length; i++) {
-			var t = dispatchTables[i];
-			var pos = w.pos;
-			if (t.2 != null) {
-				// TODO: some code in this page are in the upper 128; read extended LEB
-				genDispatch0(null, t.2, false);
-			} else {
+		// Generate extended LEB landing pads for non-subpage secondary dispatch tables
+		for (t in dispatchTables) {
+			if (t.0 == 0) continue;		// skip main dispatch table
+			if (t.4 != null) continue;	// skip subpage
+			var leb_pos = w.pos;
+			var refsndary = t.1;
+			var refleb = t.2;
+			if (refleb == null) {
 				// all codes in this page are in the lower 128; just skip extended LEB
+				// happens only with non-minimal encoding
 				genSkipLeb();
+				asm.d.and_r_i(r_tmp0, 0x7F);		// clear upper bit
+				genDispatch0(null, refsndary, false);	// use secondary table
+			} else {
+				// code needs to grab next byte to see what to do
+				asm.movd_r_r(r_tmp2, r_tmp0);		// save opcode
+				asm.d.movbzx_r_m(r_tmp0, ip_ptr);	// load next byte
+				asm.q.inc_r(r_ip);			// increment pointer
+				// convert value to an index we can use into an unused portion
+				// of the LEB table
+
+				// Wish we had: asm.rolb_r_i(r_tmp0, 1) to rotate 8-bit reg.
+				// Encodes as 0xD0 0xCr, where r is register number,
+				//   available in reg's regnum field:
+				// asm.comment(";; rol cl, 1\n");
+				w.putb(0xD0);
+				w.putb(0xC0 | r_tmp0.regnum);
+				// alternative code sequence (encoding slightly different)
+				// asm.movq(r_scratch, r_tmp0);
+				// asm.d.sar_r_i(r_tmp0, 6);	// move upper bit to 0x2 position
+				// asm.d.andi(r_scratch, 0x1);
+				// asm.d.or_r_r(r_tmp0, r_scratch);
+				// a more clever alternative code sequence
+				// asm.imul_r_i(r_tmp0, 0x02020000)
+				//   low bit  ends up in 0x02000000 position (and another)
+				//   0x80 bit ends up in 0x01000000 position (and overflow)
+				// asm.q.slr_r_i(r_tmp0, 24)
+
+				// mapping using rol is:
+				// 0000 0000 -> 0000 0000 upper bit 0, no LEB continuation
+				// 0000 0001 -> 0000 0010 upper bit 1, no LEB continuation
+				// 1000 0000 -> 0000 0001 upper bit 0, LEB continues
+				// 1000 0001 -> 0000 0011 upper bit 1, LEB continues
+				// entries 0-3 of the LEB table are otherwise unused :-)
+				genDispatch0(null, refleb, false);
+
+				// create and install the four dispatch sequences for mapped second byte
+
+				var leb00_pos = w.pos;
+				// upper bit of opcode is 0, no LEB continuation:
+				// dispatch through secondary table after clearing upper bit
+				// not used when encoding is minimal
+				asm.movd_r_r(r_tmp0, r_tmp2);
 				asm.d.and_r_i(r_tmp0, 0x7F);
-				genDispatch0(null, t.1, false);
+				genDispatch0(null, refsndary, false);
+				writeDispatchEntry(refleb, 0x00, leb00_pos);
+
+				var leb01_pos = w.pos;
+				// upper bit of opcode is 0, has LEB continuation:
+				// dispatch through LEB table after skipping LEB and clearing upper bit
+				// not used when encoding is minimal
+				genSkipLeb();
+				asm.movd_r_r(r_tmp0, r_tmp2);	// EBM check this!
+				asm.d.and_r_i(r_tmp0, 0x7F);
+				genDispatch0(null, refsndary, false);
+				writeDispatchEntry(refleb, 0x01, leb01_pos);
+
+				var leb02_pos = w.pos;
+				// upper bit of opcode is 1, no LEB continuation:
+				// dispatch through LEB, don't clear upper bit
+				asm.movd_r_r(r_tmp0, r_tmp2);
+				genDispatch0(null, refleb, false);
+				writeDispatchEntry(refleb, 0x02, leb02_pos);
+
+				var leb03_pos = w.pos;
+				// upper bit of opcode is 1, has LEB continuation:
+				// dispatch through LEB table after skipping LEB
+				// don't clear upper bit
+				// not used when encoding is minimal
+				genSkipLeb();
+				asm.movd_r_r(r_tmp0, r_tmp2);
+				genDispatch0(null, refleb, false);
+				writeDispatchEntry(refleb, 0x03, leb03_pos);
 			}
 			for (i = 128; i < 256; i++) {
-				writeDispatchEntry(t.1, i, pos);
+				writeDispatchEntry(refsndary, i, leb_pos);
+			}
+		}
+		// Generate subpage dispatching
+		for (t in dispatchTables) {
+			if (t.0 == 0) continue;		// skip main dispatch table
+			if (t.4 == null) continue;	// skip non-subpages
+			// there are five cases for subpage index 0XXX XXXX:
+			// First byte  Second byte
+			// 0XXX XXXX   ---- ----    dispatch 0XXX XXXX in secondary table (not subpage)
+			//                          (doesn't get here)
+			// 1XXX XXXX   0000 0000    dispatch as 0XXX XXXX in secondary table
+			// 1XXX XXXX   0YYY YYYY    dispatch 0YYY YYYY in subpage table
+			// 1XXX XXXX   1000 0000    skip LEB, dispatch as 0XXX XXXX in secondary table
+			// 1XXX XXXX   1YYY YYYY    skip LEB, dispatch as 0YYY YYYY in subpage table
+			//                          avoid clearing upper bit by duplicating entry?
+
+			// create and install subpage dispatch
+			var subpage_pos = w.pos;
+			var refsndary = t.1;
+			var refleb = t.2;
+			var sub_index = t.3;
+			var sub_index_leb = sub_index | byte.view(0x80);
+			var refsub = t.4;
+
+			genDispatch0(ip_ptr, refsub, true);
+			// all uses of a subpage will have the LEB bit set
+			writeDispatchEntry(refsndary, sub_index_leb, subpage_pos);
+
+			// Note: writeDispatchEntry installs duplicately for second byte == 0,
+			// in the secondary table (at sub_index) and the subpage table at 0.
+			// The subpage entry at 0 and at 0x80 happen for non-minimal encodings.
+
+			// Generate redirecting handler for upper bit of second byte == 1,
+			// a non-minimal encoding.
+			
+			var subpage_leb_pos = w.pos;
+			genSkipLeb();
+			asm.d.and_r_i(r_tmp0, 0x7F);
+			genDispatch0(null, refsub, false);
+			for (i = 128; i < 256; ++i) {
+				writeDispatchEntry(refsub, i, subpage_leb_pos);
 			}
 		}
 
@@ -1323,7 +1473,6 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		genLoad(Opcode.I64_LOAD8_S, BpTypeCode.I64.code, asm.movbsx_r_m);
 		genLoad(Opcode.I64_LOAD8_U, BpTypeCode.I64.code, asm.movbzx_r_m);
 		genLoad(Opcode.I64_LOAD16_S, BpTypeCode.I64.code, asm.movwsx_r_m);
-		genLoad(Opcode.I64_LOAD16_U, BpTypeCode.I64.code, asm.movwzx_r_m);
 		genLoad(Opcode.I64_LOAD16_U, BpTypeCode.I64.code, asm.movwzx_r_m);
 		genLoad(Opcode.I64_LOAD32_S, BpTypeCode.I64.code, masm.emit_movq_32s_r_m);
 		genLoad(Opcode.I64_LOAD32_U, BpTypeCode.I64.code, asm.movd_r_m);
@@ -2646,8 +2795,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		load_v128_s_r(r_xmm0, r_tmp0);
 	}
 	def load_imm8(r: X86_64Gpr) {
-		asm.movb_r_m(r, ip_ptr);
-		asm.q.add_r_i(r_ip, 1);
+		asm.movbzx_r_m(r, ip_ptr);
+		asm.q.inc_r(r_ip);
 	}
 	def decode_memarg(src: X86_64Addr, scratch1: X86_64Gpr, scratch2: X86_64Gpr) -> X86_64Addr{
 		asm.q.inc_r(r_ip);			// skip flags byte
@@ -3337,7 +3486,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		if (!FeatureDisable.multiMemory) { // dynamically check for memory index
 			has_index = asm.newLabel();
 			asm.q.inc_r(r_ip);				// skip flags byte
-			asm.test_m_i(r_ip.plus(-1), BpConstants.MEMARG_INDEX_FLAG); // XXX: test byte
+			// this instruction is tricky: it considers 32 bits, but looks only in the low byte
+			asm.d.test_m_i(r_ip.plus(-1), BpConstants.MEMARG_INDEX_FLAG); // XXX: test byte
 			asm.jc_rel_near(C.NZ, has_index);
 		} else {
 			asm.q.inc_r(r_ip);				// skip flags byte
@@ -3370,7 +3520,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		if (!FeatureDisable.multiMemory) { // dynamically check for memory index
 			has_index = asm.newLabel();
 			asm.q.inc_r(r_ip);				// skip flags byte
-			asm.test_m_i(r_ip.plus(-1), BpConstants.MEMARG_INDEX_FLAG); // XXX: test byte
+			// this instruction is tricky: it considers 32 bits, but looks only in the low byte
+			asm.d.test_m_i(r_ip.plus(-1), BpConstants.MEMARG_INDEX_FLAG); // XXX: test byte
 			asm.jc_rel_near(C.NZ, has_index);
 		} else {
 			asm.q.inc_r(r_ip);				// skip flags byte
@@ -3420,7 +3571,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		var asm = this.asm.d;
 		asm.movbzx_r_m(dest, ip_ptr);	// load first byte
 		asm.q.inc_r(r_ip);			// increment pointer
-		asm.test_r_i(dest, LEB_UPPER_BIT);	// test most-significant bit
+		// this instruction is tricky: it considers 32 bits, but looks only in the low byte
+		asm.d.test_r_i(dest, LEB_UPPER_BIT);	// test most-significant bit
 		if (FastIntTuning.inlineAllLEBs) {
 			var leb_done = X86_64Label.new();
 			asm.jc_rel_near(C.Z, leb_done);
@@ -3522,7 +3674,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		asm.bind(more);
 		asm.movbzx_r_m(scratch, ip_ptr);	// load first byte
 		asm.q.inc_r(r_ip);			// increment pointer
-		asm.test_r_i(scratch, LEB_UPPER_BIT);	// test most-significant bit
+		// this instruction is tricky: it considers 32 bits, but looks only in the low byte
+		asm.d.test_r_i(scratch, LEB_UPPER_BIT);	// test most-significant bit
 		asm.jc_rel_near(C.NZ, more);
 	}
 	// End the handler for the current bytecode
@@ -3586,16 +3739,77 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 	}
 	// Patch the dispatch table for the given opcode to go to the given position.
 	def patchDispatchTable(opcode: Opcode, pos: int) {
-		for (t in dispatchTables) {
-			if (t.0 != opcode.prefix) continue;
-			var ref1 = t.1;
-			if (opcode.prefix == 0 || opcode.code < 128) writeDispatchEntry(ref1, opcode.code, pos);
-			var ref2 = t.2;
-			if (ref2 != null) writeDispatchEntry(ref2, opcode.code, pos);
+		if (opcode.prefix == 0) {
+			if (opcode.code > 255) {
+				fatal("prefix 0 opcode > 255");
+			}
+			var ref0 = dispatchTables[0].1;		// main dispatch table
+			if (Debug.interpreter) {
+				Trace.OUT.put3("\t\tpatch main table at %x for prefix %x code %x\n",
+					       opcode.code, opcode.prefix, opcode.code);
+			}
+			writeDispatchEntry(ref0, opcode.code, pos);
 			w.atEnd();
 			return;
 		}
-		fatal("no dispatch table found for prefix");
+		// find closest matching info
+		var refsndary: IcCodeRef;
+		var refleb: IcCodeRef;
+		if (opcode.code > 0x3FFF) {
+			fatal("opcode > 0x3FFF");
+		}
+		var lower = opcode.code & 0x7F;		// subpage number when appropriate
+		var upper = opcode.code >> 7;
+		for (t in dispatchTables) {
+			var prefix = t.0;
+			if (prefix != opcode.prefix) continue;
+			refsndary = t.1;	// secondary table for this prefix
+			refleb = t.2;		// LEB table for this prefix
+			if (t.3 == lower) {
+				// code is in this subpage
+				var refsub = t.4;	// subpage table for this prefix and subpage
+				if (refsub == null) continue;
+				// if upper is 0, can encode as just lower, so put there as well
+				if (upper == 0) {
+					if (Debug.interpreter)
+						Trace.OUT.put3("\t\tpatch secondary table at %x for prefix %x code %x\n",
+							       lower, opcode.prefix, opcode.code);
+					writeDispatchEntry(refsndary, lower, pos);
+				}
+				// write subpage entry at upper
+				// also covers case of non-minimal encoding of upper == 0
+				if (Debug.interpreter) {
+					Trace.OUT.put2("\t\tpatch subpage table %x at %x", lower, upper);
+					Trace.OUT.put2(" for prefix %x code %x\n", opcode.prefix, opcode.code);
+				}
+				writeDispatchEntry(refsub, upper, pos);
+				w.atEnd();
+				return;
+			}
+		}
+		if (refsndary == null) {
+			fatal("no dispatch table found for prefix");
+		}
+		if (opcode.code > 255) {
+			fatal("opcode > 255 but no matching subpage");
+		}
+		// here if prefix and not a subpage
+		if (opcode.code < 128) {
+			// minimal encoding goes to secondary
+			// other encodings will redirect here
+			if (Debug.interpreter)
+				Trace.OUT.put3("\t\tpatch secondary table at %x for prefix %x code %x\n",
+					       opcode.code, opcode.prefix, opcode.code);
+			writeDispatchEntry(refsndary, opcode.code, pos);
+		} else {
+			// all encodings go to LEB table
+			if (Debug.interpreter)
+				Trace.OUT.put3("\t\tpatch LEB table at %x for prefix %x code %x\n",
+					       opcode.code, opcode.prefix, opcode.code);
+			writeDispatchEntry(refleb, opcode.code, pos);
+		}
+		w.atEnd();
+		return;
 	}
 	// Generate the out-of-line LEB decoding code.
 	def genOutOfLineLEBs() { // XXX: use a separate out-of-line assembler on the end of the buffer

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -1250,7 +1250,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 		computeCurIpForTrap(-1);
 		var r_tmp5 = r_eip; // XXX, ugly, need one more register, and func_decl is not dirty and is not needed.
-		var sig_index = r_tmp5, table_index = r_tmp3, func_index = r_tmp0;
+		var sig_index = r_tmp5, table_index = r_tmp4, func_index = r_tmp0;
 		genReadUleb32(sig_index);
 		genReadUleb32(table_index);
 
@@ -1258,7 +1258,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		asm.movd_r_m(func_index, vsph[0].value);
 
 		var tmp = r_tmp2;
-		var sig_id = r_tmp4;
+		var sig_id = r_tmp3;
 		// load instance.sig_ids[sig_index] into sig_id
 		asm.movq_r_m(tmp, r_instance.plus(offsets.Instance_sig_ids));
 		asm.movd_r_m(sig_id, tmp.plusR(sig_index, offsets.INT_SIZE, offsets.Array_contents));
@@ -2242,7 +2242,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		}
 		bindHandler(Opcode.RESUME_THROW); {
 			var resumeStub = X86_64Label.new();
-			var cont_id = r_tmp0, ip_store = r_tmp1, tag_index = r_tmp3;
+			var cont_id = r_tmp0, ip_store = r_tmp1, tag_index = r_tmp4;
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
 			// read info and rewind %ip (need %ip at start of opcode during call)
@@ -2252,7 +2252,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			asm.movq_r_r(r_ip, ip_store);
 			saveCallerIVars();
 			var r_cont = r_tmp1;
-			genResume(cont_id, r_cont, r_tmp4);
+			genResume(cont_id, r_cont, r_tmp3);
 			var r_tag = r_tmp3;
 			asm.movq_r_m(r_scratch, r_instance.plus(offsets.Instance_tags));
 			asm.movq_r_m(r_tag, r_scratch.plusR(tag_index, offsets.REF_SIZE, offsets.Array_contents));
@@ -3409,6 +3409,9 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 	// Generate a read of a 32-bit unsigned LEB.
 	def genReadUleb32(dest: X86_64Gpr) {
+		// TODO: fix reading of LEBs
+		if (dest == r_scratch) System.error("X86_64InterpreterError", "cannot use r_scratch as an LEB destination");
+		if (dest == r_tmp3) System.error("X86_64InterpreterError", "cannot use r_tmp3 as an LEB destination");
 		var ool_leb: OutOfLineLEB;
 		if (!FastIntTuning.inlineAllLEBs) {
 			ool_leb = OutOfLineLEB.new(dest);
@@ -3789,8 +3792,8 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		// goto read_done
 		asm.jc_rel_near(C.S, read_done);
 		// read handler type
-		genReadUleb32(r_scratch);
-		asm.q.cmp_r_i(r_scratch, 0);
+		genReadUleb32(r_tmp4);
+		asm.q.cmp_r_i(r_tmp4, 0);
 		// if {handler_type} is 0x01, read switch handler
 		asm.jc_rel_near(X86_64Conds.NZ, read_switch);
 		// read normal handler

--- a/src/util/OpcodeMap.v3
+++ b/src/util/OpcodeMap.v3
@@ -3,7 +3,7 @@
 
 // Efficiently maps opcodes to a value of type {T}.
 class OpcodeMap<T> {
-	private def main_table = OpcodeMapTable<T>.new(0, Opcodes.opcodes);
+	private def main_table = OpcodeMapTable<T>.new(0, Opcodes.opcodes_no_prefix);
 	private def fb_table = OpcodeMapTable<T>.new(0xFB, Opcodes.page_FB.opcodes);
 	private def fc_table = OpcodeMapTable<T>.new(0xFC, Opcodes.page_FC.opcodes);
 	private def fd_table = OpcodeMapTable<T>.new(0xFD, Opcodes.page_FD.opcodes);

--- a/src/util/OpcodeMap.v3
+++ b/src/util/OpcodeMap.v3
@@ -3,7 +3,7 @@
 
 // Efficiently maps opcodes to a value of type {T}.
 class OpcodeMap<T> {
-	private def main_table = OpcodeMapTable<T>.new(0, Opcodes.page_00.opcodes);
+	private def main_table = OpcodeMapTable<T>.new(0, Opcodes.opcodes);
 	private def fb_table = OpcodeMapTable<T>.new(0xFB, Opcodes.page_FB.opcodes);
 	private def fc_table = OpcodeMapTable<T>.new(0xFC, Opcodes.page_FC.opcodes);
 	private def fd_table = OpcodeMapTable<T>.new(0xFD, Opcodes.page_FD.opcodes);

--- a/src/util/WasmAsm.v3
+++ b/src/util/WasmAsm.v3
@@ -23,158 +23,158 @@ class WasmAsm extends Vector<byte> {
 		put_blockType(vt);
 	}
 	def local_get(index: int) -> this {
-		put(Opcode.LOCAL_GET.code).put_u32leb(index);
+		put_u32leb(Opcode.LOCAL_GET.code).put_u32leb(index);
 	}
 	def local_tee(index: int) -> this {
-		put(Opcode.LOCAL_TEE.code).put_u32leb(index);
+		put_u32leb(Opcode.LOCAL_TEE.code).put_u32leb(index);
 	}
 	def global_get(index: int) -> this {
-		put(Opcode.GLOBAL_GET.code).put_u32leb(index);
+		put_u32leb(Opcode.GLOBAL_GET.code).put_u32leb(index);
 	}
 	def global_set(index: int) -> this {
-		put(Opcode.GLOBAL_SET.code).put_u32leb(index);
+		put_u32leb(Opcode.GLOBAL_SET.code).put_u32leb(index);
 	}
 	def local_set(index: int) -> this {
-		put(Opcode.LOCAL_SET.code).put_u32leb(index);
+		put_u32leb(Opcode.LOCAL_SET.code).put_u32leb(index);
 	}
 	def i32const(v: int) -> this {
-		put(Opcode.I32_CONST.code).put_u32leb(v);
+		put_u32leb(Opcode.I32_CONST.code).put_u32leb(v);
 	}
 	def struct_get(decl: StructDecl, field: int) -> this {
-		put(Opcode.STRUCT_GET.prefix).put(Opcode.STRUCT_GET.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
+		put(Opcode.STRUCT_GET.prefix).put_u32leb(Opcode.STRUCT_GET.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
 	}
 	def struct_get_s(decl: StructDecl, field: int) -> this {
-		put(Opcode.STRUCT_GET_S.prefix).put(Opcode.STRUCT_GET_S.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
+		put(Opcode.STRUCT_GET_S.prefix).put_u32leb(Opcode.STRUCT_GET_S.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
 	}
 	def struct_get_u(decl: StructDecl, field: int) -> this {
-		put(Opcode.STRUCT_GET_U.prefix).put(Opcode.STRUCT_GET_U.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
+		put(Opcode.STRUCT_GET_U.prefix).put_u32leb(Opcode.STRUCT_GET_U.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
 	}
 	def struct_set(decl: StructDecl, field: int) -> this {
-		put(Opcode.STRUCT_SET.prefix).put(Opcode.STRUCT_SET.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
+		put(Opcode.STRUCT_SET.prefix).put_u32leb(Opcode.STRUCT_SET.code).put_u32leb(decl.heaptype_index).put_u32leb(field);
 	}
 	def struct_new_canon_default(decl: StructDecl) -> this {
 		put(Opcode.STRUCT_NEW_DEFAULT.prefix)
-			.put(Opcode.STRUCT_NEW_DEFAULT.code).put_u32leb(decl.heaptype_index);
+			.put_u32leb(Opcode.STRUCT_NEW_DEFAULT.code).put_u32leb(decl.heaptype_index);
 	}
 	def struct_new_canon(decl: StructDecl) -> this {
 		put(Opcode.STRUCT_NEW.prefix)
-			.put(Opcode.STRUCT_NEW.code).put_u32leb(decl.heaptype_index);
+			.put_u32leb(Opcode.STRUCT_NEW.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_get(decl: ArrayDecl) -> this {
-		put(Opcode.ARRAY_GET.prefix).put(Opcode.ARRAY_GET.code).put_u32leb(decl.heaptype_index);
+		put(Opcode.ARRAY_GET.prefix).put_u32leb(Opcode.ARRAY_GET.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_get_s(decl: ArrayDecl) -> this {
-		put(Opcode.ARRAY_GET_S.prefix).put(Opcode.ARRAY_GET_S.code).put_u32leb(decl.heaptype_index);
+		put(Opcode.ARRAY_GET_S.prefix).put_u32leb(Opcode.ARRAY_GET_S.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_get_u(decl: ArrayDecl) -> this {
-		put(Opcode.ARRAY_GET_U.prefix).put(Opcode.ARRAY_GET_U.code).put_u32leb(decl.heaptype_index);
+		put(Opcode.ARRAY_GET_U.prefix).put_u32leb(Opcode.ARRAY_GET_U.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_set(decl: ArrayDecl) -> this {
-		put(Opcode.ARRAY_SET.prefix).put(Opcode.ARRAY_SET.code).put_u32leb(decl.heaptype_index);
+		put(Opcode.ARRAY_SET.prefix).put_u32leb(Opcode.ARRAY_SET.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_new(decl: ArrayDecl) -> this {
-		put(Opcode.ARRAY_NEW.prefix).put(Opcode.ARRAY_NEW.code).put_u32leb(decl.heaptype_index);
+		put(Opcode.ARRAY_NEW.prefix).put_u32leb(Opcode.ARRAY_NEW.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_new_canon_default(decl: ArrayDecl) -> this {
 		put(Opcode.ARRAY_NEW_DEFAULT.prefix)
-			.put(Opcode.ARRAY_NEW_DEFAULT.code).put_u32leb(decl.heaptype_index);
+			.put_u32leb(Opcode.ARRAY_NEW_DEFAULT.code).put_u32leb(decl.heaptype_index);
 	}
 	def array_len(decl: ArrayDecl) -> this {
-		put(Opcode.ARRAY_LEN.prefix).put(Opcode.ARRAY_LEN.code).put_u32leb(decl.heaptype_index);
+		put(Opcode.ARRAY_LEN.prefix).put_u32leb(Opcode.ARRAY_LEN.code).put_u32leb(decl.heaptype_index);
 	}
 	def ref_eq() -> this {
-		put(Opcode.REF_EQ.code);
+		put_u32leb(Opcode.REF_EQ.code);
 	}
 	def ref_is_null() -> this {
-		put(Opcode.REF_IS_NULL.code);
+		put_u32leb(Opcode.REF_IS_NULL.code);
 	}
 	def ref_cast(ft: int, tt: int) -> this {
-		put(Opcode.REF_CAST.prefix).put(Opcode.REF_CAST.code);
+		put(Opcode.REF_CAST.prefix).put_u32leb(Opcode.REF_CAST.code);
 		put_u32leb(tt);
 	}
 	def ref_test(ft: int, tt: int) -> this {
-		put(Opcode.REF_TEST.prefix).put(Opcode.REF_TEST.code);
+		put(Opcode.REF_TEST.prefix).put_u32leb(Opcode.REF_TEST.code);
 		put_u32leb(tt);
 	}
 	def ref_null(i: int) -> this {
-		put(Opcode.REF_NULL.code).put_u32leb(i);
+		put_u32leb(Opcode.REF_NULL.code).put_u32leb(i);
 	}
 	def ref_as_non_null() -> this {
-		put(Opcode.REF_AS_NON_NULL.code);
+		put_u32leb(Opcode.REF_AS_NON_NULL.code);
 	}
 	def call_ref() -> this {
-		put(Opcode.CALL_REF.code);
+		put_u32leb(Opcode.CALL_REF.code);
 	}
 	def return_call_ref() -> this {
-		put(Opcode.RETURN_CALL_REF.code);
+		put_u32leb(Opcode.RETURN_CALL_REF.code);
 	}
 	def loop0() -> this {
-		put(Opcode.LOOP.code);
+		put_u32leb(Opcode.LOOP.code);
 		put(BpTypeCode.EmptyBlock.code);
 	}
 	def block0() -> this {
-		put(Opcode.BLOCK.code);
+		put_u32leb(Opcode.BLOCK.code);
 		put(BpTypeCode.EmptyBlock.code);
 	}
 	def blocks(sig: SigDecl) -> this {
-		put(Opcode.BLOCK.code);
+		put_u32leb(Opcode.BLOCK.code);
 		put_u32leb(sig.heaptype_index);
 	}
 	def loops(sig: SigDecl) -> this {
-		put(Opcode.LOOP.code);
+		put_u32leb(Opcode.LOOP.code);
 		put_u32leb(sig.heaptype_index);
 	}
 	def if_(t: ValueType) -> this {
-		put(Opcode.IF.code);
+		put_u32leb(Opcode.IF.code);
 		put_blockType(t);
 	}
 	def if0() -> this {
-		put(Opcode.IF.code);
+		put_u32leb(Opcode.IF.code);
 		put(BpTypeCode.EmptyBlock.code);
 	}
 	def else_() -> this {
-		put(Opcode.ELSE.code);
+		put_u32leb(Opcode.ELSE.code);
 	}
 	def drop() -> this {
-		put(Opcode.DROP.code);
+		put_u32leb(Opcode.DROP.code);
 	}
 	def br_if(depth: int) -> this {
-		put(Opcode.BR_IF.code);
+		put_u32leb(Opcode.BR_IF.code);
 		put_u32leb(depth);
 	}
 	def br(depth: int) -> this {
-		put(Opcode.BR.code);
+		put_u32leb(Opcode.BR.code);
 		put_u32leb(depth);
 	}
 	def br_on_cast(depth: int, t1: int, t2: int) -> this {
-		put(Opcode.BR_ON_CAST.prefix).put(Opcode.BR_ON_CAST.code);
+		put(Opcode.BR_ON_CAST.prefix).put_u32leb(Opcode.BR_ON_CAST.code);
 		put_u32leb(depth);
 		put_u32leb(t2);
 	}
 	def br_on_null(depth: int) -> this {
-		put(Opcode.BR_ON_NULL.code);
+		put_u32leb(Opcode.BR_ON_NULL.code);
 		put_u32leb(depth);
 	}
 	def end() -> this {
-		put(Opcode.END.code);
+		put_u32leb(Opcode.END.code);
 	}
 	def op(opcode: Opcode) -> this {
-		put(opcode.code);
+		put_u32leb(opcode.code);
 	}
 	def unreachable() -> this {
-		put(Opcode.UNREACHABLE.code);
+		put_u32leb(Opcode.UNREACHABLE.code);
 	}
 	def ret() -> this {
-		put(Opcode.RETURN.code);
+		put_u32leb(Opcode.RETURN.code);
 	}
 	def put_blockType(t: ValueType) -> this {
 		// TODO: factor out code into src/util/WasmWriter
 		match (t) {
-			I32 => put(BpTypeCode.I32.code);
-			I64 => put(BpTypeCode.I64.code);
-			F32 => put(BpTypeCode.F32.code);
-			F64 => put(BpTypeCode.F64.code);
-			V128 => put(BpTypeCode.V128.code);
+			I32 => put_u32leb(BpTypeCode.I32.code);
+			I64 => put_u32leb(BpTypeCode.I64.code);
+			F32 => put_u32leb(BpTypeCode.F32.code);
+			F64 => put_u32leb(BpTypeCode.F64.code);
+			V128 => put_u32leb(BpTypeCode.V128.code);
 			_ => ; // TODO
 		}
 	}

--- a/test/unittest/BinParserTest.v3
+++ b/test/unittest/BinParserTest.v3
@@ -92,6 +92,11 @@ def Z = void(
 	()
 );
 
+// provide short forms
+def op8  (code: u16) -> u8 { return Opcodes.op8  (code); }
+def op16l(code: u16) -> u8 { return Opcodes.op16l(code); }
+def op16h(code: u16) -> u8 { return Opcodes.op16h(code); }
+
 def doDump(raw: Array<byte>, pos: int, length: int) {
 	var buf = StringBuilder.new();
 	buf.puts("[");
@@ -291,7 +296,7 @@ def EMPTY_FUNC_TYPE: Array<byte> = [
 	BpDefTypeCode.Function.code, 0, 0
 ];
 def EMPTY_FUNC_BODY: Array<byte> = [
-	0, Opcode.UNREACHABLE.code, Opcode.END.code
+	0, op8(Opcode.UNREACHABLE.code), op8(Opcode.END.code)
 ];
 def ONE_FUNC_TYPES_SECTION: Array<byte> = [
 	BpSection.Type.code, 4, 1, BpDefTypeCode.Function.code, 0, 0
@@ -300,14 +305,14 @@ def ONE_FUNC_DECL_SECTION: Array<byte> = [
 	BpSection.Function.code, 2, 1, 0
 ];
 def ONE_FUNC_CODE_SECTION: Array<byte> = [
-	BpSection.Code.code, 4, 1, 2, 0, Opcode.END.code
+	BpSection.Code.code, 4, 1, 2, 0, op8(Opcode.END.code)
 ];
 def ONE_IMPORTED_FUNC_SECTION: Array<byte> = [
 	BpSection.Import.code, 7, 1, 1, 'M', 1, 'f', BpImportExportKind.Function.code, 0
 ];
 def ONE_GLOBAL_SECTION: Array<byte> = [
 	BpSection.Global.code, 6, 1, BpTypeCode.I32.code, 0,
-		Opcode.I32_CONST.code, 0, Opcode.END.code
+		op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)
 ];
 def ONE_PAGE_MEMORY_SECTION: Array<byte> = [
 	BpSection.Memory.code, 3, 1, 0, 1
@@ -688,60 +693,60 @@ def test_memory_limits(t: BinParserTester) {
 def test_globals0(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Global);
 	s.valid([1, BpTypeCode.I32.code, 0,
-		Opcode.I32_CONST.code, 1, Opcode.END.code]);
+		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.I32.code, 1,
-		Opcode.I32_CONST.code, 1, Opcode.END.code]);
+		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.I64.code, 0,
-		Opcode.I64_CONST.code, 2, Opcode.END.code]);
+		op8(Opcode.I64_CONST.code), 2, op8(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.F32.code, 0,
-		Opcode.F32_CONST.code, 0, 0, 0, 0, Opcode.END.code]);
+		op8(Opcode.F32_CONST.code), 0, 0, 0, 0, op8(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.F64.code, 0,
-		Opcode.F64_CONST.code, 0, 0, 0, 0, 0, 0, 0, 0, Opcode.END.code]);
-	s.invalid(WasmError.INVALID_TYPE, [1, 0x2C, 0, Opcode.END.code]);
+		op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0, op8(Opcode.END.code)]);
+	s.invalid(WasmError.INVALID_TYPE, [1, 0x2C, 0, op8(Opcode.END.code)]);
 
 	s.invalid(WasmError.INVALID_GLOBAL_FLAGS, [1, BpTypeCode.I32.code, 2,
-		Opcode.I32_CONST.code, 1, Opcode.END.code]);
+		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.F32.code, 0,
-		Opcode.I32_CONST.code, 1, Opcode.END.code]);
+		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.F64.code, 0,
-		Opcode.I64_CONST.code, 2, Opcode.END.code]);
+		op8(Opcode.I64_CONST.code), 2, op8(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.I32.code, 0,
-		Opcode.F32_CONST.code, 0, 0, 0, 0, Opcode.END.code]);
+		op8(Opcode.F32_CONST.code), 0, 0, 0, 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.I64.code, 0,
-		Opcode.F64_CONST.code, 0, 0, 0, 0, 0, 0, 0, 0, Opcode.END.code]);
+		op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0, op8(Opcode.END.code)]);
 }
 
 def test_globals1(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Global);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I32.code, 0, Opcode.I32_CONST.code, 1, Opcode.END.code,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code),
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I64.code, 0, Opcode.I64_CONST.code, 1, Opcode.END.code,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I64.code, 0, op8(Opcode.I64_CONST.code), 1, op8(Opcode.END.code),
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.OOB_INDEX, [1,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 
 	// relaxed with GC extension
 	t.extensions |= Extension.GC;
 	s.valid([2,
-		BpTypeCode.I32.code, 0, Opcode.I32_CONST.code, 1, Opcode.END.code,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code),
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [2,
-		BpTypeCode.I64.code, 0, Opcode.I64_CONST.code, 1, Opcode.END.code,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I64.code, 0, op8(Opcode.I64_CONST.code), 1, op8(Opcode.END.code),
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 }
 
 def test_globals2(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Global);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [1, BpTypeCode.F32.code, 0,
-		Opcode.NOP.code, 0, 0, 0, 0, Opcode.END.code]);
+		op8(Opcode.NOP.code), 0, 0, 0, 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I32.code, 0, Opcode.I32_CONST.code, 2, Opcode.END.code,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 2, op8(Opcode.END.code),
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I32.code, 1, Opcode.I32_CONST.code, 2, Opcode.END.code,
-		BpTypeCode.I32.code, 0, Opcode.GLOBAL_GET.code, 0, Opcode.END.code]);
+		BpTypeCode.I32.code, 1, op8(Opcode.I32_CONST.code), 2, op8(Opcode.END.code),
+		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
 }
 
 def test_exports0(t: BinParserTester) {
@@ -835,37 +840,37 @@ def test_start2(t: BinParserTester) {
 
 def test_elements0(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Element);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
 	s.b.puta(ONE_TABLE_SECTION);
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, Opcode.I64_CONST.code, 0, Opcode.END.code, 0]);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 0]);
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I64_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
 
 	s.b.resize(VALID_HEADER.length);
 	s.b.puta(ONE_FUNC_TYPES_SECTION);
 	s.b.puta(ONE_IMPORTED_FUNC_SECTION);
 	s.b.puta(ONE_TABLE_SECTION);
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 0]);
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 3, 0, 0, 0]);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 1]);
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 0, 0, 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 1]);
 }
 
 def test_elements1(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Element);
 	s.b.puta([BpSection.Table.code, 4, 1, BpTypeCode.EXTERNREF.code, 0, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
-	s.valid([1, 4, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, Opcode.I32_CONST.code, 0, Opcode.END.code,
-			1, Opcode.I32_CONST.code, 0, Opcode.END.code]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.valid([1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code),
+			1, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)]);
 }
 
 def test_elements2(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Element);
 	s.b.puta([BpSection.Table.code, 4, 1, BpTypeCode.FUNCREF.code, 0, 0]);
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
-	s.valid([1, 4, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, Opcode.I32_CONST.code, 0, Opcode.END.code,
-			1, Opcode.I32_CONST.code, 0, Opcode.END.code]);
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.valid([1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code),
+			1, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)]);
 }
 
 def test_elements3(t: BinParserTester) {
@@ -879,8 +884,8 @@ def test_elements3(t: BinParserTester) {
 		1, 'M', 1, 'f', BpImportExportKind.Function.code, 1]);
 	s.b.puta([BpSection.Table.code, 5, 1, BpTypeCode.REF_NULL.code, 0, 0, 0]);
 
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 1]); // incorrect function sig
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 1]); // incorrect function sig
 }
 
 def test_elements4(t: BinParserTester) {
@@ -894,8 +899,8 @@ def test_elements4(t: BinParserTester) {
 		1, 'M', 1, 'f', BpImportExportKind.Function.code, 1]);
 	s.b.puta([BpSection.Table.code, 5, 1, BpTypeCode.REF_NULL.code, 0, 0, 0]);
 
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 1, 1]); // incorrect function sig
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 1]); // incorrect function sig
 }
 
 def testCountedSection(t: BinParserTester, max: int, sect: BpSection,
@@ -965,7 +970,7 @@ def test_funcsN(t: BinParserTester) {
 
 	// Test valid function body/code pairs
 	var func_entry: Array<byte> = [0];
-	var func_body: Array<byte> = [2, 0, Opcode.END.code];
+	var func_body: Array<byte> = [2, 0, op8(Opcode.END.code)];
 	for (count < 4) {
 		// valid case.
 		b.resize(len);
@@ -1034,7 +1039,7 @@ def test_memoriesN(t: BinParserTester) {
 
 def test_globalsN(t: BinParserTester) {
 	testCountedSection(t, 3, BpSection.Global, null, [
-		BpTypeCode.I32.code, 0, Opcode.I32_CONST.code, 0, Opcode.END.code
+		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)
 	]);
 }
 
@@ -1060,13 +1065,13 @@ def test_elementsN(t: BinParserTester) {
 	var setup = b.extract();
 
 	testCountedSection(t, 3, BpSection.Element, setup, [
-		0, Opcode.I32_CONST.code, 0, Opcode.END.code, 3, 0, 0, 0
+		0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 0, 0, 0
 	]);
 }
 
 def test_dataN(t: BinParserTester) {
 	testCountedSection(t, 3, BpSection.Data, ONE_PAGE_MEMORY_SECTION, [
-		0, Opcode.I32_CONST.code, 0, Opcode.END.code, 3, 'a', 'b', 'c'
+		0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 'a', 'b', 'c'
 	]);
 }
 
@@ -1076,8 +1081,8 @@ def test_code0(t: BinParserTester) {
 	s.b.puta(ONE_FUNC_TYPES_SECTION);
 	s.b.puta(ONE_FUNC_DECL_SECTION);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [0]);
-	s.valid([1, 2, 0, Opcode.END.code]);
-	s.valid([1, 3, 0, Opcode.NOP.code, Opcode.END.code]);
+	s.valid([1, 2, 0, op8(Opcode.END.code)]);
+	s.valid([1, 3, 0, op8(Opcode.NOP.code), op8(Opcode.END.code)]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [2, 0, 0]);
 }
 
@@ -1093,9 +1098,9 @@ def test_code1(t: BinParserTester) {
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [0]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [1, 0]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [2, 0, 0]);
-	s.valid([3, 2, 0, Opcode.END.code,
-			2, 0, Opcode.END.code,
-			2, 0, Opcode.END.code]);
+	s.valid([3, 2, 0, op8(Opcode.END.code),
+			2, 0, op8(Opcode.END.code),
+			2, 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [4, 0, 0, 0, 0]);
 }
 
@@ -1106,7 +1111,7 @@ def test_code2(t: BinParserTester) {
 	s.b.beginSection(BpSection.Function);
 	s.b.puta([1, 0]);
 	s.b.endSection();
-	s.valid([1, 2, 0, Opcode.END.code]);
+	s.valid([1, 2, 0, op8(Opcode.END.code)]);
 	s.invalid(WasmError.INCOMPLETE_FUNCTION_BODY, [1]);
 	s.invalid(WasmError.INCOMPLETE_FUNCTION_BODY, [1, 2, 0]);
 
@@ -1132,16 +1137,16 @@ def test_code_missing(t: BinParserTester) {
 
 def test_data0(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Data);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
 	s.b.puta(ONE_PAGE_MEMORY_SECTION);
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 0]);
-	s.valid([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code, 2, 99, 88]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, Opcode.I64_CONST.code, 0, Opcode.END.code, 0]);
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 2, 99, 88]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I64_CONST.code), 0, op8(Opcode.END.code), 0]);
 
 
 	var max = DEFAULT_LIMITS.max_data_segment_size;
 	var b = BinBuilder.new();
-	b.puta([1, 0, Opcode.I32_CONST.code, 0, Opcode.END.code]);
+	b.puta([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)]);
 	var pre_size = b.length;
 	for (size in [7788u, max - 1, max, max + 1]) {
 		b.resize(pre_size);
@@ -1284,7 +1289,7 @@ def test_data_count(t: BinParserTester) {
 	b.beginSection(BpSection.DataCount);
 	b.put_u32leb(1);
 	b.endSection();
-	def seg: Array<byte> = [0, Opcode.I32_CONST.code, 0, Opcode.END.code, 3, 'a', 'b', 'c'];
+	def seg: Array<byte> = [0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 'a', 'b', 'c'];
 	b.beginSection(BpSection.Data);
 	b.put_u32leb(2);
 	b.puta(seg);

--- a/test/unittest/BinParserTest.v3
+++ b/test/unittest/BinParserTest.v3
@@ -92,11 +92,6 @@ def Z = void(
 	()
 );
 
-// provide short forms
-def op8   = Opcodes.op8;
-def op16l = Opcodes.op16l;
-def op16h = Opcodes.op16h;
-
 def doDump(raw: Array<byte>, pos: int, length: int) {
 	var buf = StringBuilder.new();
 	buf.puts("[");
@@ -296,7 +291,7 @@ def EMPTY_FUNC_TYPE: Array<byte> = [
 	BpDefTypeCode.Function.code, 0, 0
 ];
 def EMPTY_FUNC_BODY: Array<byte> = [
-	0, op8(Opcode.UNREACHABLE.code), op8(Opcode.END.code)
+	0, u8.!(Opcode.UNREACHABLE.code), u8.!(Opcode.END.code)
 ];
 def ONE_FUNC_TYPES_SECTION: Array<byte> = [
 	BpSection.Type.code, 4, 1, BpDefTypeCode.Function.code, 0, 0
@@ -305,14 +300,14 @@ def ONE_FUNC_DECL_SECTION: Array<byte> = [
 	BpSection.Function.code, 2, 1, 0
 ];
 def ONE_FUNC_CODE_SECTION: Array<byte> = [
-	BpSection.Code.code, 4, 1, 2, 0, op8(Opcode.END.code)
+	BpSection.Code.code, 4, 1, 2, 0, u8.!(Opcode.END.code)
 ];
 def ONE_IMPORTED_FUNC_SECTION: Array<byte> = [
 	BpSection.Import.code, 7, 1, 1, 'M', 1, 'f', BpImportExportKind.Function.code, 0
 ];
 def ONE_GLOBAL_SECTION: Array<byte> = [
 	BpSection.Global.code, 6, 1, BpTypeCode.I32.code, 0,
-		op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)
+		u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code)
 ];
 def ONE_PAGE_MEMORY_SECTION: Array<byte> = [
 	BpSection.Memory.code, 3, 1, 0, 1
@@ -693,60 +688,60 @@ def test_memory_limits(t: BinParserTester) {
 def test_globals0(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Global);
 	s.valid([1, BpTypeCode.I32.code, 0,
-		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
+		u8.!(Opcode.I32_CONST.code), 1, u8.!(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.I32.code, 1,
-		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
+		u8.!(Opcode.I32_CONST.code), 1, u8.!(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.I64.code, 0,
-		op8(Opcode.I64_CONST.code), 2, op8(Opcode.END.code)]);
+		u8.!(Opcode.I64_CONST.code), 2, u8.!(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.F32.code, 0,
-		op8(Opcode.F32_CONST.code), 0, 0, 0, 0, op8(Opcode.END.code)]);
+		u8.!(Opcode.F32_CONST.code), 0, 0, 0, 0, u8.!(Opcode.END.code)]);
 	s.valid([1, BpTypeCode.F64.code, 0,
-		op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0, op8(Opcode.END.code)]);
-	s.invalid(WasmError.INVALID_TYPE, [1, 0x2C, 0, op8(Opcode.END.code)]);
+		u8.!(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0, u8.!(Opcode.END.code)]);
+	s.invalid(WasmError.INVALID_TYPE, [1, 0x2C, 0, u8.!(Opcode.END.code)]);
 
 	s.invalid(WasmError.INVALID_GLOBAL_FLAGS, [1, BpTypeCode.I32.code, 2,
-		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
+		u8.!(Opcode.I32_CONST.code), 1, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.F32.code, 0,
-		op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code)]);
+		u8.!(Opcode.I32_CONST.code), 1, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.F64.code, 0,
-		op8(Opcode.I64_CONST.code), 2, op8(Opcode.END.code)]);
+		u8.!(Opcode.I64_CONST.code), 2, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.I32.code, 0,
-		op8(Opcode.F32_CONST.code), 0, 0, 0, 0, op8(Opcode.END.code)]);
+		u8.!(Opcode.F32_CONST.code), 0, 0, 0, 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [1, BpTypeCode.I64.code, 0,
-		op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0, op8(Opcode.END.code)]);
+		u8.!(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0, u8.!(Opcode.END.code)]);
 }
 
 def test_globals1(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Global);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code),
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I32.code, 0, u8.!(Opcode.I32_CONST.code), 1, u8.!(Opcode.END.code),
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I64.code, 0, op8(Opcode.I64_CONST.code), 1, op8(Opcode.END.code),
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I64.code, 0, u8.!(Opcode.I64_CONST.code), 1, u8.!(Opcode.END.code),
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.OOB_INDEX, [1,
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 
 	// relaxed with GC extension
 	t.extensions |= Extension.GC;
 	s.valid([2,
-		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 1, op8(Opcode.END.code),
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I32.code, 0, u8.!(Opcode.I32_CONST.code), 1, u8.!(Opcode.END.code),
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.TYPE_MISMATCH, [2,
-		BpTypeCode.I64.code, 0, op8(Opcode.I64_CONST.code), 1, op8(Opcode.END.code),
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I64.code, 0, u8.!(Opcode.I64_CONST.code), 1, u8.!(Opcode.END.code),
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 }
 
 def test_globals2(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Global);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [1, BpTypeCode.F32.code, 0,
-		op8(Opcode.NOP.code), 0, 0, 0, 0, op8(Opcode.END.code)]);
+		u8.!(Opcode.NOP.code), 0, 0, 0, 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 2, op8(Opcode.END.code),
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I32.code, 0, u8.!(Opcode.I32_CONST.code), 2, u8.!(Opcode.END.code),
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.INVALID_INIT_EXPR, [2,
-		BpTypeCode.I32.code, 1, op8(Opcode.I32_CONST.code), 2, op8(Opcode.END.code),
-		BpTypeCode.I32.code, 0, op8(Opcode.GLOBAL_GET.code), 0, op8(Opcode.END.code)]);
+		BpTypeCode.I32.code, 1, u8.!(Opcode.I32_CONST.code), 2, u8.!(Opcode.END.code),
+		BpTypeCode.I32.code, 0, u8.!(Opcode.GLOBAL_GET.code), 0, u8.!(Opcode.END.code)]);
 }
 
 def test_exports0(t: BinParserTester) {
@@ -840,37 +835,37 @@ def test_start2(t: BinParserTester) {
 
 def test_elements0(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Element);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
 	s.b.puta(ONE_TABLE_SECTION);
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I64_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, u8.!(Opcode.I64_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 0]);
 
 	s.b.resize(VALID_HEADER.length);
 	s.b.puta(ONE_FUNC_TYPES_SECTION);
 	s.b.puta(ONE_IMPORTED_FUNC_SECTION);
 	s.b.puta(ONE_TABLE_SECTION);
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 0, 0, 0]);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 1]);
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 0]);
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 3, 0, 0, 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 1]);
 }
 
 def test_elements1(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Element);
 	s.b.puta([BpSection.Table.code, 4, 1, BpTypeCode.EXTERNREF.code, 0, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.valid([1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code),
-			1, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.valid([1, 4, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code),
+			1, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code)]);
 }
 
 def test_elements2(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Element);
 	s.b.puta([BpSection.Table.code, 4, 1, BpTypeCode.FUNCREF.code, 0, 0]);
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.valid([1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code),
-			1, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)]);
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.valid([1, 4, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 4, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code),
+			1, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code)]);
 }
 
 def test_elements3(t: BinParserTester) {
@@ -884,8 +879,8 @@ def test_elements3(t: BinParserTester) {
 		1, 'M', 1, 'f', BpImportExportKind.Function.code, 1]);
 	s.b.puta([BpSection.Table.code, 5, 1, BpTypeCode.REF_NULL.code, 0, 0, 0]);
 
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 1]); // incorrect function sig
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 1]); // incorrect function sig
 }
 
 def test_elements4(t: BinParserTester) {
@@ -899,8 +894,8 @@ def test_elements4(t: BinParserTester) {
 		1, 'M', 1, 'f', BpImportExportKind.Function.code, 1]);
 	s.b.puta([BpSection.Table.code, 5, 1, BpTypeCode.REF_NULL.code, 0, 0, 0]);
 
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 0]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 1, 1]); // incorrect function sig
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 0]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 1, 1]); // incorrect function sig
 }
 
 def testCountedSection(t: BinParserTester, max: int, sect: BpSection,
@@ -970,7 +965,7 @@ def test_funcsN(t: BinParserTester) {
 
 	// Test valid function body/code pairs
 	var func_entry: Array<byte> = [0];
-	var func_body: Array<byte> = [2, 0, op8(Opcode.END.code)];
+	var func_body: Array<byte> = [2, 0, u8.!(Opcode.END.code)];
 	for (count < 4) {
 		// valid case.
 		b.resize(len);
@@ -1039,7 +1034,7 @@ def test_memoriesN(t: BinParserTester) {
 
 def test_globalsN(t: BinParserTester) {
 	testCountedSection(t, 3, BpSection.Global, null, [
-		BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)
+		BpTypeCode.I32.code, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code)
 	]);
 }
 
@@ -1065,13 +1060,13 @@ def test_elementsN(t: BinParserTester) {
 	var setup = b.extract();
 
 	testCountedSection(t, 3, BpSection.Element, setup, [
-		0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 0, 0, 0
+		0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 3, 0, 0, 0
 	]);
 }
 
 def test_dataN(t: BinParserTester) {
 	testCountedSection(t, 3, BpSection.Data, ONE_PAGE_MEMORY_SECTION, [
-		0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 'a', 'b', 'c'
+		0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 3, 'a', 'b', 'c'
 	]);
 }
 
@@ -1081,8 +1076,8 @@ def test_code0(t: BinParserTester) {
 	s.b.puta(ONE_FUNC_TYPES_SECTION);
 	s.b.puta(ONE_FUNC_DECL_SECTION);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [0]);
-	s.valid([1, 2, 0, op8(Opcode.END.code)]);
-	s.valid([1, 3, 0, op8(Opcode.NOP.code), op8(Opcode.END.code)]);
+	s.valid([1, 2, 0, u8.!(Opcode.END.code)]);
+	s.valid([1, 3, 0, u8.!(Opcode.NOP.code), u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [2, 0, 0]);
 }
 
@@ -1098,9 +1093,9 @@ def test_code1(t: BinParserTester) {
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [0]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [1, 0]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [2, 0, 0]);
-	s.valid([3, 2, 0, op8(Opcode.END.code),
-			2, 0, op8(Opcode.END.code),
-			2, 0, op8(Opcode.END.code)]);
+	s.valid([3, 2, 0, u8.!(Opcode.END.code),
+			2, 0, u8.!(Opcode.END.code),
+			2, 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.FUNC_COUNT_MISMATCH, [4, 0, 0, 0, 0]);
 }
 
@@ -1111,7 +1106,7 @@ def test_code2(t: BinParserTester) {
 	s.b.beginSection(BpSection.Function);
 	s.b.puta([1, 0]);
 	s.b.endSection();
-	s.valid([1, 2, 0, op8(Opcode.END.code)]);
+	s.valid([1, 2, 0, u8.!(Opcode.END.code)]);
 	s.invalid(WasmError.INCOMPLETE_FUNCTION_BODY, [1]);
 	s.invalid(WasmError.INCOMPLETE_FUNCTION_BODY, [1, 2, 0]);
 
@@ -1137,16 +1132,16 @@ def test_code_missing(t: BinParserTester) {
 
 def test_data0(t: BinParserTester) {
 	var s = BinSectionTester.new(t, BpSection.Data);
-	s.invalid(WasmError.OOB_INDEX, [1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.invalid(WasmError.OOB_INDEX, [1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
 	s.b.puta(ONE_PAGE_MEMORY_SECTION);
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 0]);
-	s.valid([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 2, 99, 88]);
-	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, op8(Opcode.I64_CONST.code), 0, op8(Opcode.END.code), 0]);
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 0]);
+	s.valid([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 2, 99, 88]);
+	s.invalid(WasmError.TYPE_MISMATCH, [1, 0, u8.!(Opcode.I64_CONST.code), 0, u8.!(Opcode.END.code), 0]);
 
 
 	var max = DEFAULT_LIMITS.max_data_segment_size;
 	var b = BinBuilder.new();
-	b.puta([1, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)]);
+	b.puta([1, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code)]);
 	var pre_size = b.length;
 	for (size in [7788u, max - 1, max, max + 1]) {
 		b.resize(pre_size);
@@ -1289,7 +1284,7 @@ def test_data_count(t: BinParserTester) {
 	b.beginSection(BpSection.DataCount);
 	b.put_u32leb(1);
 	b.endSection();
-	def seg: Array<byte> = [0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code), 3, 'a', 'b', 'c'];
+	def seg: Array<byte> = [0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code), 3, 'a', 'b', 'c'];
 	b.beginSection(BpSection.Data);
 	b.put_u32leb(2);
 	b.puta(seg);

--- a/test/unittest/BinParserTest.v3
+++ b/test/unittest/BinParserTest.v3
@@ -93,9 +93,9 @@ def Z = void(
 );
 
 // provide short forms
-def op8  (code: u16) -> u8 { return Opcodes.op8  (code); }
-def op16l(code: u16) -> u8 { return Opcodes.op16l(code); }
-def op16h(code: u16) -> u8 { return Opcodes.op16h(code); }
+def op8   = Opcodes.op8;
+def op16l = Opcodes.op16l;
+def op16h = Opcodes.op16h;
 
 def doDump(raw: Array<byte>, pos: int, length: int) {
 	var buf = StringBuilder.new();

--- a/test/unittest/BytecodeIteratorTest.v3
+++ b/test/unittest/BytecodeIteratorTest.v3
@@ -15,7 +15,7 @@ def X_ = void(
 );
 
 // provide short form
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 class OpcodeAndImmPosGatherer(it: BytecodeIterator) extends BytecodeVisitor {
 	var pc: int;

--- a/test/unittest/BytecodeIteratorTest.v3
+++ b/test/unittest/BytecodeIteratorTest.v3
@@ -14,9 +14,6 @@ def X_ = void(
 	()
 );
 
-// provide short form
-def op8 = Opcodes.op8;
-
 class OpcodeAndImmPosGatherer(it: BytecodeIterator) extends BytecodeVisitor {
 	var pc: int;
 	var op: Opcode;
@@ -94,29 +91,29 @@ def test_empty(t: BytecodeIteratorTester) {
 }
 
 def test_nop0(t: BytecodeIteratorTester) {
-	t.code([op8(Opcode.NOP.code)]);
+	t.code([u8.!(Opcode.NOP.code)]);
 	t.assert_bytecodes([Opcode.NOP, Opcode.END]);
 
-	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
+	t.code([u8.!(Opcode.NOP.code), u8.!(Opcode.NOP.code)]);
 	t.assert_bytecodes([Opcode.NOP, Opcode.NOP, Opcode.END]);
 
-	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
+	t.code([u8.!(Opcode.NOP.code), u8.!(Opcode.NOP.code), u8.!(Opcode.NOP.code)]);
 	t.assert_bytecodes([Opcode.NOP, Opcode.NOP, Opcode.NOP, Opcode.END]);
 }
 
 def test_nop1(t: BytecodeIteratorTester) {
-	t.code([op8(Opcode.NOP.code)]);
+	t.code([u8.!(Opcode.NOP.code)]);
 	t.assert_pcs([
 		(1, Opcode.NOP, 2),
 		(2, Opcode.END, 3)]);
 
-	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
+	t.code([u8.!(Opcode.NOP.code), u8.!(Opcode.NOP.code)]);
 	t.assert_pcs([
 		(1, Opcode.NOP, 2),
 		(2, Opcode.NOP, 3),
 		(3, Opcode.END, 4)]);
 
-	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
+	t.code([u8.!(Opcode.NOP.code), u8.!(Opcode.NOP.code), u8.!(Opcode.NOP.code)]);
 	t.assert_pcs([
 		(1, Opcode.NOP, 2),
 		(2, Opcode.NOP, 3),
@@ -137,7 +134,7 @@ def test_locals0(t: BytecodeIteratorTester) {
 }
 
 def test_imm0(t: BytecodeIteratorTester) {
-	t.code([op8(Opcode.I32_CONST.code), 44]);
+	t.code([u8.!(Opcode.I32_CONST.code), 44]);
 	t.assert_pcs([
 		(1, Opcode.I32_CONST, 2),
 		(3, Opcode.END, 4)
@@ -148,20 +145,20 @@ def test_imm1(t: BytecodeIteratorTester) {
 	def EMPTY_BLOCK: byte = 0x40;
 	def LABEL: byte = 0;
 	t.code([
-		op8(Opcode.BLOCK.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
-		op8(Opcode.LOOP.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
-		op8(Opcode.IF.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
-		op8(Opcode.BR.code),	LABEL,		//ImmSigs.LABEL, null),
-		op8(Opcode.BR_IF.code), LABEL,		//ImmSigs.LABEL, null),
-		op8(Opcode.BR_TABLE.code), 0, LABEL,	//ImmSigs.LABELS, null),
-		op8(Opcode.CALL.code), 0,		//ImmSigs.FUNC, null),
-		op8(Opcode.CALL_INDIRECT.code), 0, 0,	//ImmSigs.SIG_TABLE, null),
-		op8(Opcode.RETURN_CALL.code), 0,	//ImmSigs.FUNC, null),
-		op8(Opcode.RETURN_CALL_INDIRECT.code), 0, 0,	//ImmSigs.SIG_TABLE, null),
-		op8(Opcode.CALL_REF.code), 0,		//ImmSigs.SIG, null),
-		op8(Opcode.RETURN_CALL_REF.code), 0,	//ImmSigs.SIG, null),
-		op8(Opcode.SELECT_T.code), 1, 0,	//ImmSigs.VALTS, null)
-		op8(Opcode.NOP.code)
+		u8.!(Opcode.BLOCK.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
+		u8.!(Opcode.LOOP.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
+		u8.!(Opcode.IF.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
+		u8.!(Opcode.BR.code),	LABEL,		//ImmSigs.LABEL, null),
+		u8.!(Opcode.BR_IF.code), LABEL,		//ImmSigs.LABEL, null),
+		u8.!(Opcode.BR_TABLE.code), 0, LABEL,	//ImmSigs.LABELS, null),
+		u8.!(Opcode.CALL.code), 0,		//ImmSigs.FUNC, null),
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 0,	//ImmSigs.SIG_TABLE, null),
+		u8.!(Opcode.RETURN_CALL.code), 0,	//ImmSigs.FUNC, null),
+		u8.!(Opcode.RETURN_CALL_INDIRECT.code), 0, 0,	//ImmSigs.SIG_TABLE, null),
+		u8.!(Opcode.CALL_REF.code), 0,		//ImmSigs.SIG, null),
+		u8.!(Opcode.RETURN_CALL_REF.code), 0,	//ImmSigs.SIG, null),
+		u8.!(Opcode.SELECT_T.code), 1, 0,	//ImmSigs.VALTS, null)
+		u8.!(Opcode.NOP.code)
 	]);
 	t.assert_pcs([
 		(1, Opcode.BLOCK, 2),

--- a/test/unittest/BytecodeIteratorTest.v3
+++ b/test/unittest/BytecodeIteratorTest.v3
@@ -14,6 +14,9 @@ def X_ = void(
 	()
 );
 
+// provide short form
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 class OpcodeAndImmPosGatherer(it: BytecodeIterator) extends BytecodeVisitor {
 	var pc: int;
 	var op: Opcode;
@@ -91,29 +94,29 @@ def test_empty(t: BytecodeIteratorTester) {
 }
 
 def test_nop0(t: BytecodeIteratorTester) {
-	t.code([Opcode.NOP.code]);
+	t.code([op8(Opcode.NOP.code)]);
 	t.assert_bytecodes([Opcode.NOP, Opcode.END]);
 
-	t.code([Opcode.NOP.code, Opcode.NOP.code]);
+	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
 	t.assert_bytecodes([Opcode.NOP, Opcode.NOP, Opcode.END]);
 
-	t.code([Opcode.NOP.code, Opcode.NOP.code, Opcode.NOP.code]);
+	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
 	t.assert_bytecodes([Opcode.NOP, Opcode.NOP, Opcode.NOP, Opcode.END]);
 }
 
 def test_nop1(t: BytecodeIteratorTester) {
-	t.code([Opcode.NOP.code]);
+	t.code([op8(Opcode.NOP.code)]);
 	t.assert_pcs([
 		(1, Opcode.NOP, 2),
 		(2, Opcode.END, 3)]);
 
-	t.code([Opcode.NOP.code, Opcode.NOP.code]);
+	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
 	t.assert_pcs([
 		(1, Opcode.NOP, 2),
 		(2, Opcode.NOP, 3),
 		(3, Opcode.END, 4)]);
 
-	t.code([Opcode.NOP.code, Opcode.NOP.code, Opcode.NOP.code]);
+	t.code([op8(Opcode.NOP.code), op8(Opcode.NOP.code), op8(Opcode.NOP.code)]);
 	t.assert_pcs([
 		(1, Opcode.NOP, 2),
 		(2, Opcode.NOP, 3),
@@ -134,7 +137,7 @@ def test_locals0(t: BytecodeIteratorTester) {
 }
 
 def test_imm0(t: BytecodeIteratorTester) {
-	t.code([Opcode.I32_CONST.code, 44]);
+	t.code([op8(Opcode.I32_CONST.code), 44]);
 	t.assert_pcs([
 		(1, Opcode.I32_CONST, 2),
 		(3, Opcode.END, 4)
@@ -145,20 +148,20 @@ def test_imm1(t: BytecodeIteratorTester) {
 	def EMPTY_BLOCK: byte = 0x40;
 	def LABEL: byte = 0;
 	t.code([
-		Opcode.BLOCK.code, EMPTY_BLOCK,		//ImmSigs.BLOCKT, null),
-		Opcode.LOOP.code, EMPTY_BLOCK,		//ImmSigs.BLOCKT, null),
-		Opcode.IF.code, EMPTY_BLOCK,		//ImmSigs.BLOCKT, null),
-		Opcode.BR.code,	LABEL,			//ImmSigs.LABEL, null),
-		Opcode.BR_IF.code, LABEL,		//ImmSigs.LABEL, null),
-		Opcode.BR_TABLE.code, 0, LABEL,		//ImmSigs.LABELS, null),
-		Opcode.CALL.code, 0,			//ImmSigs.FUNC, null),
-		Opcode.CALL_INDIRECT.code, 0, 0,	//ImmSigs.SIG_TABLE, null),
-		Opcode.RETURN_CALL.code, 0,		//ImmSigs.FUNC, null),
-		Opcode.RETURN_CALL_INDIRECT.code, 0, 0,	//ImmSigs.SIG_TABLE, null),
-		Opcode.CALL_REF.code, 0,		//ImmSigs.SIG, null),
-		Opcode.RETURN_CALL_REF.code, 0,		//ImmSigs.SIG, null),
-		Opcode.SELECT_T.code, 1, 0,		//ImmSigs.VALTS, null)
-		Opcode.NOP.code
+		op8(Opcode.BLOCK.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
+		op8(Opcode.LOOP.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
+		op8(Opcode.IF.code), EMPTY_BLOCK,	//ImmSigs.BLOCKT, null),
+		op8(Opcode.BR.code),	LABEL,		//ImmSigs.LABEL, null),
+		op8(Opcode.BR_IF.code), LABEL,		//ImmSigs.LABEL, null),
+		op8(Opcode.BR_TABLE.code), 0, LABEL,	//ImmSigs.LABELS, null),
+		op8(Opcode.CALL.code), 0,		//ImmSigs.FUNC, null),
+		op8(Opcode.CALL_INDIRECT.code), 0, 0,	//ImmSigs.SIG_TABLE, null),
+		op8(Opcode.RETURN_CALL.code), 0,	//ImmSigs.FUNC, null),
+		op8(Opcode.RETURN_CALL_INDIRECT.code), 0, 0,	//ImmSigs.SIG_TABLE, null),
+		op8(Opcode.CALL_REF.code), 0,		//ImmSigs.SIG, null),
+		op8(Opcode.RETURN_CALL_REF.code), 0,	//ImmSigs.SIG, null),
+		op8(Opcode.SELECT_T.code), 1, 0,	//ImmSigs.VALTS, null)
+		op8(Opcode.NOP.code)
 	]);
 	t.assert_pcs([
 		(1, Opcode.BLOCK, 2),

--- a/test/unittest/CodeValidatorTest.v3
+++ b/test/unittest/CodeValidatorTest.v3
@@ -2,12 +2,8 @@
 // See LICENSE for details of Apache 2.0 license.
 
 // provide short names
-def op7   = Opcodes.op7;
-def op8   = Opcodes.op8;
 def op14l = Opcodes.op14l;
 def op14h = Opcodes.op14h;
-def op14l_no_check(code: u16) -> u8 { return byte.!((code & 0x7f) | 0x80); }
-def op14h_no_check(code: u16) -> u8 { return byte.!(code >> 7); }
 
 def T = UnitTests.registerT("validator:", _, CodeValidatorTester.new, _);
 def X_ = void(
@@ -153,14 +149,14 @@ class CodeValidatorTester(t: Tester) extends ModuleBuilder {
 def EB = BpTypeCode.EmptyBlock.code;
 
 def test_local0(t: CodeValidatorTester) {
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0];
 	t.invalid(WasmError.OOB_INDEX, code1, 1);
 	t.sig(SigCache.i_i);
 	t.valid(code1);
 }
 
 def test_local1(t: CodeValidatorTester) {
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0];
 	t.sig(SigCache.i_i);
 	t.addLocals(10000000, ValueType.I32);
 	t.invalid(WasmError.EXCEEDED_LIMIT, code1, 1);
@@ -170,11 +166,11 @@ def test_localref(t: CodeValidatorTester) {
 	var lg = t.addLocals(1, ValueTypes.FUNCREF);
 	var le = t.addLocals(1, ValueTypes.EXTERNREF);
 	t.sig0([ValueTypes.FUNCREF, ValueTypes.EXTERNREF], SigCache.arr_v);
-	t.valid([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_SET.code), byte.!(lg)]);
-	t.valid([op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.LOCAL_SET.code), byte.!(le)]);
+	t.valid([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.LOCAL_SET.code), byte.!(lg)]);
+	t.valid([u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.LOCAL_SET.code), byte.!(le)]);
 
-	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_SET.code), byte.!(le)], 7);
-	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.LOCAL_SET.code), byte.!(lg)], 7);
+	t.invalid(WasmError.TYPE_MISMATCH, [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.LOCAL_SET.code), byte.!(le)], 7);
+	t.invalid(WasmError.TYPE_MISMATCH, [u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.LOCAL_SET.code), byte.!(lg)], 7);
 }
 
 def test_globalref(t: CodeValidatorTester) {
@@ -182,15 +178,15 @@ def test_globalref(t: CodeValidatorTester) {
 	var le = byte.!(t.newGlobal(ValueTypes.EXTERNREF, InitExpr.ExternRefNull).global_index);
 
 	t.sig0([ValueTypes.FUNCREF, ValueTypes.EXTERNREF], SigCache.arr_v);
-	t.valid([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.GLOBAL_SET.code), lg]);
-	t.valid([op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.GLOBAL_SET.code), le]);
+	t.valid([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.GLOBAL_SET.code), lg]);
+	t.valid([u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.GLOBAL_SET.code), le]);
 
-	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.GLOBAL_SET.code), le], 3);
-	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.GLOBAL_SET.code), lg], 3);
+	t.invalid(WasmError.TYPE_MISMATCH, [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.GLOBAL_SET.code), le], 3);
+	t.invalid(WasmError.TYPE_MISMATCH, [u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.GLOBAL_SET.code), lg], 3);
 }
 
 def test_refparam(t: CodeValidatorTester) {
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0];
 	var refs = [ValueTypes.FUNCREF, ValueTypes.EXTERNREF];
 	for (p in refs) {
 		for (r in refs) {
@@ -204,41 +200,41 @@ def test_refparam(t: CodeValidatorTester) {
 def test_ret0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
 	t.valid([]);
-	t.valid([op8(Opcode.RETURN.code)]);
+	t.valid([u8.!(Opcode.RETURN.code)]);
 
-	t.TypeError([op8(Opcode.I32_CONST.code), 0], 3);
-	t.TypeError([op8(Opcode.I64_CONST.code), 0], 3);
-	t.TypeError([op8(Opcode.F32_CONST.code), 0, 0, 0, 0], 6);
-	t.TypeError([op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0], 10);
+	t.TypeError([u8.!(Opcode.I32_CONST.code), 0], 3);
+	t.TypeError([u8.!(Opcode.I64_CONST.code), 0], 3);
+	t.TypeError([u8.!(Opcode.F32_CONST.code), 0, 0, 0, 0], 6);
+	t.TypeError([u8.!(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0], 10);
 }
 
 def test_ret1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.TypeError([], 1);
-	t.TypeError([op8(Opcode.RETURN.code)], 1);
+	t.TypeError([u8.!(Opcode.RETURN.code)], 1);
 
-	t.valid([op8(Opcode.I32_CONST.code), 0]);
-	t.TypeError([op8(Opcode.I64_CONST.code), 0], 3);
-	t.TypeError([op8(Opcode.F32_CONST.code), 0, 0, 0, 0], 6);
-	t.TypeError([op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0], 10);
+	t.valid([u8.!(Opcode.I32_CONST.code), 0]);
+	t.TypeError([u8.!(Opcode.I64_CONST.code), 0], 3);
+	t.TypeError([u8.!(Opcode.F32_CONST.code), 0, 0, 0, 0], 6);
+	t.TypeError([u8.!(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0], 10);
 }
 
 def test_br0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
-	t.valid([op8(Opcode.BR.code), 0]);
-	t.invalid(WasmError.OOB_LABEL, [op8(Opcode.BR.code), 1], 1);
+	t.valid([u8.!(Opcode.BR.code), 0]);
+	t.invalid(WasmError.OOB_LABEL, [u8.!(Opcode.BR.code), 1], 1);
 	t.invalid(WasmError.OOB_LABEL, [
-		op8(Opcode.BLOCK.code), EB,
-		op8(Opcode.BR.code), 2,
-		op8(Opcode.END.code)
+		u8.!(Opcode.BLOCK.code), EB,
+		u8.!(Opcode.BR.code), 2,
+		u8.!(Opcode.END.code)
 	], 3);
 }
 
 def test_br_table0(t: CodeValidatorTester) {
 	var code1: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 7,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2, 0, 0, 0];
+		u8.!(Opcode.I32_CONST.code), 7,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2, 0, 0, 0];
 	t.sig(SigCache.i_i);
 	t.valid(code1);
 
@@ -249,11 +245,11 @@ def test_br_table0(t: CodeValidatorTester) {
 	t.TypeError(code1, 5);
 
 	var code2: Array<byte> = [
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 7,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2, 0, 1, 0,
-		op8(Opcode.END.code)];
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 7,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2, 0, 1, 0,
+		u8.!(Opcode.END.code)];
 	t.sig(SigCache.i_i);
 	t.valid(code2);
 
@@ -263,31 +259,31 @@ def test_br_table0(t: CodeValidatorTester) {
 
 def test_br_table1(t: CodeValidatorTester) {
 	var code1: Array<byte> = [
-		op8(Opcode.BLOCK.code), EB,
-		op8(Opcode.I32_CONST.code), 8,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2, 0, 1, 0,
-		op8(Opcode.END.code)];
+		u8.!(Opcode.BLOCK.code), EB,
+		u8.!(Opcode.I32_CONST.code), 8,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2, 0, 1, 0,
+		u8.!(Opcode.END.code)];
 	t.sig(SigCache.i_i);
 	t.TypeError(code1, 7);
 
 	var code2: Array<byte> = [
-		op8(Opcode.F32_CONST.code), 0, 0, 0, 0,
-		op8(Opcode.LOOP.code), BpTypeCode.F32.code,
-		op8(Opcode.I32_CONST.code), 9,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2, 0, 1, 0,
-		op8(Opcode.END.code)];
+		u8.!(Opcode.F32_CONST.code), 0, 0, 0, 0,
+		u8.!(Opcode.LOOP.code), BpTypeCode.F32.code,
+		u8.!(Opcode.I32_CONST.code), 9,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2, 0, 1, 0,
+		u8.!(Opcode.END.code)];
 	t.sig(SigCache.i_i);
 	t.TypeError(code2, 12);
 }
 
 def test_if0(t: CodeValidatorTester) {
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	];
 	t.sig(SigCache.i_v);
 	t.valid(code1);
@@ -296,12 +292,12 @@ def test_if0(t: CodeValidatorTester) {
 	t.TypeError(code1, 3);
 
 	var code2: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code)
 	];
 	t.sig(SigCache.i_v);
 	t.valid(code2);
@@ -310,10 +306,10 @@ def test_if0(t: CodeValidatorTester) {
 	t.TypeError(code2, 3);
 
 	var code3: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.BR.code), 1,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.BR.code), 1,
+		u8.!(Opcode.END.code)
 	];
 	t.sig(SigCache.i_v);
 	t.valid(code3);
@@ -325,44 +321,44 @@ def test_if0(t: CodeValidatorTester) {
 def test_if1(t: CodeValidatorTester) {
 	t.sig(SigCache.i_i);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	], 5);
 
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)
 	], 5);
 
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	], 8);
 
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	]);
 
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.END.code)
 	];
 	t.sig(SigCache.ii_i);
 	t.valid(code1);
@@ -371,12 +367,12 @@ def test_if1(t: CodeValidatorTester) {
 	t.TypeError(code1, 7);
 
 	var code2: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.F32.code,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.F32.code,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	];
 	t.sig(SigCache.ii_i);
 	t.TypeError(code2, 9);
@@ -385,10 +381,10 @@ def test_if1(t: CodeValidatorTester) {
 def test_if2(t: CodeValidatorTester) {
 	t.sig(SigCache.i_i);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.END.code)
 	], 7);
 }
 
@@ -397,32 +393,32 @@ def test_if_end(t: CodeValidatorTester) {
 	var i_i = byte.!(t.addSig(SigCache.i_i).heaptype_index);
 	var i_f = byte.!(t.addSig(SigCache.i_f).heaptype_index);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.END.code)
 	]);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.DROP.code),
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.END.code)
 	], 9);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_f,
-		op8(Opcode.F32_CONST.code), 3, 3, 3, 3,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_f,
+		u8.!(Opcode.F32_CONST.code), 3, 3, 3, 3,
+		u8.!(Opcode.END.code)
 	], 12);
 
 }
@@ -432,49 +428,49 @@ def test_if_unr1(t: CodeValidatorTester) {
 	var i_i = byte.!(t.addSig(SigCache.i_i).heaptype_index);
 	var v_i = byte.!(t.addSig(SigCache.v_i).heaptype_index);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), v_i,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), v_i,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	]);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), v_i,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), v_i,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	], 6);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.I64_CONST.code), 5,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.I64_CONST.code), 5,
+		u8.!(Opcode.END.code)
 	], 10);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), i_i,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), i_i,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	]);
 }
 def test_if_unr2(t: CodeValidatorTester) {
@@ -482,51 +478,51 @@ def test_if_unr2(t: CodeValidatorTester) {
 	var i_i = byte.!(t.addSig(SigCache.i_i).heaptype_index);
 	var v_i = byte.!(t.addSig(SigCache.v_i).heaptype_index);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	], 8);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	], 13);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	], 13);
 }
 
 def test_select(t: CodeValidatorTester) {
 	var types = [ValueType.I32, ValueType.I64, ValueType.F32, ValueType.F64];
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.SELECT.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.SELECT.code)
 	];
 	for (a in types) {
 		for (b in types) {
@@ -540,10 +536,10 @@ def test_select(t: CodeValidatorTester) {
 def test_selectn(t: CodeValidatorTester) {
 	var types = [ValueType.I32, ValueTypes.FUNCREF, ValueTypes.EXTERNREF];
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.SELECT.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.SELECT.code)
 	];
 	for (a in types) {
 		for (b in types) {
@@ -561,10 +557,10 @@ def test_selectt(t: CodeValidatorTester) {
 		(BpTypeCode.EXTERNREF.code, ValueTypes.EXTERNREF)
 	];
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.SELECT_T.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.SELECT_T.code), 1,
 		0 /*tpos*/
 	];
 	var tpos = 8;
@@ -587,61 +583,61 @@ def test_selectt(t: CodeValidatorTester) {
 def test_loop0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
 	t.valid([
-		op8(Opcode.LOOP.code), EB,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), EB,
+		u8.!(Opcode.END.code)
 	]);
 	t.sig(SigCache.v_i);
 	t.valid([
-		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.I32.code,
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code)
 	]);
 	t.sig(SigCache.v_i);
 	t.valid([
-		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
-		op8(Opcode.I64_CONST.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I64_CONST.code), 0,
+		u8.!(Opcode.END.code)
 	], 5);
 	t.TypeError([
-		op8(Opcode.LOOP.code), BpTypeCode.I64.code,
-		op8(Opcode.I64_CONST.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.I64.code,
+		u8.!(Opcode.I64_CONST.code), 0,
+		u8.!(Opcode.END.code)
 	], 6);
 }
 
 def test_loop_br(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
 	t.valid([
-		op8(Opcode.LOOP.code), EB,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), EB,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code)
 	]);
 	t.valid([
-		op8(Opcode.LOOP.code), EB,
-		op8(Opcode.BR.code), 1,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), EB,
+		u8.!(Opcode.BR.code), 1,
+		u8.!(Opcode.END.code)
 	]);
 	t.invalid(WasmError.OOB_LABEL, [
-		op8(Opcode.LOOP.code), EB,
-		op8(Opcode.BR.code), 2,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), EB,
+		u8.!(Opcode.BR.code), 2,
+		u8.!(Opcode.END.code)
 	], 3);
 	t.sig(SigCache.v_i);
 	t.valid([
-		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.I32.code,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code)
 	]);
 	t.valid([
-		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.BR.code), 1,
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.BR.code), 1,
+		u8.!(Opcode.END.code)
 	]);
 }
 
@@ -653,21 +649,21 @@ def test_loopv(t: CodeValidatorTester) {
 
 	t.sig(SigCache.if_v);
 	t.TypeError([
-		op8(Opcode.LOOP.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOOP.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	], 1);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOOP.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOOP.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	], 3);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOOP.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOOP.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	]);
 }
 
@@ -677,39 +673,39 @@ def test_blockp1(t: CodeValidatorTester) {
 
 	t.sig(SigCache.if_v);
 	t.TypeError([
-		op8(Opcode.BLOCK.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.BLOCK.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	], 1);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	], 3);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BLOCK.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BLOCK.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), i_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), i_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	], 3);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), f_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), f_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BLOCK.code), f_v,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BLOCK.code), f_v,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code)
 	], 3);
 }
 
@@ -720,44 +716,44 @@ def test_blockp2(t: CodeValidatorTester) {
 
 	t.sig(SigCache.if_v);
 	t.TypeError([
-		op8(Opcode.BLOCK.code), f_f,
-		op8(Opcode.END.code)
+		u8.!(Opcode.BLOCK.code), f_f,
+		u8.!(Opcode.END.code)
 	], 1);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BLOCK.code), f_f,
-		op8(Opcode.END.code),
-		op8(Opcode.DROP.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BLOCK.code), f_f,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.DROP.code)
 	], 3);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), f_f,
-		op8(Opcode.END.code),
-		op8(Opcode.DROP.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), f_f,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.DROP.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), f_f,
-		op8(Opcode.DROP.code),
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.DROP.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), f_f,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.DROP.code)
 	], 8);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), f_l,
-		op8(Opcode.DROP.code),
-		op8(Opcode.I64_CONST.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.DROP.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), f_l,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.I64_CONST.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.DROP.code)
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), f_l,
-		op8(Opcode.DROP.code),
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.DROP.code)
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), f_l,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.DROP.code)
 	], 8);
 }
 
@@ -768,35 +764,35 @@ def test_blockv2(t: CodeValidatorTester) {
 def test_blockinv(t: CodeValidatorTester) {
 	t.sig(SigCache.i_i);
 	t.invalid(WasmError.INVALID_BLOCK_TYPE, [
-		op8(Opcode.BLOCK.code), 33,
-		op8(Opcode.END.code)
+		u8.!(Opcode.BLOCK.code), 33,
+		u8.!(Opcode.END.code)
 	], 2);
 }
 
 def test_unterm(t: CodeValidatorTester) {
 	t.invalid(WasmError.UNTERMINATED_BODY, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.IF.code), EB
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.IF.code), EB
 	], 6);
 	t.invalid(WasmError.UNTERMINATED_BODY, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.ELSE.code)
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.ELSE.code)
 	], 7);
 	t.sig(SigCache.v_v);
-	t.invalid(WasmError.OOB_LABEL, [op8(Opcode.END.code)], 2);
+	t.invalid(WasmError.OOB_LABEL, [u8.!(Opcode.END.code)], 2);
 }
 
 def test_else0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
-	t.invalid(WasmError.MISMATCHED_ELSE, [op8(Opcode.ELSE.code)], 1);
+	t.invalid(WasmError.MISMATCHED_ELSE, [u8.!(Opcode.ELSE.code)], 1);
 
 	t.invalid(WasmError.MISMATCHED_ELSE, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.IF.code), EB,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.IF.code), EB,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.END.code)
 	], 6);
 
 }
@@ -810,10 +806,10 @@ def test_simple_ops_v(t: CodeValidatorTester) {
 		if (!isSimpleOp(op)) continue;
 		t.sig(op.sig);
 		for (i < op.sig.params.length) {
-			code.put(op8(Opcode.LOCAL_GET.code));
+			code.put(u8.!(Opcode.LOCAL_GET.code));
 			code.put(byte.!(i));
 		}
-		code.put(op8(op.code));
+		code.put(u8.!(op.code));
 		t.valid(code.extract());
 	}
 }
@@ -827,10 +823,10 @@ def test_simple_ops_r(t: CodeValidatorTester) {
 		for (rt in types) {
 			t.sig0(op.sig.params, [rt]);
 			for (i < op.sig.params.length) {
-				code.put(op8(Opcode.LOCAL_GET.code));
+				code.put(u8.!(Opcode.LOCAL_GET.code));
 				code.put(byte.!(i));
 			}
-			code.put(op8(op.code));
+			code.put(u8.!(op.code));
 			if (op.sig.results.length == 1 && op.sig.results[0] == rt) {
 				t.valid(code.extract());
 			} else {
@@ -844,7 +840,7 @@ def test_simple_ops_r(t: CodeValidatorTester) {
 
 def test_simple_ops0(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code),
+		u8.!(Opcode.LOCAL_GET.code),
 		/* local_pt */0,
 		/* opcode_pt */0
 	];
@@ -863,7 +859,7 @@ def test_simple_ops0(t: CodeValidatorTester) {
 		t.sig(op.sig);
 		for (l in locals) {
 			template[local_pt] = byte.!(l);
-			template[opcode_pt] = op8(op.code);
+			template[opcode_pt] = u8.!(op.code);
 			var pt = template.length + 9;
 			t.TypeError(template, pt);
 		}
@@ -872,7 +868,7 @@ def test_simple_ops0(t: CodeValidatorTester) {
 
 def test_simple_ops1(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code),
+		u8.!(Opcode.LOCAL_GET.code),
 		/* local_pt */0,
 		/* opcode_pt */0
 	];
@@ -891,7 +887,7 @@ def test_simple_ops1(t: CodeValidatorTester) {
 		t.sig(op.sig);
 		for (l in locals) {
 			template[local_pt] = byte.!(l.1);
-			template[opcode_pt] = op8(op.code);
+			template[opcode_pt] = u8.!(op.code);
 			if (l.0 == op.sig.params[0]) {
 				t.valid(template);
 			} else {
@@ -904,9 +900,9 @@ def test_simple_ops1(t: CodeValidatorTester) {
 
 def test_simple_ops2(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code),
+		u8.!(Opcode.LOCAL_GET.code),
 		/* local0_pt */0,
-		op8(Opcode.LOCAL_GET.code),
+		u8.!(Opcode.LOCAL_GET.code),
 		/* local1_pt */0,
 		/* opcode_pt */0
 	];
@@ -926,7 +922,7 @@ def test_simple_ops2(t: CodeValidatorTester) {
 		for (l in locals) {
 			template[local0_pt] = 0;
 			template[local1_pt] = byte.!(l.1);
-			template[opcode_pt] = op8(op.code);
+			template[opcode_pt] = u8.!(op.code);
 			if (l.0 == op.sig.params[1]) {
 				t.valid(template);
 			} else {
@@ -936,7 +932,7 @@ def test_simple_ops2(t: CodeValidatorTester) {
 
 			template[local0_pt] = byte.!(l.1);
 			template[local1_pt] = 1;
-			template[opcode_pt] = op8(op.code);
+			template[opcode_pt] = u8.!(op.code);
 			if (l.0 == op.sig.params[0]) {
 				t.valid(template);
 			} else {
@@ -951,57 +947,57 @@ def test_memindex1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.addMemory(1, Max.Set(1));
 	t.valid([
-		op8(Opcode.MEMORY_SIZE.code), 0
+		u8.!(Opcode.MEMORY_SIZE.code), 0
 	]);
 	t.valid([
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0
 	]);
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		op8(Opcode.MEMORY_SIZE.code), 1
+		u8.!(Opcode.MEMORY_SIZE.code), 1
 	], 2);
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 1
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 1
 	], 4);
 
 	// expect a zero byte if no multi-memory
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		op8(Opcode.MEMORY_SIZE.code), 0x80, 0
+		u8.!(Opcode.MEMORY_SIZE.code), 0x80, 0
 	], 2);
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0x80, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0x80, 0
 	], 4);
 
 	// allow a full LEB if multi-memory
 	t.setExtensions(Extension.MULTI_MEMORY);
 	t.valid([
-		op8(Opcode.MEMORY_SIZE.code), 0x80, 0
+		u8.!(Opcode.MEMORY_SIZE.code), 0x80, 0
 	]);
 	t.valid([
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0x80, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0x80, 0
 	]);
 }
 
 def test_memindex2(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.MEMORY_SIZE.code), 0
+		u8.!(Opcode.MEMORY_SIZE.code), 0
 	], 2);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0
 	], 4);
 	// allow a full LEB if multi-memory
 	t.setExtensions(Extension.MULTI_MEMORY);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.MEMORY_SIZE.code), 0x80, 0
+		u8.!(Opcode.MEMORY_SIZE.code), 0x80, 0
 	], 2);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0x80, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0x80, 0
 	], 4);
 }
 
@@ -1009,61 +1005,61 @@ def test_tabindex1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.addTable(1, 1, null);
 	t.valid([
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.CALL_INDIRECT.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 0
 	]);
 	t.valid([
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.CALL_INDIRECT.code), 0, 0x80, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 0x80, 0
 	]);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.CALL_INDIRECT.code), 0, 1
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 1
 	], 5);
 }
 
 def test_tabindex2(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.CALL_INDIRECT.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 0
 	], 5);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.CALL_INDIRECT.code), 0, 0x80, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 0x80, 0
 	], 5);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.CALL_INDIRECT.code), 0, 1
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.CALL_INDIRECT.code), 0, 1
 	], 5);
 }
 
 def test_retcall1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	var code1: Array<byte> = [
-		op8(Opcode.RETURN_CALL.code), 0
+		u8.!(Opcode.RETURN_CALL.code), 0
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 1);
 
 	t.setExtensions(Extension.TAIL_CALL);
 	t.valid(code1);
 
-	var f2 = t.newFunction(SigCache.v_v, [op8(Opcode.END.code)]);
+	var f2 = t.newFunction(SigCache.v_v, [u8.!(Opcode.END.code)]);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.RETURN_CALL.code), byte.!(f2.func_index)
+		u8.!(Opcode.RETURN_CALL.code), byte.!(f2.func_index)
 	], 1);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.RETURN_CALL.code), byte.!(f2.func_index),
-		op8(Opcode.I32_CONST.code), 1
+		u8.!(Opcode.RETURN_CALL.code), byte.!(f2.func_index),
+		u8.!(Opcode.I32_CONST.code), 1
 	], 1);
 
-	var f3 = t.newFunction(SigCache.v_l, [op8(Opcode.END.code)]);
+	var f3 = t.newFunction(SigCache.v_l, [u8.!(Opcode.END.code)]);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.RETURN_CALL.code), byte.!(f3.func_index)
+		u8.!(Opcode.RETURN_CALL.code), byte.!(f3.func_index)
 	], 1);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.RETURN_CALL.code), byte.!(f3.func_index),
-		op8(Opcode.I32_CONST.code), 2
+		u8.!(Opcode.RETURN_CALL.code), byte.!(f3.func_index),
+		u8.!(Opcode.I32_CONST.code), 2
 	], 1);
 }
 
@@ -1071,8 +1067,8 @@ def test_retcall2(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.addTable(1, 1, null);
 	var code1: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.RETURN_CALL_INDIRECT.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.RETURN_CALL_INDIRECT.code), 0, 0
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
@@ -1081,13 +1077,13 @@ def test_retcall2(t: CodeValidatorTester) {
 
 	var s2 = t.addSig(SigCache.v_v).heaptype_index;
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.view(s2), 0
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.RETURN_CALL_INDIRECT.code), byte.view(s2), 0
 	], 3);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.view(s2), 0,
-		op8(Opcode.I32_CONST.code), 2
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.RETURN_CALL_INDIRECT.code), byte.view(s2), 0,
+		u8.!(Opcode.I32_CONST.code), 2
 	], 3);
 }
 
@@ -1108,7 +1104,7 @@ def test_invalid2(t: CodeValidatorTester) {
 
 def test_prefix_ops1(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code),
+		u8.!(Opcode.LOCAL_GET.code),
 		/* local_pt */0,
 		/* prefix_pt */0,
 		/* opcode_pt */0,
@@ -1134,8 +1130,8 @@ def test_prefix_ops1(t: CodeValidatorTester) {
 			template[local_pt] = byte.!(l.1);
 			template[prefix_pt] = op.prefix;
 			if (Opcodes.page_by_prefix[op.prefix].oneByte) {
-				template[opcode_pt  ] = op8(op.code);
-				template[opcode_pt+1] = op8(Opcode.NOP.code);
+				template[opcode_pt  ] = u8.!(op.code);
+				template[opcode_pt+1] = u8.!(Opcode.NOP.code);
 			} else {
 				template[opcode_pt  ] = op14l(op.code);
 				template[opcode_pt+1] = op14h(op.code);
@@ -1151,23 +1147,23 @@ def test_prefix_ops1(t: CodeValidatorTester) {
 }
 
 def test_ref_null(t: CodeValidatorTester) {
-	t.TypeError([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code], 3);
+	t.TypeError([u8.!(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code], 3);
 
 	t.sig(SigCache.v_e);
-	t.valid([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code]);
-	t.TypeError([op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code], 3);
+	t.valid([u8.!(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code]);
+	t.TypeError([u8.!(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code], 3);
 
 	t.sig(SigCache.v_g);
-	t.valid([op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code]);
-	t.TypeError([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code], 3);
-	t.invalid(WasmError.INVALID_TYPE, [op8(Opcode.REF_NULL.code), BpTypeCode.I32.code], 2);
+	t.valid([u8.!(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code]);
+	t.TypeError([u8.!(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code], 3);
+	t.invalid(WasmError.INVALID_TYPE, [u8.!(Opcode.REF_NULL.code), BpTypeCode.I32.code], 2);
 }
 
 def test_ref_is_null(t: CodeValidatorTester) {
-	t.TypeError([op8(Opcode.REF_IS_NULL.code)], 1);
+	t.TypeError([u8.!(Opcode.REF_IS_NULL.code)], 1);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.REF_IS_NULL.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.REF_IS_NULL.code)
 	];
 	t.sig(SigCache.i_i);
 	t.invalid(WasmError.ILLEGAL_TYPE, code1, 3);
@@ -1180,9 +1176,9 @@ def test_ref_is_null(t: CodeValidatorTester) {
 }
 
 def test_ref_func(t: CodeValidatorTester) {
-	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.REF_FUNC.code), 11], 2);
-	var f2 = t.newFunction(SigCache.v_v, [op8(Opcode.END.code)]);
-	var code1: Array<byte> = [op8(Opcode.REF_FUNC.code), byte.!(f2.func_index)];
+	t.invalid(WasmError.OOB_INDEX, [u8.!(Opcode.REF_FUNC.code), 11], 2);
+	var f2 = t.newFunction(SigCache.v_v, [u8.!(Opcode.END.code)]);
+	var code1: Array<byte> = [u8.!(Opcode.REF_FUNC.code), byte.!(f2.func_index)];
 	t.sig(SigCache.v_g);
 	t.invalid(WasmError.ILLEGAL_FUNCREF, code1, 1);
 	f2.reffed = true;
@@ -1196,7 +1192,7 @@ def test_ref_func(t: CodeValidatorTester) {
 def test_ref_as_non_null(t: CodeValidatorTester) {
 	var nft = ValueTypes.RefFunc(true, SigCache.i_i), ft = ValueTypes.RefFunc(false, SigCache.i_i);
 	t.sig0([nft], [ft]);
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.REF_AS_NON_NULL.code)];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.REF_AS_NON_NULL.code)];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
@@ -1210,18 +1206,18 @@ def test_ref_as_non_null(t: CodeValidatorTester) {
 def test_br_on_null(t: CodeValidatorTester) {
 	var nft = ValueTypes.RefFunc(true, SigCache.i_i), ft = ValueTypes.RefFunc(false, SigCache.i_i);
 	t.sig0([nft], [ft]);
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR_ON_NULL.code), 0];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.BR_ON_NULL.code), 0];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
 	t.invalid(WasmError.TYPE_MISMATCH, code1, 3);
 	t.valid([
-		op8(Opcode.BLOCK.code), EB,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_ON_NULL.code), 0,
-		op8(Opcode.BR.code), 1,
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.BLOCK.code), EB,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_ON_NULL.code), 0,
+		u8.!(Opcode.BR.code), 1,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 
 	t.sig(SigCache.i_i);
@@ -1231,25 +1227,25 @@ def test_br_on_null(t: CodeValidatorTester) {
 def test_br_on_non_null(t: CodeValidatorTester) {
 	var nft = ValueTypes.RefFunc(true, SigCache.i_i), ft = ValueTypes.RefFunc(false, SigCache.i_i);
 	t.sig0([nft], [ft]);
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR_ON_NON_NULL.code), 0, op8(Opcode.UNREACHABLE.code)];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.BR_ON_NON_NULL.code), 0, u8.!(Opcode.UNREACHABLE.code)];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
 	t.valid(code1);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		op8(Opcode.BLOCK.code), EB,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_ON_NON_NULL.code), 0,
-		op8(Opcode.BR.code), 1,
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.BLOCK.code), EB,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_ON_NON_NULL.code), 0,
+		u8.!(Opcode.BR.code), 1,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 	], 7);
 	t.valid([
-		op8(Opcode.BLOCK.code), EB,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_ON_NON_NULL.code), 1,
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.BLOCK.code), EB,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_ON_NON_NULL.code), 1,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 
 	t.sig(SigCache.i_i);
@@ -1259,12 +1255,12 @@ def test_br_on_non_null(t: CodeValidatorTester) {
 def test_data_drop(t: CodeValidatorTester) {
 	t.addData(0, [0]);
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.DATA_DROP.prefix, op8(Opcode.DATA_DROP.code), 0];
+	var code1: Array<byte> = [Opcode.DATA_DROP.prefix, u8.!(Opcode.DATA_DROP.code), 0];
 	t.invalid(WasmError.MISSING_DATA_COUNT, code1, 1);
 
 	t.module.explicit_data_count = 1;
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.DATA_DROP.prefix, op8(Opcode.DATA_DROP.code), 1], 3);
+	t.invalid(WasmError.OOB_INDEX, [Opcode.DATA_DROP.prefix, u8.!(Opcode.DATA_DROP.code), 1], 3);
 }
 
 def test_memory_init(t: CodeValidatorTester) {
@@ -1272,21 +1268,21 @@ def test_memory_init(t: CodeValidatorTester) {
 	t.addData(0, [0]);
 	t.module.explicit_data_count = 1;
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0];
+	var code1: Array<byte> = [Opcode.MEMORY_INIT.prefix, u8.!(Opcode.MEMORY_INIT.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_INIT.prefix, u8.!(Opcode.MEMORY_INIT.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 1, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_INIT.prefix, u8.!(Opcode.MEMORY_INIT.code), 1, 0
 	];
 	t.invalid(WasmError.OOB_INDEX, code3, 9);
 }
@@ -1294,21 +1290,21 @@ def test_memory_init(t: CodeValidatorTester) {
 def test_memory_copy(t: CodeValidatorTester) {
 	t.addMemory(1, Max.Set(1));
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 0, 0];
+	var code1: Array<byte> = [Opcode.MEMORY_COPY.prefix, u8.!(Opcode.MEMORY_COPY.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_COPY.prefix, u8.!(Opcode.MEMORY_COPY.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 1, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_COPY.prefix, u8.!(Opcode.MEMORY_COPY.code), 1, 0
 	];
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, code3, 9);
 }
@@ -1316,21 +1312,21 @@ def test_memory_copy(t: CodeValidatorTester) {
 def test_memory_fill(t: CodeValidatorTester) {
 	t.addMemory(1, Max.Set(1));
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 0];
+	var code1: Array<byte> = [Opcode.MEMORY_FILL.prefix, u8.!(Opcode.MEMORY_FILL.code), 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_FILL.prefix, u8.!(Opcode.MEMORY_FILL.code), 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 1
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_FILL.prefix, u8.!(Opcode.MEMORY_FILL.code), 1
 	];
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, code3, 9);
 }
@@ -1338,21 +1334,21 @@ def test_memory_fill(t: CodeValidatorTester) {
 def test_table_init(t: CodeValidatorTester) {
 	t.addTable(1, 1, [1]);
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 0, 0];
+	var code1: Array<byte> = [Opcode.TABLE_INIT.prefix, u8.!(Opcode.TABLE_INIT.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_INIT.prefix, u8.!(Opcode.TABLE_INIT.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 1, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_INIT.prefix, u8.!(Opcode.TABLE_INIT.code), 1, 0
 	];
 	t.invalid(WasmError.OOB_INDEX, code3, 9);
 }
@@ -1360,21 +1356,21 @@ def test_table_init(t: CodeValidatorTester) {
 def test_table_copy1(t: CodeValidatorTester) {
 	t.addTable(1, 1, [0]);
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 0, 0];
+	var code1: Array<byte> = [Opcode.TABLE_COPY.prefix, u8.!(Opcode.TABLE_COPY.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 0, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_COPY.prefix, u8.!(Opcode.TABLE_COPY.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 1, 0
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_COPY.prefix, u8.!(Opcode.TABLE_COPY.code), 1, 0
 	];
 	t.invalid(WasmError.OOB_INDEX, code3, 9);
 }
@@ -1386,10 +1382,10 @@ def test_table_copy2(t: CodeValidatorTester) {
 	t.module.addDecl(table2);
 	t.sig(SigCache.v_v);
 	var code1: Array<byte> = [
-		op8(Opcode.I32_CONST.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_CONST.code), 2,
-		Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), byte.!(table1.table_index), byte.!(table2.table_index)
+		u8.!(Opcode.I32_CONST.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_COPY.prefix, u8.!(Opcode.TABLE_COPY.code), byte.!(table1.table_index), byte.!(table2.table_index)
 	];
 	t.TypeError(code1, 7);
 }
@@ -1398,24 +1394,24 @@ def test_elem_drop(t: CodeValidatorTester) {
 	t.addTable(1, 0, [0]);
 	t.sig(SigCache.v_v);
 
-	t.valid([Opcode.ELEM_DROP.prefix, op8(Opcode.ELEM_DROP.code), 0]);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.ELEM_DROP.prefix, op8(Opcode.ELEM_DROP.code), 1], 3);
+	t.valid([Opcode.ELEM_DROP.prefix, u8.!(Opcode.ELEM_DROP.code), 0]);
+	t.invalid(WasmError.OOB_INDEX, [Opcode.ELEM_DROP.prefix, u8.!(Opcode.ELEM_DROP.code), 1], 3);
 }
 
 def test_table_get(t: CodeValidatorTester) {
 	t.addTable(1, 0, [0]);
 	t.sig(SigCache.v_g);
 	t.sig(SigCache.v_e);
-	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.I32_CONST.code), 0, op8(Opcode.TABLE_GET.code), 0], 5);
-	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.I32_CONST.code), 0, op8(Opcode.TABLE_GET.code), 1], 4);
+	t.invalid(WasmError.TYPE_MISMATCH, [u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.TABLE_GET.code), 0], 5);
+	t.invalid(WasmError.OOB_INDEX, [u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.TABLE_GET.code), 1], 4);
 }
 
 def test_table_set(t: CodeValidatorTester) {
 	t.addTable(1, 0, [0]);
 	t.sig(SigCache.g_v);
-	var code1: Array<byte> = [op8(Opcode.I32_CONST.code), 0, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.TABLE_SET.code), 0];
+	var code1: Array<byte> = [u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.TABLE_SET.code), 0];
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.I32_CONST.code), 0, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.TABLE_SET.code), 2], 6);
+	t.invalid(WasmError.OOB_INDEX, [u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.TABLE_SET.code), 2], 6);
 	t.sig(SigCache.e_v);
 	t.invalid(WasmError.TYPE_MISMATCH, code1, 5);
 }
@@ -1423,19 +1419,19 @@ def test_table_set(t: CodeValidatorTester) {
 def test_table_grow(t: CodeValidatorTester) {
 	t.addTable(1, 1, [0]);
 	t.sig0([ValueTypes.EXTERNREF, ValueType.I32], SigCache.arr_i);
-	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0];
+	var code1: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.LOCAL_GET.code), 1, Opcode.TABLE_GROW.prefix, u8.!(Opcode.TABLE_GROW.code), 0];
 	t.TypeError(code1, 5);
 	t.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_i);
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 1], 7);
+	t.invalid(WasmError.OOB_INDEX, [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.LOCAL_GET.code), 1, Opcode.TABLE_GROW.prefix, u8.!(Opcode.TABLE_GROW.code), 1], 7);
 }
 
 def test_table_size(t: CodeValidatorTester) {
 	t.addTable(3, 0, [0, 0, 0]);
 	t.sig(SigCache.v_i);
-	var code1: Array<byte> = [Opcode.TABLE_SIZE.prefix, op8(Opcode.TABLE_SIZE.code), 0];
+	var code1: Array<byte> = [Opcode.TABLE_SIZE.prefix, u8.!(Opcode.TABLE_SIZE.code), 0];
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.TABLE_SIZE.prefix, op8(Opcode.TABLE_SIZE.code), 1], 3);
+	t.invalid(WasmError.OOB_INDEX, [Opcode.TABLE_SIZE.prefix, u8.!(Opcode.TABLE_SIZE.code), 1], 3);
 	t.sig(SigCache.v_f);
 	t.TypeError(code1, 4);
 }
@@ -1444,19 +1440,19 @@ def test_table_fill(t: CodeValidatorTester) {
 	t.addTable(1, 1, [0]);
 	t.sig0([ValueType.I32, ValueTypes.EXTERNREF, ValueType.I32], SigCache.arr_v);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.TABLE_FILL.prefix, op8(Opcode.TABLE_FILL.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_FILL.prefix, u8.!(Opcode.TABLE_FILL.code), 0
 	];
 	t.TypeError(code1, 7);
 	t.sig0([ValueType.I32, ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_v);
 	t.valid(code1);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.TABLE_FILL.prefix, op8(Opcode.TABLE_FILL.code), 1
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_FILL.prefix, u8.!(Opcode.TABLE_FILL.code), 1
 	], 9);
 }
 
@@ -1466,27 +1462,27 @@ def test_call_ref0(t: CodeValidatorTester) {
 	var ref_i_i = ValueTypes.RefFunc(false, sig_i_i);
 	var ref_v_v = ValueTypes.RefFunc(false, sig_v_v);
 
-	var code1_i_i: Array<byte> = [op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
-	var code1_v_v: Array<byte> = [op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_v)];
-	var code2_i_i: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
-	var code2_v_v: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code1_i_i: Array<byte> = [u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code1_v_v: Array<byte> = [u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_v_v)];
+	var code2_i_i: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code2_v_v: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
 
 	t.sig(SigCache.i_i);
-	t.invalid(WasmError.INVALID_OPCODE, [op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)], 1);
+	t.invalid(WasmError.INVALID_OPCODE, [u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)], 1);
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
 
 	for (sig in [sig_i_i, sig_v_v]) {
-		var code1: Array<byte> = [op8(Opcode.CALL_REF.code), heapIndexByte(sig)];
+		var code1: Array<byte> = [u8.!(Opcode.CALL_REF.code), heapIndexByte(sig)];
 		t.sig(sig);
 		t.TypeError(code1, 1);
 
 		t.sig(newSig([ref_v_v], SigCache.arr_v));
-		var code2: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL_REF.code), heapIndexByte(sig)];
+		var code2: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.CALL_REF.code), heapIndexByte(sig)];
 		if (sig == sig_v_v) t.valid(code2);
 		else t.TypeError(code2, 3);
 	}
 
-	var code3: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code3: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
 	t.sig0([ValueType.I32, ref_i_i], SigCache.arr_v);
 	t.TypeError(code3, 7);
 	t.sig0([ValueType.I32, ref_i_i], SigCache.arr_i);
@@ -1506,7 +1502,7 @@ def test_retcall_ref0(t: CodeValidatorTester) {
 	var ref_i_i = ValueTypes.RefFunc(false, sig_i_i);
 	var ref_i_v = ValueTypes.RefFunc(false, sig_i_v);
 	var ref_i_l = ValueTypes.RefFunc(false, sig_i_l);
-	var code1: Array<byte> = [op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code1: Array<byte> = [u8.!(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_i_i)];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 1);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
@@ -1514,16 +1510,16 @@ def test_retcall_ref0(t: CodeValidatorTester) {
 
 	for (sig in [sig_v_v, sig_i_i, sig_i_v, sig_i_l]) {
 		t.sig(sig_v_v);
-		var code2: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig)];
+		var code2: Array<byte> = [u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig)];
 		var ref = ValueType.Ref(false, HeapType.Func(sig));
 		t.sig0([ref], SigCache.arr_v);
 		if (sig == sig_v_v) t.valid(code2);
 		else t.TypeError(code2, 3);
 
 		var code3: Array<byte> = [
-			op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.LOCAL_GET.code), 1,
-			op8(Opcode.RETURN_CALL_REF.code),
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.LOCAL_GET.code), 1,
+			u8.!(Opcode.RETURN_CALL_REF.code),
 			heapIndexByte(sig)
 		];
 
@@ -1554,9 +1550,9 @@ def test_ref_eq(t: CodeValidatorTester) {
 		ValueType.I32, ValueType.F32, ValueTypes.RefStruct(false, st), ValueTypes.ANYREF, ValueTypes.EQREF, ValueTypes.STRUCTREF, ValueTypes.I31REF
 	];
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.REF_EQ.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.REF_EQ.code)
 	];
 	// TODO: test externref and funcref
 	for (x in cases) {
@@ -1573,9 +1569,9 @@ def test_struct_new(t: CodeValidatorTester) {
 	var st = t.newStruct([unpackedT(ValueType.F32, true)]);
 	t.sig(SigCache.d_d);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		op8(Opcode.STRUCT_NEW.code),
+		u8.!(Opcode.STRUCT_NEW.code),
 		heapIndexByte(st)
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
@@ -1587,17 +1583,17 @@ def test_struct_new(t: CodeValidatorTester) {
 	t.valid(code1);
 
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		op8(Opcode.STRUCT_NEW.code),
+		u8.!(Opcode.STRUCT_NEW.code),
 		byte.view(t.module.heaptypes.length) // oob
 	], 5);
 
 	var ft = t.addSig(SigCache.ff_i).heaptype_index;
 	t.invalid(WasmError.ILLEGAL_TYPE, [
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		op8(Opcode.STRUCT_NEW.code),
+		u8.!(Opcode.STRUCT_NEW.code),
 		byte.view(ft) // func type reference
 	], 5);
 }
@@ -1614,7 +1610,7 @@ def test_struct_newdef(t: CodeValidatorTester) {
 		var st = t.newStruct([unpackedT(c.0, true)]);
 		var code1: Array<byte> = [
 			Opcode.STRUCT_NEW_DEFAULT.prefix,
-			op8(Opcode.STRUCT_NEW_DEFAULT.code),
+			u8.!(Opcode.STRUCT_NEW_DEFAULT.code),
 			heapIndexByte(st)
 		];
 
@@ -1639,16 +1635,16 @@ def test_struct_get(t: CodeValidatorTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, st)], SigCache.arr_i);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code), heapIndexByte(st), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_GET.prefix, u8.!(Opcode.STRUCT_GET.code), heapIndexByte(st), 0
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code), heapIndexByte(st), 1
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_GET.prefix, u8.!(Opcode.STRUCT_GET.code), heapIndexByte(st), 1
 	], 7);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code), heapIndexByte(st), 2
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_GET.prefix, u8.!(Opcode.STRUCT_GET.code), heapIndexByte(st), 2
 	], 6);
 }
 
@@ -1660,8 +1656,8 @@ def test_struct_get_su(t: CodeValidatorTester) {
 
 		for (opcode in [Opcode.STRUCT_GET_S, Opcode.STRUCT_GET_U, Opcode.STRUCT_GET]) {
 			var code1: Array<byte> = [
-				op8(Opcode.LOCAL_GET.code), 0,
-				opcode.prefix, op8(opcode.code), heapIndexByte(st), 0
+				u8.!(Opcode.LOCAL_GET.code), 0,
+				opcode.prefix, u8.!(opcode.code), heapIndexByte(st), 0
 			];
 			var ok = (pack == Packedness.UNPACKED) == (opcode == Opcode.STRUCT_GET);
 			if (ok) t.valid(code1);
@@ -1676,23 +1672,23 @@ def test_struct_set(t: CodeValidatorTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, st)], SigCache.arr_v);
 	t.valid([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		Opcode.STRUCT_SET.prefix, u8.!(Opcode.STRUCT_SET.code), heapIndexByte(st), 0
 	]);
 	t.TypeError([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_CONST.code), 1,
-		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_CONST.code), 1,
+		Opcode.STRUCT_SET.prefix, u8.!(Opcode.STRUCT_SET.code), heapIndexByte(st), 0
 	], 5);
 	t.invalid(WasmError.ILLEGAL_ASSIGNMENT, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 1
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		Opcode.STRUCT_SET.prefix, u8.!(Opcode.STRUCT_SET.code), heapIndexByte(st), 1
 	], 5);
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 2
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_SET.prefix, u8.!(Opcode.STRUCT_SET.code), heapIndexByte(st), 2
 	], 6);
 }
 
@@ -1700,10 +1696,10 @@ def test_array_new(t: CodeValidatorTester) {
 	var at = t.newArray([unpackedT(ValueType.F64, true)]);
 	t.sig(SigCache.f_f);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 6,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 6,
 		Opcode.ARRAY_NEW.prefix,
-		op8(Opcode.ARRAY_NEW.code),
+		u8.!(Opcode.ARRAY_NEW.code),
 		heapIndexByte(at)
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 5);
@@ -1715,19 +1711,19 @@ def test_array_new(t: CodeValidatorTester) {
 	t.valid(code1);
 
 	t.invalid(WasmError.OOB_INDEX, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 7,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 7,
 		Opcode.ARRAY_NEW.prefix,
-		op8(Opcode.ARRAY_NEW.code),
+		u8.!(Opcode.ARRAY_NEW.code),
 		byte.view(t.module.heaptypes.length) // oob
 	], 7);
 
 	var ft = t.addSig(SigCache.dd_i).heaptype_index;
 	t.invalid(WasmError.ILLEGAL_TYPE, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 8,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 8,
 		Opcode.ARRAY_NEW.prefix,
-		op8(Opcode.ARRAY_NEW.code),
+		u8.!(Opcode.ARRAY_NEW.code),
 		byte.view(ft) // func type reference
 	], 7);
 }
@@ -1743,9 +1739,9 @@ def test_array_newdef(t: CodeValidatorTester) {
 	for (c in cases) {
 		var at = t.newArray([unpackedT(c.0, true)]);
 		var code1: Array<byte> = [
-			op8(Opcode.I32_CONST.code), 5,
+			u8.!(Opcode.I32_CONST.code), 5,
 			Opcode.ARRAY_NEW_DEFAULT.prefix,
-			op8(Opcode.ARRAY_NEW_DEFAULT.code),
+			u8.!(Opcode.ARRAY_NEW_DEFAULT.code),
 			heapIndexByte(at)
 		];
 
@@ -1754,9 +1750,9 @@ def test_array_newdef(t: CodeValidatorTester) {
 			t.TypeError(code1, 6);
 			t.sig0(SigCache.arr_v, [ValueTypes.RefArray(false, at)]);
 			t.valid([
-				op8(Opcode.I32_CONST.code), 5,
+				u8.!(Opcode.I32_CONST.code), 5,
 				Opcode.ARRAY_NEW_DEFAULT.prefix,
-				op8(Opcode.ARRAY_NEW_DEFAULT.code),
+				u8.!(Opcode.ARRAY_NEW_DEFAULT.code),
 				heapIndexByte(at)
 			]);
 		} else {
@@ -1772,9 +1768,9 @@ def test_array_get(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.I64, true)]);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 3,
-		Opcode.ARRAY_GET.prefix, op8(Opcode.ARRAY_GET.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 3,
+		Opcode.ARRAY_GET.prefix, u8.!(Opcode.ARRAY_GET.code), heapIndexByte(at)
 	];
 	t.sig(SigCache.f_f);
 	t.TypeError(code1, 5);
@@ -1793,9 +1789,9 @@ def test_array_get_su(t: CodeValidatorTester) {
 		t.sig0([ValueTypes.RefArray(false, at)], SigCache.arr_i);
 		for (opcode in [Opcode.ARRAY_GET_S, Opcode.ARRAY_GET_U, Opcode.ARRAY_GET]) {
 			var code1: Array<byte> = [
-				op8(Opcode.LOCAL_GET.code), 0,
-				op8(Opcode.I32_CONST.code), 11,
-				opcode.prefix, op8(opcode.code), heapIndexByte(at), 0
+				u8.!(Opcode.LOCAL_GET.code), 0,
+				u8.!(Opcode.I32_CONST.code), 11,
+				opcode.prefix, u8.!(opcode.code), heapIndexByte(at), 0
 			];
 			var ok = (pack == Packedness.UNPACKED) == (opcode == Opcode.ARRAY_GET);
 			if (ok) t.valid(code1);
@@ -1808,10 +1804,10 @@ def test_array_set(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.F32, true)]);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 3,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.ARRAY_SET.prefix, op8(Opcode.ARRAY_SET.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 3,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_SET.prefix, u8.!(Opcode.ARRAY_SET.code), heapIndexByte(at)
 	];
 	t.sig(SigCache.ff_f);
 	t.TypeError(code1, 7);
@@ -1829,8 +1825,8 @@ def test_array_len(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.F64, true)]);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ARRAY_LEN.prefix, op8(Opcode.ARRAY_LEN.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_LEN.prefix, u8.!(Opcode.ARRAY_LEN.code), heapIndexByte(at)
 	];
 	t.sig(SigCache.f_f);
 	t.TypeError(code1, 3);
@@ -1846,8 +1842,8 @@ def test_array_new_fixed(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.F64, true)]);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ARRAY_NEW_FIXED.prefix, op8(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), 1
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_NEW_FIXED.prefix, u8.!(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), 1
 	];
 	var results: Array<ValueType> = [ValueTypes.RefArray(false, at)];
 	t.sig(SigCache.dd_d);
@@ -1859,8 +1855,8 @@ def test_array_new_fixed(t: CodeValidatorTester) {
 	var params = Vector<ValueType>.new();
 	for (count < 5) {
 		code.resize(0);
-		for (i < count) code.put(op8(Opcode.LOCAL_GET.code)).put(byte.view(i));
-		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, op8(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), byte.view(count)]);
+		for (i < count) code.put(u8.!(Opcode.LOCAL_GET.code)).put(byte.view(i));
+		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, u8.!(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), byte.view(count)]);
 		for (i < count) params.put(ValueType.F64);
 
 		var raw = code.extract();
@@ -1882,9 +1878,9 @@ def test_array_new_data(t: CodeValidatorTester) {
 	t.addData(0, [0]);
 	t.module.explicit_data_count = 1;
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.ARRAY_NEW_DATA.prefix, op8(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(at), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_DATA.prefix, u8.!(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(at), 0
 	];
 	var results: Array<ValueType> = [ValueTypes.RefArray(false, at)];
 	t.sig0([ValueType.I32, ValueType.F32], results);
@@ -1893,16 +1889,16 @@ def test_array_new_data(t: CodeValidatorTester) {
 	t.valid(code1);
 
 	var code2: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.ARRAY_NEW_DATA.prefix, op8(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(at), 1 // data index OOB
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_DATA.prefix, u8.!(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(at), 1 // data index OOB
 	];
 	t.invalid(WasmError.OOB_INDEX, code2, 8);
 
 	var code3: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.ARRAY_NEW_DATA.prefix, op8(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(rat), 0 // reference array
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_DATA.prefix, u8.!(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(rat), 0 // reference array
 	];
 
 	results = [ValueTypes.RefArray(false, rat)];
@@ -1926,9 +1922,9 @@ def test_array_new_elem(t: CodeValidatorTester) {
 		(dat, dtable, true)]) { // test all permutations of anyref, dataref
 
 		var code1: Array<byte> = [
-			op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.LOCAL_GET.code), 1,
-			Opcode.ARRAY_NEW_ELEM.prefix, op8(Opcode.ARRAY_NEW_ELEM.code), heapIndexByte(i.0), byte.view(i.1.1.elem_index)
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.LOCAL_GET.code), 1,
+			Opcode.ARRAY_NEW_ELEM.prefix, u8.!(Opcode.ARRAY_NEW_ELEM.code), heapIndexByte(i.0), byte.view(i.1.1.elem_index)
 		];
 		var results: Array<ValueType> = [ValueTypes.RefArray(false, i.0)];
 		t.sig0([ValueType.I32, ValueType.F32], results);
@@ -1939,9 +1935,9 @@ def test_array_new_elem(t: CodeValidatorTester) {
 	}
 
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.ARRAY_NEW_ELEM.prefix, op8(Opcode.ARRAY_NEW_ELEM.code), heapIndexByte(aat), byte.view(t.module.elems.length)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_ELEM.prefix, u8.!(Opcode.ARRAY_NEW_ELEM.code), heapIndexByte(aat), byte.view(t.module.elems.length)
 	];
 	var results: Array<ValueType> = [ValueTypes.RefArray(false, aat)];
 	t.sig0([ValueType.I32, ValueType.I32], results);
@@ -1951,8 +1947,8 @@ def test_array_new_elem(t: CodeValidatorTester) {
 def test_i31_new(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_I31.prefix, op8(Opcode.REF_I31.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_I31.prefix, u8.!(Opcode.REF_I31.code)
 	];
 	t.sig(SigCache.i_i);
 	t.TypeError(code1, 5);
@@ -1968,8 +1964,8 @@ def test_i31_get_su(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	for (opcode in [Opcode.I31_GET_S, Opcode.I31_GET_U]) {
 		var code1: Array<byte> = [
-			op8(Opcode.LOCAL_GET.code), 0,
-			opcode.prefix, op8(opcode.code)
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			opcode.prefix, u8.!(opcode.code)
 		];
 		t.sig(SigCache.i_i);
 		t.TypeError(code1, 3);
@@ -2003,8 +1999,8 @@ def testDeclPairs(t: CodeValidatorTester,
 def test_ref_test0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Ref, dj: HeapTypeDecl, djt: ValueType.Ref) {
 	t.setExtensions(Extension.GC);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_TEST.prefix, op8(Opcode.REF_TEST.code), heapIndexByte(dj)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_TEST.prefix, u8.!(Opcode.REF_TEST.code), heapIndexByte(dj)
 	];
 	t.sig0([dit], SigCache.arr_i);
 	t.valid(code1);
@@ -2015,8 +2011,8 @@ def test_ref_test0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Ref,
 def test_ref_cast0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Ref, dj: HeapTypeDecl, djt: ValueType.Ref) {
 	t.setExtensions(Extension.GC);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_CAST.prefix, op8(Opcode.REF_CAST.code), heapIndexByte(dj)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_CAST.prefix, u8.!(Opcode.REF_CAST.code), heapIndexByte(dj)
 	];
 	var arr_djt: Array<ValueType> = [djt];
 	t.sig0([dit], arr_djt);
@@ -2033,9 +2029,9 @@ def test_br_on_cast0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Re
 	t.setExtensions(Extension.GC);
 	var flags = nullableFlags(dit, djt);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), flags, 0, heapIndexByte(di), heapIndexByte(dj),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, u8.!(Opcode.BR_ON_CAST.code), flags, 0, heapIndexByte(di), heapIndexByte(dj),
+		u8.!(Opcode.UNREACHABLE.code)
 	];
 	var rt: Array<ValueType> = [djt];
 	t.sig0([dit], rt);
@@ -2058,11 +2054,11 @@ def test_br_on_cast1(t: CodeValidatorTester) {
 	for (opcode in [Opcode.NOP, Opcode.DROP, Opcode.UNREACHABLE]) {
 		var flags = nullableFlags(st1t, st2t);
 		var code1: Array<byte> = [
-			op8(Opcode.BLOCK.code), BpTypeCode.REF.code, heapIndexByte(st2),
-			op8(Opcode.LOCAL_GET.code), 0,
-			Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), flags, 0, heapIndexByte(st1), heapIndexByte(st2),
-			op8(opcode.code), // drop, nop, or unreachable
-			op8(Opcode.END.code)
+			u8.!(Opcode.BLOCK.code), BpTypeCode.REF.code, heapIndexByte(st2),
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			Opcode.BR_ON_CAST.prefix, u8.!(Opcode.BR_ON_CAST.code), flags, 0, heapIndexByte(st1), heapIndexByte(st2),
+			u8.!(opcode.code), // drop, nop, or unreachable
+			u8.!(Opcode.END.code)
 		];
 
 		t.sig0([st1t], [st2t]);
@@ -2086,8 +2082,8 @@ def shared_br_on_cast_fail0(t: CodeValidatorTester, error: WasmError, from_nulla
 	t.sig0([ft], [tt]);
 	var flags = nullableFlags(ft, tt);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST_FAIL.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), flags, 0, heapIndexByte(st1), heapIndexByte(st1)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST_FAIL.prefix, u8.!(Opcode.BR_ON_CAST_FAIL.code), flags, 0, heapIndexByte(st1), heapIndexByte(st1)
 	];
 	if (error == WasmError.NONE) t.valid(code1);
 	else t.invalid(error, code1, 3);
@@ -2106,8 +2102,8 @@ def test_br_on_cast_fail1(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueTy
 	t.setExtensions(Extension.GC);
 	var flags = nullableFlags(dit, djt);
 	var code1: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST_FAIL.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), flags, 0, heapIndexByte(di), heapIndexByte(dj)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST_FAIL.prefix, u8.!(Opcode.BR_ON_CAST_FAIL.code), flags, 0, heapIndexByte(di), heapIndexByte(dj)
 	];
 	if (!ValueTypes.isAssignable(djt, dit)) {
 		t.sig0([dit], [djt]);
@@ -2202,7 +2198,7 @@ def test_simd_unop1(t: CodeValidatorTester) {
 
 def test_simd_unop2(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	t.sig(SigCache.s_s);
@@ -2215,7 +2211,7 @@ def test_simd_unop2(t: CodeValidatorTester) {
 
 def test_simd_unop3(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	for (sig in [SigCache.i_i, SigCache.i_s, SigCache.f_s, SigCache.ff_f]) {
@@ -2354,7 +2350,7 @@ def SIMD_BINOPS = [
 
 def test_simd_binop1(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	t.sig(SigCache.ss_s);
@@ -2368,8 +2364,8 @@ def test_simd_binop1(t: CodeValidatorTester) {
 
 def test_simd_binop2(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	t.sig(SigCache.ss_s);
@@ -2383,8 +2379,8 @@ def test_simd_binop2(t: CodeValidatorTester) {
 
 def test_simd_binop3(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	for (sig in [SigCache.ii_i, SigCache.is_s, SigCache.si_s, SigCache.ff_f]) {

--- a/test/unittest/CodeValidatorTest.v3
+++ b/test/unittest/CodeValidatorTest.v3
@@ -2,10 +2,10 @@
 // See LICENSE for details of Apache 2.0 license.
 
 // provide short names
-def op7(code: u16) -> u8 { return Opcodes.op7(code); }
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
-def op14l(code: u16) -> u8 { return Opcodes.op14l(code); }
-def op14h(code: u16) -> u8 { return Opcodes.op14h(code); }
+def op7   = Opcodes.op7;
+def op8   = Opcodes.op8;
+def op14l = Opcodes.op14l;
+def op14h = Opcodes.op14h;
 def op14l_no_check(code: u16) -> u8 { return byte.!((code & 0x7f) | 0x80); }
 def op14h_no_check(code: u16) -> u8 { return byte.!(code >> 7); }
 

--- a/test/unittest/CodeValidatorTest.v3
+++ b/test/unittest/CodeValidatorTest.v3
@@ -1,6 +1,14 @@
 // Copyright 2020 Ben L. Titzer. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
+// provide short names
+def op7(code: u16) -> u8 { return Opcodes.op7(code); }
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op14l(code: u16) -> u8 { return Opcodes.op14l(code); }
+def op14h(code: u16) -> u8 { return Opcodes.op14h(code); }
+def op14l_no_check(code: u16) -> u8 { return byte.!((code & 0x7f) | 0x80); }
+def op14h_no_check(code: u16) -> u8 { return byte.!(code >> 7); }
+
 def T = UnitTests.registerT("validator:", _, CodeValidatorTester.new, _);
 def X_ = void(
 	T("local0", test_local0),
@@ -145,14 +153,14 @@ class CodeValidatorTester(t: Tester) extends ModuleBuilder {
 def EB = BpTypeCode.EmptyBlock.code;
 
 def test_local0(t: CodeValidatorTester) {
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0];
 	t.invalid(WasmError.OOB_INDEX, code1, 1);
 	t.sig(SigCache.i_i);
 	t.valid(code1);
 }
 
 def test_local1(t: CodeValidatorTester) {
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0];
 	t.sig(SigCache.i_i);
 	t.addLocals(10000000, ValueType.I32);
 	t.invalid(WasmError.EXCEEDED_LIMIT, code1, 1);
@@ -162,11 +170,11 @@ def test_localref(t: CodeValidatorTester) {
 	var lg = t.addLocals(1, ValueTypes.FUNCREF);
 	var le = t.addLocals(1, ValueTypes.EXTERNREF);
 	t.sig0([ValueTypes.FUNCREF, ValueTypes.EXTERNREF], SigCache.arr_v);
-	t.valid([Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_SET.code, byte.!(lg)]);
-	t.valid([Opcode.LOCAL_GET.code, 1, Opcode.LOCAL_SET.code, byte.!(le)]);
+	t.valid([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_SET.code), byte.!(lg)]);
+	t.valid([op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.LOCAL_SET.code), byte.!(le)]);
 
-	t.invalid(WasmError.TYPE_MISMATCH, [Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_SET.code, byte.!(le)], 7);
-	t.invalid(WasmError.TYPE_MISMATCH, [Opcode.LOCAL_GET.code, 1, Opcode.LOCAL_SET.code, byte.!(lg)], 7);
+	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_SET.code), byte.!(le)], 7);
+	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.LOCAL_SET.code), byte.!(lg)], 7);
 }
 
 def test_globalref(t: CodeValidatorTester) {
@@ -174,15 +182,15 @@ def test_globalref(t: CodeValidatorTester) {
 	var le = byte.!(t.newGlobal(ValueTypes.EXTERNREF, InitExpr.ExternRefNull).global_index);
 
 	t.sig0([ValueTypes.FUNCREF, ValueTypes.EXTERNREF], SigCache.arr_v);
-	t.valid([Opcode.LOCAL_GET.code, 0, Opcode.GLOBAL_SET.code, lg]);
-	t.valid([Opcode.LOCAL_GET.code, 1, Opcode.GLOBAL_SET.code, le]);
+	t.valid([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.GLOBAL_SET.code), lg]);
+	t.valid([op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.GLOBAL_SET.code), le]);
 
-	t.invalid(WasmError.TYPE_MISMATCH, [Opcode.LOCAL_GET.code, 0, Opcode.GLOBAL_SET.code, le], 3);
-	t.invalid(WasmError.TYPE_MISMATCH, [Opcode.LOCAL_GET.code, 1, Opcode.GLOBAL_SET.code, lg], 3);
+	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.GLOBAL_SET.code), le], 3);
+	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.GLOBAL_SET.code), lg], 3);
 }
 
 def test_refparam(t: CodeValidatorTester) {
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0];
 	var refs = [ValueTypes.FUNCREF, ValueTypes.EXTERNREF];
 	for (p in refs) {
 		for (r in refs) {
@@ -196,41 +204,41 @@ def test_refparam(t: CodeValidatorTester) {
 def test_ret0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
 	t.valid([]);
-	t.valid([Opcode.RETURN.code]);
+	t.valid([op8(Opcode.RETURN.code)]);
 
-	t.TypeError([Opcode.I32_CONST.code, 0], 3);
-	t.TypeError([Opcode.I64_CONST.code, 0], 3);
-	t.TypeError([Opcode.F32_CONST.code, 0, 0, 0, 0], 6);
-	t.TypeError([Opcode.F64_CONST.code, 0, 0, 0, 0, 0, 0, 0, 0], 10);
+	t.TypeError([op8(Opcode.I32_CONST.code), 0], 3);
+	t.TypeError([op8(Opcode.I64_CONST.code), 0], 3);
+	t.TypeError([op8(Opcode.F32_CONST.code), 0, 0, 0, 0], 6);
+	t.TypeError([op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0], 10);
 }
 
 def test_ret1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.TypeError([], 1);
-	t.TypeError([Opcode.RETURN.code], 1);
+	t.TypeError([op8(Opcode.RETURN.code)], 1);
 
-	t.valid([Opcode.I32_CONST.code, 0]);
-	t.TypeError([Opcode.I64_CONST.code, 0], 3);
-	t.TypeError([Opcode.F32_CONST.code, 0, 0, 0, 0], 6);
-	t.TypeError([Opcode.F64_CONST.code, 0, 0, 0, 0, 0, 0, 0, 0], 10);
+	t.valid([op8(Opcode.I32_CONST.code), 0]);
+	t.TypeError([op8(Opcode.I64_CONST.code), 0], 3);
+	t.TypeError([op8(Opcode.F32_CONST.code), 0, 0, 0, 0], 6);
+	t.TypeError([op8(Opcode.F64_CONST.code), 0, 0, 0, 0, 0, 0, 0, 0], 10);
 }
 
 def test_br0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
-	t.valid([Opcode.BR.code, 0]);
-	t.invalid(WasmError.OOB_LABEL, [Opcode.BR.code, 1], 1);
+	t.valid([op8(Opcode.BR.code), 0]);
+	t.invalid(WasmError.OOB_LABEL, [op8(Opcode.BR.code), 1], 1);
 	t.invalid(WasmError.OOB_LABEL, [
-		Opcode.BLOCK.code, EB,
-		Opcode.BR.code, 2,
-		Opcode.END.code
+		op8(Opcode.BLOCK.code), EB,
+		op8(Opcode.BR.code), 2,
+		op8(Opcode.END.code)
 	], 3);
 }
 
 def test_br_table0(t: CodeValidatorTester) {
 	var code1: Array<byte> = [
-		Opcode.I32_CONST.code, 7,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2, 0, 0, 0];
+		op8(Opcode.I32_CONST.code), 7,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2, 0, 0, 0];
 	t.sig(SigCache.i_i);
 	t.valid(code1);
 
@@ -241,11 +249,11 @@ def test_br_table0(t: CodeValidatorTester) {
 	t.TypeError(code1, 5);
 
 	var code2: Array<byte> = [
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 7,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2, 0, 1, 0,
-		Opcode.END.code];
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 7,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2, 0, 1, 0,
+		op8(Opcode.END.code)];
 	t.sig(SigCache.i_i);
 	t.valid(code2);
 
@@ -255,31 +263,31 @@ def test_br_table0(t: CodeValidatorTester) {
 
 def test_br_table1(t: CodeValidatorTester) {
 	var code1: Array<byte> = [
-		Opcode.BLOCK.code, EB,
-		Opcode.I32_CONST.code, 8,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2, 0, 1, 0,
-		Opcode.END.code];
+		op8(Opcode.BLOCK.code), EB,
+		op8(Opcode.I32_CONST.code), 8,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2, 0, 1, 0,
+		op8(Opcode.END.code)];
 	t.sig(SigCache.i_i);
 	t.TypeError(code1, 7);
 
 	var code2: Array<byte> = [
-		Opcode.F32_CONST.code, 0, 0, 0, 0,
-		Opcode.LOOP.code, BpTypeCode.F32.code,
-		Opcode.I32_CONST.code, 9,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2, 0, 1, 0,
-		Opcode.END.code];
+		op8(Opcode.F32_CONST.code), 0, 0, 0, 0,
+		op8(Opcode.LOOP.code), BpTypeCode.F32.code,
+		op8(Opcode.I32_CONST.code), 9,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2, 0, 1, 0,
+		op8(Opcode.END.code)];
 	t.sig(SigCache.i_i);
 	t.TypeError(code2, 12);
 }
 
 def test_if0(t: CodeValidatorTester) {
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	];
 	t.sig(SigCache.i_v);
 	t.valid(code1);
@@ -288,12 +296,12 @@ def test_if0(t: CodeValidatorTester) {
 	t.TypeError(code1, 3);
 
 	var code2: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.BR.code, 0,
-		Opcode.ELSE.code,
-		Opcode.RETURN.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code)
 	];
 	t.sig(SigCache.i_v);
 	t.valid(code2);
@@ -302,10 +310,10 @@ def test_if0(t: CodeValidatorTester) {
 	t.TypeError(code2, 3);
 
 	var code3: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.BR.code, 1,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.BR.code), 1,
+		op8(Opcode.END.code)
 	];
 	t.sig(SigCache.i_v);
 	t.valid(code3);
@@ -317,44 +325,44 @@ def test_if0(t: CodeValidatorTester) {
 def test_if1(t: CodeValidatorTester) {
 	t.sig(SigCache.i_i);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	], 5);
 
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.ELSE.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)
 	], 5);
 
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	], 8);
 
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.UNREACHABLE.code,
-		Opcode.ELSE.code,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	]);
 
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ELSE.code,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.END.code)
 	];
 	t.sig(SigCache.ii_i);
 	t.valid(code1);
@@ -363,12 +371,12 @@ def test_if1(t: CodeValidatorTester) {
 	t.TypeError(code1, 7);
 
 	var code2: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.F32.code,
-		Opcode.UNREACHABLE.code,
-		Opcode.ELSE.code,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.F32.code,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	];
 	t.sig(SigCache.ii_i);
 	t.TypeError(code2, 9);
@@ -377,10 +385,10 @@ def test_if1(t: CodeValidatorTester) {
 def test_if2(t: CodeValidatorTester) {
 	t.sig(SigCache.i_i);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 5,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.END.code)
 	], 7);
 }
 
@@ -389,32 +397,32 @@ def test_if_end(t: CodeValidatorTester) {
 	var i_i = byte.!(t.addSig(SigCache.i_i).heaptype_index);
 	var i_f = byte.!(t.addSig(SigCache.i_f).heaptype_index);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.END.code)
 	]);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.DROP.code,
-		Opcode.I32_CONST.code, 5,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.DROP.code),
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.I32_CONST.code, 5,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.END.code)
 	], 9);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_f,
-		Opcode.F32_CONST.code, 3, 3, 3, 3,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_f,
+		op8(Opcode.F32_CONST.code), 3, 3, 3, 3,
+		op8(Opcode.END.code)
 	], 12);
 
 }
@@ -424,49 +432,49 @@ def test_if_unr1(t: CodeValidatorTester) {
 	var i_i = byte.!(t.addSig(SigCache.i_i).heaptype_index);
 	var v_i = byte.!(t.addSig(SigCache.v_i).heaptype_index);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, v_i,
-		Opcode.UNREACHABLE.code,
-		Opcode.ELSE.code,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), v_i,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	]);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, v_i,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), v_i,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	], 6);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.UNREACHABLE.code,
-		Opcode.I32_CONST.code, 5,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.UNREACHABLE.code,
-		Opcode.I64_CONST.code, 5,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.I64_CONST.code), 5,
+		op8(Opcode.END.code)
 	], 10);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, i_i,
-		Opcode.I32_CONST.code, 5,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), i_i,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	]);
 }
 def test_if_unr2(t: CodeValidatorTester) {
@@ -474,51 +482,51 @@ def test_if_unr2(t: CodeValidatorTester) {
 	var i_i = byte.!(t.addSig(SigCache.i_i).heaptype_index);
 	var v_i = byte.!(t.addSig(SigCache.v_i).heaptype_index);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.UNREACHABLE.code,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.UNREACHABLE.code,
-		Opcode.I32_CONST.code, 5,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	], 8);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.I32_CONST.code, 1,
-		Opcode.IF.code, EB,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 5,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	], 13);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.I32_CONST.code, 5,
-		Opcode.I32_CONST.code, 1,
-		Opcode.IF.code, EB,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	], 13);
 }
 
 def test_select(t: CodeValidatorTester) {
 	var types = [ValueType.I32, ValueType.I64, ValueType.F32, ValueType.F64];
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_CONST.code, 1,
-		Opcode.SELECT.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.SELECT.code)
 	];
 	for (a in types) {
 		for (b in types) {
@@ -532,10 +540,10 @@ def test_select(t: CodeValidatorTester) {
 def test_selectn(t: CodeValidatorTester) {
 	var types = [ValueType.I32, ValueTypes.FUNCREF, ValueTypes.EXTERNREF];
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_CONST.code, 1,
-		Opcode.SELECT.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.SELECT.code)
 	];
 	for (a in types) {
 		for (b in types) {
@@ -553,10 +561,10 @@ def test_selectt(t: CodeValidatorTester) {
 		(BpTypeCode.EXTERNREF.code, ValueTypes.EXTERNREF)
 	];
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_CONST.code, 1,
-		Opcode.SELECT_T.code, 1,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.SELECT_T.code), 1,
 		0 /*tpos*/
 	];
 	var tpos = 8;
@@ -579,61 +587,61 @@ def test_selectt(t: CodeValidatorTester) {
 def test_loop0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
 	t.valid([
-		Opcode.LOOP.code, EB,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), EB,
+		op8(Opcode.END.code)
 	]);
 	t.sig(SigCache.v_i);
 	t.valid([
-		Opcode.LOOP.code, BpTypeCode.I32.code,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code)
 	]);
 	t.sig(SigCache.v_i);
 	t.valid([
-		Opcode.LOOP.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 0,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOOP.code, BpTypeCode.I32.code,
-		Opcode.I64_CONST.code, 0,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
+		op8(Opcode.I64_CONST.code), 0,
+		op8(Opcode.END.code)
 	], 5);
 	t.TypeError([
-		Opcode.LOOP.code, BpTypeCode.I64.code,
-		Opcode.I64_CONST.code, 0,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), BpTypeCode.I64.code,
+		op8(Opcode.I64_CONST.code), 0,
+		op8(Opcode.END.code)
 	], 6);
 }
 
 def test_loop_br(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
 	t.valid([
-		Opcode.LOOP.code, EB,
-		Opcode.BR.code, 0,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), EB,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code)
 	]);
 	t.valid([
-		Opcode.LOOP.code, EB,
-		Opcode.BR.code, 1,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), EB,
+		op8(Opcode.BR.code), 1,
+		op8(Opcode.END.code)
 	]);
 	t.invalid(WasmError.OOB_LABEL, [
-		Opcode.LOOP.code, EB,
-		Opcode.BR.code, 2,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), EB,
+		op8(Opcode.BR.code), 2,
+		op8(Opcode.END.code)
 	], 3);
 	t.sig(SigCache.v_i);
 	t.valid([
-		Opcode.LOOP.code, BpTypeCode.I32.code,
-		Opcode.BR.code, 0,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code)
 	]);
 	t.valid([
-		Opcode.LOOP.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 0,
-		Opcode.BR.code, 1,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.BR.code), 1,
+		op8(Opcode.END.code)
 	]);
 }
 
@@ -645,21 +653,21 @@ def test_loopv(t: CodeValidatorTester) {
 
 	t.sig(SigCache.if_v);
 	t.TypeError([
-		Opcode.LOOP.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOOP.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	], 1);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOOP.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOOP.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	], 3);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOOP.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOOP.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	]);
 }
 
@@ -669,39 +677,39 @@ def test_blockp1(t: CodeValidatorTester) {
 
 	t.sig(SigCache.if_v);
 	t.TypeError([
-		Opcode.BLOCK.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.BLOCK.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	], 1);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	], 3);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BLOCK.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BLOCK.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, i_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), i_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	], 3);
 	t.valid([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, f_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), f_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BLOCK.code, f_v,
-		Opcode.DROP.code,
-		Opcode.END.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BLOCK.code), f_v,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code)
 	], 3);
 }
 
@@ -712,44 +720,44 @@ def test_blockp2(t: CodeValidatorTester) {
 
 	t.sig(SigCache.if_v);
 	t.TypeError([
-		Opcode.BLOCK.code, f_f,
-		Opcode.END.code
+		op8(Opcode.BLOCK.code), f_f,
+		op8(Opcode.END.code)
 	], 1);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BLOCK.code, f_f,
-		Opcode.END.code,
-		Opcode.DROP.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BLOCK.code), f_f,
+		op8(Opcode.END.code),
+		op8(Opcode.DROP.code)
 	], 3);
 	t.valid([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, f_f,
-		Opcode.END.code,
-		Opcode.DROP.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), f_f,
+		op8(Opcode.END.code),
+		op8(Opcode.DROP.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, f_f,
-		Opcode.DROP.code,
-		Opcode.I32_CONST.code, 0,
-		Opcode.END.code,
-		Opcode.DROP.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), f_f,
+		op8(Opcode.DROP.code),
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.DROP.code)
 	], 8);
 	t.valid([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, f_l,
-		Opcode.DROP.code,
-		Opcode.I64_CONST.code, 0,
-		Opcode.END.code,
-		Opcode.DROP.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), f_l,
+		op8(Opcode.DROP.code),
+		op8(Opcode.I64_CONST.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.DROP.code)
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, f_l,
-		Opcode.DROP.code,
-		Opcode.I32_CONST.code, 0,
-		Opcode.END.code,
-		Opcode.DROP.code
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), f_l,
+		op8(Opcode.DROP.code),
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.DROP.code)
 	], 8);
 }
 
@@ -760,35 +768,35 @@ def test_blockv2(t: CodeValidatorTester) {
 def test_blockinv(t: CodeValidatorTester) {
 	t.sig(SigCache.i_i);
 	t.invalid(WasmError.INVALID_BLOCK_TYPE, [
-		Opcode.BLOCK.code, 33,
-		Opcode.END.code
+		op8(Opcode.BLOCK.code), 33,
+		op8(Opcode.END.code)
 	], 2);
 }
 
 def test_unterm(t: CodeValidatorTester) {
 	t.invalid(WasmError.UNTERMINATED_BODY, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.IF.code, EB
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.IF.code), EB
 	], 6);
 	t.invalid(WasmError.UNTERMINATED_BODY, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.ELSE.code
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.ELSE.code)
 	], 7);
 	t.sig(SigCache.v_v);
-	t.invalid(WasmError.OOB_LABEL, [Opcode.END.code], 2);
+	t.invalid(WasmError.OOB_LABEL, [op8(Opcode.END.code)], 2);
 }
 
 def test_else0(t: CodeValidatorTester) {
 	t.sig(SigCache.v_v);
-	t.invalid(WasmError.MISMATCHED_ELSE, [Opcode.ELSE.code], 1);
+	t.invalid(WasmError.MISMATCHED_ELSE, [op8(Opcode.ELSE.code)], 1);
 
 	t.invalid(WasmError.MISMATCHED_ELSE, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.IF.code, EB,
-		Opcode.ELSE.code,
-		Opcode.ELSE.code,
-		Opcode.END.code
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.IF.code), EB,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.END.code)
 	], 6);
 
 }
@@ -802,10 +810,10 @@ def test_simple_ops_v(t: CodeValidatorTester) {
 		if (!isSimpleOp(op)) continue;
 		t.sig(op.sig);
 		for (i < op.sig.params.length) {
-			code.put(Opcode.LOCAL_GET.code);
+			code.put(op8(Opcode.LOCAL_GET.code));
 			code.put(byte.!(i));
 		}
-		code.put(op.code);
+		code.put(op8(op.code));
 		t.valid(code.extract());
 	}
 }
@@ -819,10 +827,10 @@ def test_simple_ops_r(t: CodeValidatorTester) {
 		for (rt in types) {
 			t.sig0(op.sig.params, [rt]);
 			for (i < op.sig.params.length) {
-				code.put(Opcode.LOCAL_GET.code);
+				code.put(op8(Opcode.LOCAL_GET.code));
 				code.put(byte.!(i));
 			}
-			code.put(op.code);
+			code.put(op8(op.code));
 			if (op.sig.results.length == 1 && op.sig.results[0] == rt) {
 				t.valid(code.extract());
 			} else {
@@ -836,7 +844,7 @@ def test_simple_ops_r(t: CodeValidatorTester) {
 
 def test_simple_ops0(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		Opcode.LOCAL_GET.code,
+		op8(Opcode.LOCAL_GET.code),
 		/* local_pt */0,
 		/* opcode_pt */0
 	];
@@ -855,7 +863,7 @@ def test_simple_ops0(t: CodeValidatorTester) {
 		t.sig(op.sig);
 		for (l in locals) {
 			template[local_pt] = byte.!(l);
-			template[opcode_pt] = op.code;
+			template[opcode_pt] = op8(op.code);
 			var pt = template.length + 9;
 			t.TypeError(template, pt);
 		}
@@ -864,7 +872,7 @@ def test_simple_ops0(t: CodeValidatorTester) {
 
 def test_simple_ops1(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		Opcode.LOCAL_GET.code,
+		op8(Opcode.LOCAL_GET.code),
 		/* local_pt */0,
 		/* opcode_pt */0
 	];
@@ -883,7 +891,7 @@ def test_simple_ops1(t: CodeValidatorTester) {
 		t.sig(op.sig);
 		for (l in locals) {
 			template[local_pt] = byte.!(l.1);
-			template[opcode_pt] = op.code;
+			template[opcode_pt] = op8(op.code);
 			if (l.0 == op.sig.params[0]) {
 				t.valid(template);
 			} else {
@@ -896,9 +904,9 @@ def test_simple_ops1(t: CodeValidatorTester) {
 
 def test_simple_ops2(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		Opcode.LOCAL_GET.code,
+		op8(Opcode.LOCAL_GET.code),
 		/* local0_pt */0,
-		Opcode.LOCAL_GET.code,
+		op8(Opcode.LOCAL_GET.code),
 		/* local1_pt */0,
 		/* opcode_pt */0
 	];
@@ -918,7 +926,7 @@ def test_simple_ops2(t: CodeValidatorTester) {
 		for (l in locals) {
 			template[local0_pt] = 0;
 			template[local1_pt] = byte.!(l.1);
-			template[opcode_pt] = op.code;
+			template[opcode_pt] = op8(op.code);
 			if (l.0 == op.sig.params[1]) {
 				t.valid(template);
 			} else {
@@ -928,7 +936,7 @@ def test_simple_ops2(t: CodeValidatorTester) {
 
 			template[local0_pt] = byte.!(l.1);
 			template[local1_pt] = 1;
-			template[opcode_pt] = op.code;
+			template[opcode_pt] = op8(op.code);
 			if (l.0 == op.sig.params[0]) {
 				t.valid(template);
 			} else {
@@ -943,57 +951,57 @@ def test_memindex1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.addMemory(1, Max.Set(1));
 	t.valid([
-		Opcode.MEMORY_SIZE.code, 0
+		op8(Opcode.MEMORY_SIZE.code), 0
 	]);
 	t.valid([
-		Opcode.I32_CONST.code, 0,
-		Opcode.MEMORY_GROW.code, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0
 	]);
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		Opcode.MEMORY_SIZE.code, 1
+		op8(Opcode.MEMORY_SIZE.code), 1
 	], 2);
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.MEMORY_GROW.code, 1
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 1
 	], 4);
 
 	// expect a zero byte if no multi-memory
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		Opcode.MEMORY_SIZE.code, 0x80, 0
+		op8(Opcode.MEMORY_SIZE.code), 0x80, 0
 	], 2);
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.MEMORY_GROW.code, 0x80, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0x80, 0
 	], 4);
 
 	// allow a full LEB if multi-memory
 	t.setExtensions(Extension.MULTI_MEMORY);
 	t.valid([
-		Opcode.MEMORY_SIZE.code, 0x80, 0
+		op8(Opcode.MEMORY_SIZE.code), 0x80, 0
 	]);
 	t.valid([
-		Opcode.I32_CONST.code, 0,
-		Opcode.MEMORY_GROW.code, 0x80, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0x80, 0
 	]);
 }
 
 def test_memindex2(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.MEMORY_SIZE.code, 0
+		op8(Opcode.MEMORY_SIZE.code), 0
 	], 2);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.MEMORY_GROW.code, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0
 	], 4);
 	// allow a full LEB if multi-memory
 	t.setExtensions(Extension.MULTI_MEMORY);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.MEMORY_SIZE.code, 0x80, 0
+		op8(Opcode.MEMORY_SIZE.code), 0x80, 0
 	], 2);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.MEMORY_GROW.code, 0x80, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0x80, 0
 	], 4);
 }
 
@@ -1001,61 +1009,61 @@ def test_tabindex1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.addTable(1, 1, null);
 	t.valid([
-		Opcode.I32_CONST.code, 0,
-		Opcode.CALL_INDIRECT.code, 0, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.CALL_INDIRECT.code), 0, 0
 	]);
 	t.valid([
-		Opcode.I32_CONST.code, 0,
-		Opcode.CALL_INDIRECT.code, 0, 0x80, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.CALL_INDIRECT.code), 0, 0x80, 0
 	]);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.CALL_INDIRECT.code, 0, 1
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.CALL_INDIRECT.code), 0, 1
 	], 5);
 }
 
 def test_tabindex2(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.CALL_INDIRECT.code, 0, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.CALL_INDIRECT.code), 0, 0
 	], 5);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.CALL_INDIRECT.code, 0, 0x80, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.CALL_INDIRECT.code), 0, 0x80, 0
 	], 5);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.I32_CONST.code, 0,
-		Opcode.CALL_INDIRECT.code, 0, 1
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.CALL_INDIRECT.code), 0, 1
 	], 5);
 }
 
 def test_retcall1(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	var code1: Array<byte> = [
-		Opcode.RETURN_CALL.code, 0
+		op8(Opcode.RETURN_CALL.code), 0
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 1);
 
 	t.setExtensions(Extension.TAIL_CALL);
 	t.valid(code1);
 
-	var f2 = t.newFunction(SigCache.v_v, [Opcode.END.code]);
+	var f2 = t.newFunction(SigCache.v_v, [op8(Opcode.END.code)]);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.RETURN_CALL.code, byte.!(f2.func_index)
+		op8(Opcode.RETURN_CALL.code), byte.!(f2.func_index)
 	], 1);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.RETURN_CALL.code, byte.!(f2.func_index),
-		Opcode.I32_CONST.code, 1
+		op8(Opcode.RETURN_CALL.code), byte.!(f2.func_index),
+		op8(Opcode.I32_CONST.code), 1
 	], 1);
 
-	var f3 = t.newFunction(SigCache.v_l, [Opcode.END.code]);
+	var f3 = t.newFunction(SigCache.v_l, [op8(Opcode.END.code)]);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.RETURN_CALL.code, byte.!(f3.func_index)
+		op8(Opcode.RETURN_CALL.code), byte.!(f3.func_index)
 	], 1);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.RETURN_CALL.code, byte.!(f3.func_index),
-		Opcode.I32_CONST.code, 2
+		op8(Opcode.RETURN_CALL.code), byte.!(f3.func_index),
+		op8(Opcode.I32_CONST.code), 2
 	], 1);
 }
 
@@ -1063,8 +1071,8 @@ def test_retcall2(t: CodeValidatorTester) {
 	t.sig(SigCache.v_i);
 	t.addTable(1, 1, null);
 	var code1: Array<byte> = [
-		Opcode.I32_CONST.code, 5,
-		Opcode.RETURN_CALL_INDIRECT.code, 0, 0
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.RETURN_CALL_INDIRECT.code), 0, 0
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
@@ -1073,13 +1081,13 @@ def test_retcall2(t: CodeValidatorTester) {
 
 	var s2 = t.addSig(SigCache.v_v).heaptype_index;
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.I32_CONST.code, 5,
-		Opcode.RETURN_CALL_INDIRECT.code, byte.view(s2), 0
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.view(s2), 0
 	], 3);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.I32_CONST.code, 5,
-		Opcode.RETURN_CALL_INDIRECT.code, byte.view(s2), 0,
-		Opcode.I32_CONST.code, 2
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.view(s2), 0,
+		op8(Opcode.I32_CONST.code), 2
 	], 3);
 }
 
@@ -1100,10 +1108,11 @@ def test_invalid2(t: CodeValidatorTester) {
 
 def test_prefix_ops1(t: CodeValidatorTester) {
 	var template: Array<byte> = [
-		Opcode.LOCAL_GET.code,
+		op8(Opcode.LOCAL_GET.code),
 		/* local_pt */0,
 		/* prefix_pt */0,
-		/* opcode_pt */0
+		/* opcode_pt */0,
+		/* for second byte, if any */0
 	];
 	var local_pt = 1, prefix_pt = 2, opcode_pt = 3;
 
@@ -1124,11 +1133,17 @@ def test_prefix_ops1(t: CodeValidatorTester) {
 		for (l in locals) {
 			template[local_pt] = byte.!(l.1);
 			template[prefix_pt] = op.prefix;
-			template[opcode_pt] = op.code;
+			if (Opcodes.page_by_prefix[op.prefix].oneByte) {
+				template[opcode_pt  ] = op8(op.code);
+				template[opcode_pt+1] = op8(Opcode.NOP.code);
+			} else {
+				template[opcode_pt  ] = op14l(op.code);
+				template[opcode_pt+1] = op14h(op.code);
+			}
 			if (l.0 == op.sig.params[0]) {
 				t.valid(template);
 			} else {
-				var pt = template.length + 7;
+				var pt = template.length + 6;
 				t.TypeError(template, pt);
 			}
 		}
@@ -1136,23 +1151,23 @@ def test_prefix_ops1(t: CodeValidatorTester) {
 }
 
 def test_ref_null(t: CodeValidatorTester) {
-	t.TypeError([Opcode.REF_NULL.code, BpTypeCode.EXTERNREF.code], 3);
+	t.TypeError([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code], 3);
 
 	t.sig(SigCache.v_e);
-	t.valid([Opcode.REF_NULL.code, BpTypeCode.EXTERNREF.code]);
-	t.TypeError([Opcode.REF_NULL.code, BpTypeCode.FUNCREF.code], 3);
+	t.valid([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code]);
+	t.TypeError([op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code], 3);
 
 	t.sig(SigCache.v_g);
-	t.valid([Opcode.REF_NULL.code, BpTypeCode.FUNCREF.code]);
-	t.TypeError([Opcode.REF_NULL.code, BpTypeCode.EXTERNREF.code], 3);
-	t.invalid(WasmError.INVALID_TYPE, [Opcode.REF_NULL.code, BpTypeCode.I32.code], 2);
+	t.valid([op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code]);
+	t.TypeError([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code], 3);
+	t.invalid(WasmError.INVALID_TYPE, [op8(Opcode.REF_NULL.code), BpTypeCode.I32.code], 2);
 }
 
 def test_ref_is_null(t: CodeValidatorTester) {
-	t.TypeError([Opcode.REF_IS_NULL.code], 1);
+	t.TypeError([op8(Opcode.REF_IS_NULL.code)], 1);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_IS_NULL.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.REF_IS_NULL.code)
 	];
 	t.sig(SigCache.i_i);
 	t.invalid(WasmError.ILLEGAL_TYPE, code1, 3);
@@ -1165,9 +1180,9 @@ def test_ref_is_null(t: CodeValidatorTester) {
 }
 
 def test_ref_func(t: CodeValidatorTester) {
-	t.invalid(WasmError.OOB_INDEX, [Opcode.REF_FUNC.code, 11], 2);
-	var f2 = t.newFunction(SigCache.v_v, [Opcode.END.code]);
-	var code1: Array<byte> = [Opcode.REF_FUNC.code, byte.!(f2.func_index)];
+	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.REF_FUNC.code), 11], 2);
+	var f2 = t.newFunction(SigCache.v_v, [op8(Opcode.END.code)]);
+	var code1: Array<byte> = [op8(Opcode.REF_FUNC.code), byte.!(f2.func_index)];
 	t.sig(SigCache.v_g);
 	t.invalid(WasmError.ILLEGAL_FUNCREF, code1, 1);
 	f2.reffed = true;
@@ -1181,7 +1196,7 @@ def test_ref_func(t: CodeValidatorTester) {
 def test_ref_as_non_null(t: CodeValidatorTester) {
 	var nft = ValueTypes.RefFunc(true, SigCache.i_i), ft = ValueTypes.RefFunc(false, SigCache.i_i);
 	t.sig0([nft], [ft]);
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.REF_AS_NON_NULL.code];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.REF_AS_NON_NULL.code)];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
@@ -1195,18 +1210,18 @@ def test_ref_as_non_null(t: CodeValidatorTester) {
 def test_br_on_null(t: CodeValidatorTester) {
 	var nft = ValueTypes.RefFunc(true, SigCache.i_i), ft = ValueTypes.RefFunc(false, SigCache.i_i);
 	t.sig0([nft], [ft]);
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.BR_ON_NULL.code, 0];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR_ON_NULL.code), 0];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
 	t.invalid(WasmError.TYPE_MISMATCH, code1, 3);
 	t.valid([
-		Opcode.BLOCK.code, EB,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_NULL.code, 0,
-		Opcode.BR.code, 1,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.BLOCK.code), EB,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_ON_NULL.code), 0,
+		op8(Opcode.BR.code), 1,
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 
 	t.sig(SigCache.i_i);
@@ -1216,25 +1231,25 @@ def test_br_on_null(t: CodeValidatorTester) {
 def test_br_on_non_null(t: CodeValidatorTester) {
 	var nft = ValueTypes.RefFunc(true, SigCache.i_i), ft = ValueTypes.RefFunc(false, SigCache.i_i);
 	t.sig0([nft], [ft]);
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.BR_ON_NON_NULL.code, 0, Opcode.UNREACHABLE.code];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR_ON_NON_NULL.code), 0, op8(Opcode.UNREACHABLE.code)];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
 	t.valid(code1);
 	t.invalid(WasmError.TYPE_MISMATCH, [
-		Opcode.BLOCK.code, EB,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_NON_NULL.code, 0,
-		Opcode.BR.code, 1,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.BLOCK.code), EB,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_ON_NON_NULL.code), 0,
+		op8(Opcode.BR.code), 1,
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 	], 7);
 	t.valid([
-		Opcode.BLOCK.code, EB,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_NON_NULL.code, 1,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.BLOCK.code), EB,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_ON_NON_NULL.code), 1,
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 
 	t.sig(SigCache.i_i);
@@ -1244,12 +1259,12 @@ def test_br_on_non_null(t: CodeValidatorTester) {
 def test_data_drop(t: CodeValidatorTester) {
 	t.addData(0, [0]);
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.DATA_DROP.prefix, Opcode.DATA_DROP.code, 0];
+	var code1: Array<byte> = [Opcode.DATA_DROP.prefix, op8(Opcode.DATA_DROP.code), 0];
 	t.invalid(WasmError.MISSING_DATA_COUNT, code1, 1);
 
 	t.module.explicit_data_count = 1;
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.DATA_DROP.prefix, Opcode.DATA_DROP.code, 1], 3);
+	t.invalid(WasmError.OOB_INDEX, [Opcode.DATA_DROP.prefix, op8(Opcode.DATA_DROP.code), 1], 3);
 }
 
 def test_memory_init(t: CodeValidatorTester) {
@@ -1257,21 +1272,21 @@ def test_memory_init(t: CodeValidatorTester) {
 	t.addData(0, [0]);
 	t.module.explicit_data_count = 1;
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.MEMORY_INIT.prefix, Opcode.MEMORY_INIT.code, 0, 0];
+	var code1: Array<byte> = [Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.MEMORY_INIT.prefix, Opcode.MEMORY_INIT.code, 0, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.MEMORY_INIT.prefix, Opcode.MEMORY_INIT.code, 1, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 1, 0
 	];
 	t.invalid(WasmError.OOB_INDEX, code3, 9);
 }
@@ -1279,21 +1294,21 @@ def test_memory_init(t: CodeValidatorTester) {
 def test_memory_copy(t: CodeValidatorTester) {
 	t.addMemory(1, Max.Set(1));
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.MEMORY_COPY.prefix, Opcode.MEMORY_COPY.code, 0, 0];
+	var code1: Array<byte> = [Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.MEMORY_COPY.prefix, Opcode.MEMORY_COPY.code, 0, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.MEMORY_COPY.prefix, Opcode.MEMORY_COPY.code, 1, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 1, 0
 	];
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, code3, 9);
 }
@@ -1301,21 +1316,21 @@ def test_memory_copy(t: CodeValidatorTester) {
 def test_memory_fill(t: CodeValidatorTester) {
 	t.addMemory(1, Max.Set(1));
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.MEMORY_FILL.prefix, Opcode.MEMORY_FILL.code, 0];
+	var code1: Array<byte> = [Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.MEMORY_FILL.prefix, Opcode.MEMORY_FILL.code, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.MEMORY_FILL.prefix, Opcode.MEMORY_FILL.code, 1
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 1
 	];
 	t.invalid(WasmError.EXPECTED_ZERO_BYTE, code3, 9);
 }
@@ -1323,21 +1338,21 @@ def test_memory_fill(t: CodeValidatorTester) {
 def test_table_init(t: CodeValidatorTester) {
 	t.addTable(1, 1, [1]);
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.TABLE_INIT.prefix, Opcode.TABLE_INIT.code, 0, 0];
+	var code1: Array<byte> = [Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.TABLE_INIT.prefix, Opcode.TABLE_INIT.code, 0, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.TABLE_INIT.prefix, Opcode.TABLE_INIT.code, 1, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 1, 0
 	];
 	t.invalid(WasmError.OOB_INDEX, code3, 9);
 }
@@ -1345,21 +1360,21 @@ def test_table_init(t: CodeValidatorTester) {
 def test_table_copy1(t: CodeValidatorTester) {
 	t.addTable(1, 1, [0]);
 	t.sig(SigCache.v_v);
-	var code1: Array<byte> = [Opcode.TABLE_COPY.prefix, Opcode.TABLE_COPY.code, 0, 0];
+	var code1: Array<byte> = [Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 0, 0];
 	t.TypeError(code1, 1);
 
 	var code2: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.TABLE_COPY.prefix, Opcode.TABLE_COPY.code, 0, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 0, 0
 	];
 	t.valid(code2);
 	var code3: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.TABLE_COPY.prefix, Opcode.TABLE_COPY.code, 1, 0
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 1, 0
 	];
 	t.invalid(WasmError.OOB_INDEX, code3, 9);
 }
@@ -1371,10 +1386,10 @@ def test_table_copy2(t: CodeValidatorTester) {
 	t.module.addDecl(table2);
 	t.sig(SigCache.v_v);
 	var code1: Array<byte> = [
-		Opcode.I32_CONST.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_CONST.code, 2,
-		Opcode.TABLE_COPY.prefix, Opcode.TABLE_COPY.code, byte.!(table1.table_index), byte.!(table2.table_index)
+		op8(Opcode.I32_CONST.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_CONST.code), 2,
+		Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), byte.!(table1.table_index), byte.!(table2.table_index)
 	];
 	t.TypeError(code1, 7);
 }
@@ -1383,24 +1398,24 @@ def test_elem_drop(t: CodeValidatorTester) {
 	t.addTable(1, 0, [0]);
 	t.sig(SigCache.v_v);
 
-	t.valid([Opcode.ELEM_DROP.prefix, Opcode.ELEM_DROP.code, 0]);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.ELEM_DROP.prefix, Opcode.ELEM_DROP.code, 1], 3);
+	t.valid([Opcode.ELEM_DROP.prefix, op8(Opcode.ELEM_DROP.code), 0]);
+	t.invalid(WasmError.OOB_INDEX, [Opcode.ELEM_DROP.prefix, op8(Opcode.ELEM_DROP.code), 1], 3);
 }
 
 def test_table_get(t: CodeValidatorTester) {
 	t.addTable(1, 0, [0]);
 	t.sig(SigCache.v_g);
 	t.sig(SigCache.v_e);
-	t.invalid(WasmError.TYPE_MISMATCH, [Opcode.I32_CONST.code, 0, Opcode.TABLE_GET.code, 0], 5);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.I32_CONST.code, 0, Opcode.TABLE_GET.code, 1], 4);
+	t.invalid(WasmError.TYPE_MISMATCH, [op8(Opcode.I32_CONST.code), 0, op8(Opcode.TABLE_GET.code), 0], 5);
+	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.I32_CONST.code), 0, op8(Opcode.TABLE_GET.code), 1], 4);
 }
 
 def test_table_set(t: CodeValidatorTester) {
 	t.addTable(1, 0, [0]);
 	t.sig(SigCache.g_v);
-	var code1: Array<byte> = [Opcode.I32_CONST.code, 0, Opcode.LOCAL_GET.code, 0, Opcode.TABLE_SET.code, 0];
+	var code1: Array<byte> = [op8(Opcode.I32_CONST.code), 0, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.TABLE_SET.code), 0];
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.I32_CONST.code, 0, Opcode.LOCAL_GET.code, 0, Opcode.TABLE_SET.code, 2], 6);
+	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.I32_CONST.code), 0, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.TABLE_SET.code), 2], 6);
 	t.sig(SigCache.e_v);
 	t.invalid(WasmError.TYPE_MISMATCH, code1, 5);
 }
@@ -1408,19 +1423,19 @@ def test_table_set(t: CodeValidatorTester) {
 def test_table_grow(t: CodeValidatorTester) {
 	t.addTable(1, 1, [0]);
 	t.sig0([ValueTypes.EXTERNREF, ValueType.I32], SigCache.arr_i);
-	var code1: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_GET.code, 1, Opcode.TABLE_GROW.prefix, Opcode.TABLE_GROW.code, 0];
+	var code1: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0];
 	t.TypeError(code1, 5);
 	t.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_i);
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_GET.code, 1, Opcode.TABLE_GROW.prefix, Opcode.TABLE_GROW.code, 1], 7);
+	t.invalid(WasmError.OOB_INDEX, [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 1], 7);
 }
 
 def test_table_size(t: CodeValidatorTester) {
 	t.addTable(3, 0, [0, 0, 0]);
 	t.sig(SigCache.v_i);
-	var code1: Array<byte> = [Opcode.TABLE_SIZE.prefix, Opcode.TABLE_SIZE.code, 0];
+	var code1: Array<byte> = [Opcode.TABLE_SIZE.prefix, op8(Opcode.TABLE_SIZE.code), 0];
 	t.valid(code1);
-	t.invalid(WasmError.OOB_INDEX, [Opcode.TABLE_SIZE.prefix, Opcode.TABLE_SIZE.code, 1], 3);
+	t.invalid(WasmError.OOB_INDEX, [Opcode.TABLE_SIZE.prefix, op8(Opcode.TABLE_SIZE.code), 1], 3);
 	t.sig(SigCache.v_f);
 	t.TypeError(code1, 4);
 }
@@ -1429,19 +1444,19 @@ def test_table_fill(t: CodeValidatorTester) {
 	t.addTable(1, 1, [0]);
 	t.sig0([ValueType.I32, ValueTypes.EXTERNREF, ValueType.I32], SigCache.arr_v);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.TABLE_FILL.prefix, Opcode.TABLE_FILL.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_FILL.prefix, op8(Opcode.TABLE_FILL.code), 0
 	];
 	t.TypeError(code1, 7);
 	t.sig0([ValueType.I32, ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_v);
 	t.valid(code1);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.TABLE_FILL.prefix, Opcode.TABLE_FILL.code, 1
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_FILL.prefix, op8(Opcode.TABLE_FILL.code), 1
 	], 9);
 }
 
@@ -1451,27 +1466,27 @@ def test_call_ref0(t: CodeValidatorTester) {
 	var ref_i_i = ValueTypes.RefFunc(false, sig_i_i);
 	var ref_v_v = ValueTypes.RefFunc(false, sig_v_v);
 
-	var code1_i_i: Array<byte> = [Opcode.CALL_REF.code, heapIndexByte(sig_i_i)];
-	var code1_v_v: Array<byte> = [Opcode.CALL_REF.code, heapIndexByte(sig_v_v)];
-	var code2_i_i: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.CALL_REF.code, heapIndexByte(sig_i_i)];
-	var code2_v_v: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.CALL_REF.code, heapIndexByte(sig_i_i)];
+	var code1_i_i: Array<byte> = [op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code1_v_v: Array<byte> = [op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_v)];
+	var code2_i_i: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
+	var code2_v_v: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
 
 	t.sig(SigCache.i_i);
-	t.invalid(WasmError.INVALID_OPCODE, [Opcode.CALL_REF.code, heapIndexByte(sig_i_i)], 1);
+	t.invalid(WasmError.INVALID_OPCODE, [op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)], 1);
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
 
 	for (sig in [sig_i_i, sig_v_v]) {
-		var code1: Array<byte> = [Opcode.CALL_REF.code, heapIndexByte(sig)];
+		var code1: Array<byte> = [op8(Opcode.CALL_REF.code), heapIndexByte(sig)];
 		t.sig(sig);
 		t.TypeError(code1, 1);
 
 		t.sig(newSig([ref_v_v], SigCache.arr_v));
-		var code2: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.CALL_REF.code, heapIndexByte(sig)];
+		var code2: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL_REF.code), heapIndexByte(sig)];
 		if (sig == sig_v_v) t.valid(code2);
 		else t.TypeError(code2, 3);
 	}
 
-	var code3: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_GET.code, 1, Opcode.CALL_REF.code, heapIndexByte(sig_i_i)];
+	var code3: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.CALL_REF.code), heapIndexByte(sig_i_i)];
 	t.sig0([ValueType.I32, ref_i_i], SigCache.arr_v);
 	t.TypeError(code3, 7);
 	t.sig0([ValueType.I32, ref_i_i], SigCache.arr_i);
@@ -1491,7 +1506,7 @@ def test_retcall_ref0(t: CodeValidatorTester) {
 	var ref_i_i = ValueTypes.RefFunc(false, sig_i_i);
 	var ref_i_v = ValueTypes.RefFunc(false, sig_i_v);
 	var ref_i_l = ValueTypes.RefFunc(false, sig_i_l);
-	var code1: Array<byte> = [Opcode.RETURN_CALL_REF.code, heapIndexByte(sig_i_i)];
+	var code1: Array<byte> = [op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_i_i)];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 1);
 
 	t.setExtensions(Extension.FUNCTION_REFERENCES);
@@ -1499,16 +1514,16 @@ def test_retcall_ref0(t: CodeValidatorTester) {
 
 	for (sig in [sig_v_v, sig_i_i, sig_i_v, sig_i_l]) {
 		t.sig(sig_v_v);
-		var code2: Array<byte> = [Opcode.LOCAL_GET.code, 0, Opcode.RETURN_CALL_REF.code, heapIndexByte(sig)];
+		var code2: Array<byte> = [op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig)];
 		var ref = ValueType.Ref(false, HeapType.Func(sig));
 		t.sig0([ref], SigCache.arr_v);
 		if (sig == sig_v_v) t.valid(code2);
 		else t.TypeError(code2, 3);
 
 		var code3: Array<byte> = [
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.LOCAL_GET.code, 1,
-			Opcode.RETURN_CALL_REF.code,
+			op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.LOCAL_GET.code), 1,
+			op8(Opcode.RETURN_CALL_REF.code),
 			heapIndexByte(sig)
 		];
 
@@ -1539,9 +1554,9 @@ def test_ref_eq(t: CodeValidatorTester) {
 		ValueType.I32, ValueType.F32, ValueTypes.RefStruct(false, st), ValueTypes.ANYREF, ValueTypes.EQREF, ValueTypes.STRUCTREF, ValueTypes.I31REF
 	];
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.REF_EQ.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.REF_EQ.code)
 	];
 	// TODO: test externref and funcref
 	for (x in cases) {
@@ -1558,9 +1573,9 @@ def test_struct_new(t: CodeValidatorTester) {
 	var st = t.newStruct([unpackedT(ValueType.F32, true)]);
 	t.sig(SigCache.d_d);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		Opcode.STRUCT_NEW.code,
+		op8(Opcode.STRUCT_NEW.code),
 		heapIndexByte(st)
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 3);
@@ -1572,17 +1587,17 @@ def test_struct_new(t: CodeValidatorTester) {
 	t.valid(code1);
 
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		Opcode.STRUCT_NEW.code,
+		op8(Opcode.STRUCT_NEW.code),
 		byte.view(t.module.heaptypes.length) // oob
 	], 5);
 
 	var ft = t.addSig(SigCache.ff_i).heaptype_index;
 	t.invalid(WasmError.ILLEGAL_TYPE, [
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		Opcode.STRUCT_NEW.code,
+		op8(Opcode.STRUCT_NEW.code),
 		byte.view(ft) // func type reference
 	], 5);
 }
@@ -1599,7 +1614,7 @@ def test_struct_newdef(t: CodeValidatorTester) {
 		var st = t.newStruct([unpackedT(c.0, true)]);
 		var code1: Array<byte> = [
 			Opcode.STRUCT_NEW_DEFAULT.prefix,
-			Opcode.STRUCT_NEW_DEFAULT.code,
+			op8(Opcode.STRUCT_NEW_DEFAULT.code),
 			heapIndexByte(st)
 		];
 
@@ -1624,16 +1639,16 @@ def test_struct_get(t: CodeValidatorTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, st)], SigCache.arr_i);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.STRUCT_GET.prefix, Opcode.STRUCT_GET.code, heapIndexByte(st), 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code), heapIndexByte(st), 0
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.STRUCT_GET.prefix, Opcode.STRUCT_GET.code, heapIndexByte(st), 1
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code), heapIndexByte(st), 1
 	], 7);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.STRUCT_GET.prefix, Opcode.STRUCT_GET.code, heapIndexByte(st), 2
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code), heapIndexByte(st), 2
 	], 6);
 }
 
@@ -1645,8 +1660,8 @@ def test_struct_get_su(t: CodeValidatorTester) {
 
 		for (opcode in [Opcode.STRUCT_GET_S, Opcode.STRUCT_GET_U, Opcode.STRUCT_GET]) {
 			var code1: Array<byte> = [
-				Opcode.LOCAL_GET.code, 0,
-				opcode.prefix, opcode.code, heapIndexByte(st), 0
+				op8(Opcode.LOCAL_GET.code), 0,
+				opcode.prefix, op8(opcode.code), heapIndexByte(st), 0
 			];
 			var ok = (pack == Packedness.UNPACKED) == (opcode == Opcode.STRUCT_GET);
 			if (ok) t.valid(code1);
@@ -1661,23 +1676,23 @@ def test_struct_set(t: CodeValidatorTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, st)], SigCache.arr_v);
 	t.valid([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.STRUCT_SET.prefix, Opcode.STRUCT_SET.code, heapIndexByte(st), 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 0
 	]);
 	t.TypeError([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_CONST.code, 1,
-		Opcode.STRUCT_SET.prefix, Opcode.STRUCT_SET.code, heapIndexByte(st), 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_CONST.code), 1,
+		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 0
 	], 5);
 	t.invalid(WasmError.ILLEGAL_ASSIGNMENT, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.STRUCT_SET.prefix, Opcode.STRUCT_SET.code, heapIndexByte(st), 1
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 1
 	], 5);
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.STRUCT_SET.prefix, Opcode.STRUCT_SET.code, heapIndexByte(st), 2
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code), heapIndexByte(st), 2
 	], 6);
 }
 
@@ -1685,10 +1700,10 @@ def test_array_new(t: CodeValidatorTester) {
 	var at = t.newArray([unpackedT(ValueType.F64, true)]);
 	t.sig(SigCache.f_f);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 6,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 6,
 		Opcode.ARRAY_NEW.prefix,
-		Opcode.ARRAY_NEW.code,
+		op8(Opcode.ARRAY_NEW.code),
 		heapIndexByte(at)
 	];
 	t.invalid(WasmError.INVALID_OPCODE, code1, 5);
@@ -1700,19 +1715,19 @@ def test_array_new(t: CodeValidatorTester) {
 	t.valid(code1);
 
 	t.invalid(WasmError.OOB_INDEX, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 7,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 7,
 		Opcode.ARRAY_NEW.prefix,
-		Opcode.ARRAY_NEW.code,
+		op8(Opcode.ARRAY_NEW.code),
 		byte.view(t.module.heaptypes.length) // oob
 	], 7);
 
 	var ft = t.addSig(SigCache.dd_i).heaptype_index;
 	t.invalid(WasmError.ILLEGAL_TYPE, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 8,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 8,
 		Opcode.ARRAY_NEW.prefix,
-		Opcode.ARRAY_NEW.code,
+		op8(Opcode.ARRAY_NEW.code),
 		byte.view(ft) // func type reference
 	], 7);
 }
@@ -1728,9 +1743,9 @@ def test_array_newdef(t: CodeValidatorTester) {
 	for (c in cases) {
 		var at = t.newArray([unpackedT(c.0, true)]);
 		var code1: Array<byte> = [
-			Opcode.I32_CONST.code, 5,
+			op8(Opcode.I32_CONST.code), 5,
 			Opcode.ARRAY_NEW_DEFAULT.prefix,
-			Opcode.ARRAY_NEW_DEFAULT.code,
+			op8(Opcode.ARRAY_NEW_DEFAULT.code),
 			heapIndexByte(at)
 		];
 
@@ -1739,9 +1754,9 @@ def test_array_newdef(t: CodeValidatorTester) {
 			t.TypeError(code1, 6);
 			t.sig0(SigCache.arr_v, [ValueTypes.RefArray(false, at)]);
 			t.valid([
-				Opcode.I32_CONST.code, 5,
+				op8(Opcode.I32_CONST.code), 5,
 				Opcode.ARRAY_NEW_DEFAULT.prefix,
-				Opcode.ARRAY_NEW_DEFAULT.code,
+				op8(Opcode.ARRAY_NEW_DEFAULT.code),
 				heapIndexByte(at)
 			]);
 		} else {
@@ -1757,9 +1772,9 @@ def test_array_get(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.I64, true)]);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 3,
-		Opcode.ARRAY_GET.prefix, Opcode.ARRAY_GET.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 3,
+		Opcode.ARRAY_GET.prefix, op8(Opcode.ARRAY_GET.code), heapIndexByte(at)
 	];
 	t.sig(SigCache.f_f);
 	t.TypeError(code1, 5);
@@ -1778,9 +1793,9 @@ def test_array_get_su(t: CodeValidatorTester) {
 		t.sig0([ValueTypes.RefArray(false, at)], SigCache.arr_i);
 		for (opcode in [Opcode.ARRAY_GET_S, Opcode.ARRAY_GET_U, Opcode.ARRAY_GET]) {
 			var code1: Array<byte> = [
-				Opcode.LOCAL_GET.code, 0,
-				Opcode.I32_CONST.code, 11,
-				opcode.prefix, opcode.code, heapIndexByte(at), 0
+				op8(Opcode.LOCAL_GET.code), 0,
+				op8(Opcode.I32_CONST.code), 11,
+				opcode.prefix, op8(opcode.code), heapIndexByte(at), 0
 			];
 			var ok = (pack == Packedness.UNPACKED) == (opcode == Opcode.ARRAY_GET);
 			if (ok) t.valid(code1);
@@ -1793,10 +1808,10 @@ def test_array_set(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.F32, true)]);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 3,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ARRAY_SET.prefix, Opcode.ARRAY_SET.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 3,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_SET.prefix, op8(Opcode.ARRAY_SET.code), heapIndexByte(at)
 	];
 	t.sig(SigCache.ff_f);
 	t.TypeError(code1, 7);
@@ -1814,8 +1829,8 @@ def test_array_len(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.F64, true)]);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ARRAY_LEN.prefix, Opcode.ARRAY_LEN.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_LEN.prefix, op8(Opcode.ARRAY_LEN.code), heapIndexByte(at)
 	];
 	t.sig(SigCache.f_f);
 	t.TypeError(code1, 3);
@@ -1831,8 +1846,8 @@ def test_array_new_fixed(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var at = t.newArray([unpackedT(ValueType.F64, true)]);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ARRAY_NEW_FIXED.prefix, Opcode.ARRAY_NEW_FIXED.code, heapIndexByte(at), 1
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_NEW_FIXED.prefix, op8(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), 1
 	];
 	var results: Array<ValueType> = [ValueTypes.RefArray(false, at)];
 	t.sig(SigCache.dd_d);
@@ -1844,8 +1859,8 @@ def test_array_new_fixed(t: CodeValidatorTester) {
 	var params = Vector<ValueType>.new();
 	for (count < 5) {
 		code.resize(0);
-		for (i < count) code.put(Opcode.LOCAL_GET.code).put(byte.view(i));
-		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, Opcode.ARRAY_NEW_FIXED.code, heapIndexByte(at), byte.view(count)]);
+		for (i < count) code.put(op8(Opcode.LOCAL_GET.code)).put(byte.view(i));
+		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, op8(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), byte.view(count)]);
 		for (i < count) params.put(ValueType.F64);
 
 		var raw = code.extract();
@@ -1867,9 +1882,9 @@ def test_array_new_data(t: CodeValidatorTester) {
 	t.addData(0, [0]);
 	t.module.explicit_data_count = 1;
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ARRAY_NEW_DATA.prefix, Opcode.ARRAY_NEW_DATA.code, heapIndexByte(at), 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_DATA.prefix, op8(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(at), 0
 	];
 	var results: Array<ValueType> = [ValueTypes.RefArray(false, at)];
 	t.sig0([ValueType.I32, ValueType.F32], results);
@@ -1878,16 +1893,16 @@ def test_array_new_data(t: CodeValidatorTester) {
 	t.valid(code1);
 
 	var code2: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ARRAY_NEW_DATA.prefix, Opcode.ARRAY_NEW_DATA.code, heapIndexByte(at), 1 // data index OOB
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_DATA.prefix, op8(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(at), 1 // data index OOB
 	];
 	t.invalid(WasmError.OOB_INDEX, code2, 8);
 
 	var code3: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ARRAY_NEW_DATA.prefix, Opcode.ARRAY_NEW_DATA.code, heapIndexByte(rat), 0 // reference array
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_DATA.prefix, op8(Opcode.ARRAY_NEW_DATA.code), heapIndexByte(rat), 0 // reference array
 	];
 
 	results = [ValueTypes.RefArray(false, rat)];
@@ -1911,9 +1926,9 @@ def test_array_new_elem(t: CodeValidatorTester) {
 		(dat, dtable, true)]) { // test all permutations of anyref, dataref
 
 		var code1: Array<byte> = [
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.LOCAL_GET.code, 1,
-			Opcode.ARRAY_NEW_ELEM.prefix, Opcode.ARRAY_NEW_ELEM.code, heapIndexByte(i.0), byte.view(i.1.1.elem_index)
+			op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.LOCAL_GET.code), 1,
+			Opcode.ARRAY_NEW_ELEM.prefix, op8(Opcode.ARRAY_NEW_ELEM.code), heapIndexByte(i.0), byte.view(i.1.1.elem_index)
 		];
 		var results: Array<ValueType> = [ValueTypes.RefArray(false, i.0)];
 		t.sig0([ValueType.I32, ValueType.F32], results);
@@ -1924,9 +1939,9 @@ def test_array_new_elem(t: CodeValidatorTester) {
 	}
 
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ARRAY_NEW_ELEM.prefix, Opcode.ARRAY_NEW_ELEM.code, heapIndexByte(aat), byte.view(t.module.elems.length)
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_NEW_ELEM.prefix, op8(Opcode.ARRAY_NEW_ELEM.code), heapIndexByte(aat), byte.view(t.module.elems.length)
 	];
 	var results: Array<ValueType> = [ValueTypes.RefArray(false, aat)];
 	t.sig0([ValueType.I32, ValueType.I32], results);
@@ -1936,8 +1951,8 @@ def test_array_new_elem(t: CodeValidatorTester) {
 def test_i31_new(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_I31.prefix, Opcode.REF_I31.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_I31.prefix, op8(Opcode.REF_I31.code)
 	];
 	t.sig(SigCache.i_i);
 	t.TypeError(code1, 5);
@@ -1953,8 +1968,8 @@ def test_i31_get_su(t: CodeValidatorTester) {
 	t.setExtensions(Extension.GC);
 	for (opcode in [Opcode.I31_GET_S, Opcode.I31_GET_U]) {
 		var code1: Array<byte> = [
-			Opcode.LOCAL_GET.code, 0,
-			opcode.prefix, opcode.code
+			op8(Opcode.LOCAL_GET.code), 0,
+			opcode.prefix, op8(opcode.code)
 		];
 		t.sig(SigCache.i_i);
 		t.TypeError(code1, 3);
@@ -1988,8 +2003,8 @@ def testDeclPairs(t: CodeValidatorTester,
 def test_ref_test0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Ref, dj: HeapTypeDecl, djt: ValueType.Ref) {
 	t.setExtensions(Extension.GC);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_TEST.prefix, Opcode.REF_TEST.code, heapIndexByte(dj)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_TEST.prefix, op8(Opcode.REF_TEST.code), heapIndexByte(dj)
 	];
 	t.sig0([dit], SigCache.arr_i);
 	t.valid(code1);
@@ -2000,8 +2015,8 @@ def test_ref_test0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Ref,
 def test_ref_cast0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Ref, dj: HeapTypeDecl, djt: ValueType.Ref) {
 	t.setExtensions(Extension.GC);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_CAST.prefix, Opcode.REF_CAST.code, heapIndexByte(dj)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_CAST.prefix, op8(Opcode.REF_CAST.code), heapIndexByte(dj)
 	];
 	var arr_djt: Array<ValueType> = [djt];
 	t.sig0([dit], arr_djt);
@@ -2018,9 +2033,9 @@ def test_br_on_cast0(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueType.Re
 	t.setExtensions(Extension.GC);
 	var flags = nullableFlags(dit, djt);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST.prefix, Opcode.BR_ON_CAST.code, flags, 0, heapIndexByte(di), heapIndexByte(dj),
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), flags, 0, heapIndexByte(di), heapIndexByte(dj),
+		op8(Opcode.UNREACHABLE.code)
 	];
 	var rt: Array<ValueType> = [djt];
 	t.sig0([dit], rt);
@@ -2043,11 +2058,11 @@ def test_br_on_cast1(t: CodeValidatorTester) {
 	for (opcode in [Opcode.NOP, Opcode.DROP, Opcode.UNREACHABLE]) {
 		var flags = nullableFlags(st1t, st2t);
 		var code1: Array<byte> = [
-			Opcode.BLOCK.code, BpTypeCode.REF.code, heapIndexByte(st2),
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.BR_ON_CAST.prefix, Opcode.BR_ON_CAST.code, flags, 0, heapIndexByte(st1), heapIndexByte(st2),
-			opcode.code, // drop, nop, or unreachable
-			Opcode.END.code
+			op8(Opcode.BLOCK.code), BpTypeCode.REF.code, heapIndexByte(st2),
+			op8(Opcode.LOCAL_GET.code), 0,
+			Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), flags, 0, heapIndexByte(st1), heapIndexByte(st2),
+			op8(opcode.code), // drop, nop, or unreachable
+			op8(Opcode.END.code)
 		];
 
 		t.sig0([st1t], [st2t]);
@@ -2071,8 +2086,8 @@ def shared_br_on_cast_fail0(t: CodeValidatorTester, error: WasmError, from_nulla
 	t.sig0([ft], [tt]);
 	var flags = nullableFlags(ft, tt);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST_FAIL.prefix, Opcode.BR_ON_CAST_FAIL.code, flags, 0, heapIndexByte(st1), heapIndexByte(st1)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST_FAIL.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), flags, 0, heapIndexByte(st1), heapIndexByte(st1)
 	];
 	if (error == WasmError.NONE) t.valid(code1);
 	else t.invalid(error, code1, 3);
@@ -2091,8 +2106,8 @@ def test_br_on_cast_fail1(t: CodeValidatorTester, di: HeapTypeDecl, dit: ValueTy
 	t.setExtensions(Extension.GC);
 	var flags = nullableFlags(dit, djt);
 	var code1: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST_FAIL.prefix, Opcode.BR_ON_CAST_FAIL.code, flags, 0, heapIndexByte(di), heapIndexByte(dj)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST_FAIL.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), flags, 0, heapIndexByte(di), heapIndexByte(dj)
 	];
 	if (!ValueTypes.isAssignable(djt, dit)) {
 		t.sig0([dit], [djt]);
@@ -2187,7 +2202,7 @@ def test_simd_unop1(t: CodeValidatorTester) {
 
 def test_simd_unop2(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	t.sig(SigCache.s_s);
@@ -2200,7 +2215,7 @@ def test_simd_unop2(t: CodeValidatorTester) {
 
 def test_simd_unop3(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	for (sig in [SigCache.i_i, SigCache.i_s, SigCache.f_s, SigCache.ff_f]) {
@@ -2339,7 +2354,7 @@ def SIMD_BINOPS = [
 
 def test_simd_binop1(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	t.sig(SigCache.ss_s);
@@ -2353,8 +2368,8 @@ def test_simd_binop1(t: CodeValidatorTester) {
 
 def test_simd_binop2(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	t.sig(SigCache.ss_s);
@@ -2368,8 +2383,8 @@ def test_simd_binop2(t: CodeValidatorTester) {
 
 def test_simd_binop3(t: CodeValidatorTester) {
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
 		Opcode.V128_LOAD.prefix, 0, 0
 	];
 	for (sig in [SigCache.ii_i, SigCache.is_s, SigCache.si_s, SigCache.ff_f]) {

--- a/test/unittest/ControlStackTest.v3
+++ b/test/unittest/ControlStackTest.v3
@@ -21,7 +21,7 @@ def X_ = void(
 	()
 );
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 def verbose = false;
 

--- a/test/unittest/ControlStackTest.v3
+++ b/test/unittest/ControlStackTest.v3
@@ -21,6 +21,8 @@ def X_ = void(
 	()
 );
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 def verbose = false;
 
 class ControlStackTester(t: Tester) extends ModuleBuilder {
@@ -80,7 +82,7 @@ def test_count0(t: ControlStackTester) {
 
 def test_br0(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.BR.code, 0], 1, 0)
+		([op8(Opcode.BR.code), 0], 1, 0)
 	],
 	(0, 1),
 	1);
@@ -88,9 +90,9 @@ def test_br0(t: ControlStackTester) {
 
 def test_br1(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.BLOCK.code, EMPTY],	1, 0),
-		([Opcode.BR.code, 1],		1, 0),
-		([Opcode.END.code],		0, 0)
+		([op8(Opcode.BLOCK.code), EMPTY],	1, 0),
+		([op8(Opcode.BR.code), 1],		1, 0),
+		([op8(Opcode.END.code)],		0, 0)
 	],
 	(0, 1),
 	1);
@@ -98,9 +100,9 @@ def test_br1(t: ControlStackTester) {
 
 def test_br2(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.BLOCK.code, EMPTY],	1, 0),
-		([Opcode.BR.code, 0],		1, 0),
-		([Opcode.END.code],		0, 1)
+		([op8(Opcode.BLOCK.code), EMPTY],	1, 0),
+		([op8(Opcode.BR.code), 0],		1, 0),
+		([op8(Opcode.END.code)],		0, 1)
 	],
 	(1, 0),
 	1);
@@ -108,10 +110,10 @@ def test_br2(t: ControlStackTester) {
 
 def test_br_if0(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.I32_CONST.code, 0],	1, 0),
-		([Opcode.BR_IF.code, 0],	1, 0),
-		([Opcode.I32_CONST.code, 0],	1, 1),
-		([Opcode.BR_IF.code, 0],	1, 1)
+		([op8(Opcode.I32_CONST.code), 0],	1, 0),
+		([op8(Opcode.BR_IF.code), 0],	1, 0),
+		([op8(Opcode.I32_CONST.code), 0],	1, 1),
+		([op8(Opcode.BR_IF.code), 0],	1, 1)
 	],
 	(1, 2),
 	3);
@@ -119,7 +121,7 @@ def test_br_if0(t: ControlStackTester) {
 
 def test_unreach(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.UNREACHABLE.code], 1, 0)
+		([op8(Opcode.UNREACHABLE.code)], 1, 0)
 	],
 	(0, 0),
 	0);
@@ -127,7 +129,7 @@ def test_unreach(t: ControlStackTester) {
 
 def test_return(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.RETURN.code], 1, 0)
+		([op8(Opcode.RETURN.code)], 1, 0)
 	],
 	(0, 0),
 	0);
@@ -135,9 +137,9 @@ def test_return(t: ControlStackTester) {
 
 def test_loop0(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOOP.code, EMPTY],	1, 0),
-		([Opcode.NOP.code],		1, 1),
-		([Opcode.END.code],		1, 1)
+		([op8(Opcode.LOOP.code), EMPTY],	1, 0),
+		([op8(Opcode.NOP.code)],		1, 1),
+		([op8(Opcode.END.code)],		1, 1)
 	],
 	(1, 0),
 	1
@@ -146,11 +148,11 @@ def test_loop0(t: ControlStackTester) {
 
 def test_loop1(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOOP.code, EMPTY],	1, 0),
-		([Opcode.I32_CONST.code, 0],	1, 1),
-		([Opcode.BR_IF.code, 0],	1, 1),
-		([Opcode.NOP.code],		1, 2),
-		([Opcode.END.code],		1, 2)
+		([op8(Opcode.LOOP.code), EMPTY],	1, 0),
+		([op8(Opcode.I32_CONST.code), 0],	1, 1),
+		([op8(Opcode.BR_IF.code), 0],	1, 1),
+		([op8(Opcode.NOP.code)],		1, 2),
+		([op8(Opcode.END.code)],		1, 2)
 	],
 	(1, 0),
 	1
@@ -159,12 +161,12 @@ def test_loop1(t: ControlStackTester) {
 
 def test_loop2(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOOP.code, EMPTY],	1, 0),
-		([Opcode.I32_CONST.code, 0],	1, 1),
-		([Opcode.BR_IF.code, 0],	1, 1),
-		([Opcode.NOP.code],		1, 2),
-		([Opcode.UNREACHABLE.code],	1, 2),
-		([Opcode.END.code],		0, 2)
+		([op8(Opcode.LOOP.code), EMPTY],	1, 0),
+		([op8(Opcode.I32_CONST.code), 0],	1, 1),
+		([op8(Opcode.BR_IF.code), 0],	1, 1),
+		([op8(Opcode.NOP.code)],		1, 2),
+		([op8(Opcode.UNREACHABLE.code)],	1, 2),
+		([op8(Opcode.END.code)],		0, 2)
 	],
 	(0, 0),
 	0
@@ -175,12 +177,12 @@ def EMPTY = BpTypeCode.EmptyBlock.code;
 
 def test_if0(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOCAL_GET.code, 0],	1, 0),
-		([Opcode.IF.code, EMPTY],	1, 0),
-		([Opcode.NOP.code], 		1, 0),
-		([Opcode.ELSE.code],		1, 0),
-		([Opcode.NOP.code],		1, 1),
-		([Opcode.END.code],		1, 1)
+		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([op8(Opcode.IF.code), EMPTY],	1, 0),
+		([op8(Opcode.NOP.code)], 		1, 0),
+		([op8(Opcode.ELSE.code)],		1, 0),
+		([op8(Opcode.NOP.code)],		1, 1),
+		([op8(Opcode.END.code)],		1, 1)
 	],
 	(2, 0),
 	2);
@@ -188,10 +190,10 @@ def test_if0(t: ControlStackTester) {
 
 def test_if1(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOCAL_GET.code, 0],	1, 0),
-		([Opcode.IF.code, EMPTY],	1, 0),
-		([Opcode.NOP.code], 		1, 0),
-		([Opcode.END.code],		1, 0)
+		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([op8(Opcode.IF.code), EMPTY],	1, 0),
+		([op8(Opcode.NOP.code)], 		1, 0),
+		([op8(Opcode.END.code)],		1, 0)
 	],
 	(2, 0),
 	2);
@@ -199,10 +201,10 @@ def test_if1(t: ControlStackTester) {
 
 def test_if2(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOCAL_GET.code, 0],	1, 0),
-		([Opcode.IF.code, EMPTY],	1, 0),
-		([Opcode.UNREACHABLE.code], 	1, 0),
-		([Opcode.END.code],		0, 0)
+		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([op8(Opcode.IF.code), EMPTY],	1, 0),
+		([op8(Opcode.UNREACHABLE.code)], 	1, 0),
+		([op8(Opcode.END.code)],		0, 0)
 	],
 	(1, 0),
 	1);
@@ -210,13 +212,13 @@ def test_if2(t: ControlStackTester) {
 
 def test_if_unreach0(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOCAL_GET.code, 0],	1, 0),
-		([Opcode.IF.code, EMPTY],	1, 0),
-		([Opcode.UNREACHABLE.code], 	1, 0),
-		([Opcode.NOP.code], 		0, 0),
-		([Opcode.ELSE.code],		0, 0),
-		([Opcode.NOP.code],		1, 0),
-		([Opcode.END.code],		1, 0)
+		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([op8(Opcode.IF.code), EMPTY],	1, 0),
+		([op8(Opcode.UNREACHABLE.code)], 	1, 0),
+		([op8(Opcode.NOP.code)], 		0, 0),
+		([op8(Opcode.ELSE.code)],		0, 0),
+		([op8(Opcode.NOP.code)],		1, 0),
+		([op8(Opcode.END.code)],		1, 0)
 	],
 	(1, 0),
 	1);
@@ -224,13 +226,13 @@ def test_if_unreach0(t: ControlStackTester) {
 
 def test_if_unreach1(t: ControlStackTester) {
 	t.test_count2([
-		([Opcode.LOCAL_GET.code, 0], 			1, 0),
-		([Opcode.IF.code, BpTypeCode.EmptyBlock.code],	1, 0),
-		([Opcode.NOP.code], 				1, 0),
-		([Opcode.ELSE.code],				1, 0),
-		([Opcode.UNREACHABLE.code], 			1, 1),
-		([Opcode.NOP.code],				0, 1),
-		([Opcode.END.code],				0, 1)
+		([op8(Opcode.LOCAL_GET.code), 0], 			1, 0),
+		([op8(Opcode.IF.code), BpTypeCode.EmptyBlock.code],	1, 0),
+		([op8(Opcode.NOP.code)], 				1, 0),
+		([op8(Opcode.ELSE.code)],				1, 0),
+		([op8(Opcode.UNREACHABLE.code)], 			1, 1),
+		([op8(Opcode.NOP.code)],				0, 1),
+		([op8(Opcode.END.code)],				0, 1)
 	],
 	(1, 0),
 	1);

--- a/test/unittest/ControlStackTest.v3
+++ b/test/unittest/ControlStackTest.v3
@@ -21,8 +21,6 @@ def X_ = void(
 	()
 );
 
-def op8 = Opcodes.op8;
-
 def verbose = false;
 
 class ControlStackTester(t: Tester) extends ModuleBuilder {
@@ -82,7 +80,7 @@ def test_count0(t: ControlStackTester) {
 
 def test_br0(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.BR.code), 0], 1, 0)
+		([u8.!(Opcode.BR.code), 0], 1, 0)
 	],
 	(0, 1),
 	1);
@@ -90,9 +88,9 @@ def test_br0(t: ControlStackTester) {
 
 def test_br1(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.BLOCK.code), EMPTY],	1, 0),
-		([op8(Opcode.BR.code), 1],		1, 0),
-		([op8(Opcode.END.code)],		0, 0)
+		([u8.!(Opcode.BLOCK.code), EMPTY],	1, 0),
+		([u8.!(Opcode.BR.code), 1],		1, 0),
+		([u8.!(Opcode.END.code)],		0, 0)
 	],
 	(0, 1),
 	1);
@@ -100,9 +98,9 @@ def test_br1(t: ControlStackTester) {
 
 def test_br2(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.BLOCK.code), EMPTY],	1, 0),
-		([op8(Opcode.BR.code), 0],		1, 0),
-		([op8(Opcode.END.code)],		0, 1)
+		([u8.!(Opcode.BLOCK.code), EMPTY],	1, 0),
+		([u8.!(Opcode.BR.code), 0],		1, 0),
+		([u8.!(Opcode.END.code)],		0, 1)
 	],
 	(1, 0),
 	1);
@@ -110,10 +108,10 @@ def test_br2(t: ControlStackTester) {
 
 def test_br_if0(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.I32_CONST.code), 0],	1, 0),
-		([op8(Opcode.BR_IF.code), 0],	1, 0),
-		([op8(Opcode.I32_CONST.code), 0],	1, 1),
-		([op8(Opcode.BR_IF.code), 0],	1, 1)
+		([u8.!(Opcode.I32_CONST.code), 0],	1, 0),
+		([u8.!(Opcode.BR_IF.code), 0],	1, 0),
+		([u8.!(Opcode.I32_CONST.code), 0],	1, 1),
+		([u8.!(Opcode.BR_IF.code), 0],	1, 1)
 	],
 	(1, 2),
 	3);
@@ -121,7 +119,7 @@ def test_br_if0(t: ControlStackTester) {
 
 def test_unreach(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.UNREACHABLE.code)], 1, 0)
+		([u8.!(Opcode.UNREACHABLE.code)], 1, 0)
 	],
 	(0, 0),
 	0);
@@ -129,7 +127,7 @@ def test_unreach(t: ControlStackTester) {
 
 def test_return(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.RETURN.code)], 1, 0)
+		([u8.!(Opcode.RETURN.code)], 1, 0)
 	],
 	(0, 0),
 	0);
@@ -137,9 +135,9 @@ def test_return(t: ControlStackTester) {
 
 def test_loop0(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOOP.code), EMPTY],	1, 0),
-		([op8(Opcode.NOP.code)],		1, 1),
-		([op8(Opcode.END.code)],		1, 1)
+		([u8.!(Opcode.LOOP.code), EMPTY],	1, 0),
+		([u8.!(Opcode.NOP.code)],		1, 1),
+		([u8.!(Opcode.END.code)],		1, 1)
 	],
 	(1, 0),
 	1
@@ -148,11 +146,11 @@ def test_loop0(t: ControlStackTester) {
 
 def test_loop1(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOOP.code), EMPTY],	1, 0),
-		([op8(Opcode.I32_CONST.code), 0],	1, 1),
-		([op8(Opcode.BR_IF.code), 0],	1, 1),
-		([op8(Opcode.NOP.code)],		1, 2),
-		([op8(Opcode.END.code)],		1, 2)
+		([u8.!(Opcode.LOOP.code), EMPTY],	1, 0),
+		([u8.!(Opcode.I32_CONST.code), 0],	1, 1),
+		([u8.!(Opcode.BR_IF.code), 0],	1, 1),
+		([u8.!(Opcode.NOP.code)],		1, 2),
+		([u8.!(Opcode.END.code)],		1, 2)
 	],
 	(1, 0),
 	1
@@ -161,12 +159,12 @@ def test_loop1(t: ControlStackTester) {
 
 def test_loop2(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOOP.code), EMPTY],	1, 0),
-		([op8(Opcode.I32_CONST.code), 0],	1, 1),
-		([op8(Opcode.BR_IF.code), 0],	1, 1),
-		([op8(Opcode.NOP.code)],		1, 2),
-		([op8(Opcode.UNREACHABLE.code)],	1, 2),
-		([op8(Opcode.END.code)],		0, 2)
+		([u8.!(Opcode.LOOP.code), EMPTY],	1, 0),
+		([u8.!(Opcode.I32_CONST.code), 0],	1, 1),
+		([u8.!(Opcode.BR_IF.code), 0],	1, 1),
+		([u8.!(Opcode.NOP.code)],		1, 2),
+		([u8.!(Opcode.UNREACHABLE.code)],	1, 2),
+		([u8.!(Opcode.END.code)],		0, 2)
 	],
 	(0, 0),
 	0
@@ -177,12 +175,12 @@ def EMPTY = BpTypeCode.EmptyBlock.code;
 
 def test_if0(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
-		([op8(Opcode.IF.code), EMPTY],	1, 0),
-		([op8(Opcode.NOP.code)], 		1, 0),
-		([op8(Opcode.ELSE.code)],		1, 0),
-		([op8(Opcode.NOP.code)],		1, 1),
-		([op8(Opcode.END.code)],		1, 1)
+		([u8.!(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([u8.!(Opcode.IF.code), EMPTY],	1, 0),
+		([u8.!(Opcode.NOP.code)], 		1, 0),
+		([u8.!(Opcode.ELSE.code)],		1, 0),
+		([u8.!(Opcode.NOP.code)],		1, 1),
+		([u8.!(Opcode.END.code)],		1, 1)
 	],
 	(2, 0),
 	2);
@@ -190,10 +188,10 @@ def test_if0(t: ControlStackTester) {
 
 def test_if1(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
-		([op8(Opcode.IF.code), EMPTY],	1, 0),
-		([op8(Opcode.NOP.code)], 		1, 0),
-		([op8(Opcode.END.code)],		1, 0)
+		([u8.!(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([u8.!(Opcode.IF.code), EMPTY],	1, 0),
+		([u8.!(Opcode.NOP.code)], 		1, 0),
+		([u8.!(Opcode.END.code)],		1, 0)
 	],
 	(2, 0),
 	2);
@@ -201,10 +199,10 @@ def test_if1(t: ControlStackTester) {
 
 def test_if2(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
-		([op8(Opcode.IF.code), EMPTY],	1, 0),
-		([op8(Opcode.UNREACHABLE.code)], 	1, 0),
-		([op8(Opcode.END.code)],		0, 0)
+		([u8.!(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([u8.!(Opcode.IF.code), EMPTY],	1, 0),
+		([u8.!(Opcode.UNREACHABLE.code)], 	1, 0),
+		([u8.!(Opcode.END.code)],		0, 0)
 	],
 	(1, 0),
 	1);
@@ -212,13 +210,13 @@ def test_if2(t: ControlStackTester) {
 
 def test_if_unreach0(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOCAL_GET.code), 0],	1, 0),
-		([op8(Opcode.IF.code), EMPTY],	1, 0),
-		([op8(Opcode.UNREACHABLE.code)], 	1, 0),
-		([op8(Opcode.NOP.code)], 		0, 0),
-		([op8(Opcode.ELSE.code)],		0, 0),
-		([op8(Opcode.NOP.code)],		1, 0),
-		([op8(Opcode.END.code)],		1, 0)
+		([u8.!(Opcode.LOCAL_GET.code), 0],	1, 0),
+		([u8.!(Opcode.IF.code), EMPTY],	1, 0),
+		([u8.!(Opcode.UNREACHABLE.code)], 	1, 0),
+		([u8.!(Opcode.NOP.code)], 		0, 0),
+		([u8.!(Opcode.ELSE.code)],		0, 0),
+		([u8.!(Opcode.NOP.code)],		1, 0),
+		([u8.!(Opcode.END.code)],		1, 0)
 	],
 	(1, 0),
 	1);
@@ -226,13 +224,13 @@ def test_if_unreach0(t: ControlStackTester) {
 
 def test_if_unreach1(t: ControlStackTester) {
 	t.test_count2([
-		([op8(Opcode.LOCAL_GET.code), 0], 			1, 0),
-		([op8(Opcode.IF.code), BpTypeCode.EmptyBlock.code],	1, 0),
-		([op8(Opcode.NOP.code)], 				1, 0),
-		([op8(Opcode.ELSE.code)],				1, 0),
-		([op8(Opcode.UNREACHABLE.code)], 			1, 1),
-		([op8(Opcode.NOP.code)],				0, 1),
-		([op8(Opcode.END.code)],				0, 1)
+		([u8.!(Opcode.LOCAL_GET.code), 0], 			1, 0),
+		([u8.!(Opcode.IF.code), BpTypeCode.EmptyBlock.code],	1, 0),
+		([u8.!(Opcode.NOP.code)], 				1, 0),
+		([u8.!(Opcode.ELSE.code)],				1, 0),
+		([u8.!(Opcode.UNREACHABLE.code)], 			1, 1),
+		([u8.!(Opcode.NOP.code)],				0, 1),
+		([u8.!(Opcode.END.code)],				0, 1)
 	],
 	(1, 0),
 	1);

--- a/test/unittest/DebugTest.v3
+++ b/test/unittest/DebugTest.v3
@@ -12,6 +12,8 @@ def X_ = void(
 	()
 );
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 class DebugBreak(t: DebugTester) extends Probe {
 	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		t.breaks.put(dynamicLoc.func, dynamicLoc.pc);
@@ -54,9 +56,9 @@ class DebugTester(t: Tester) extends ModuleBuilder {
 def test_break0(t: DebugTester) {
 	t.sig(SigCache.v_i);
 	t.code([
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_CONST.code, 33,
-		Opcode.I32_SUB.code
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.I32_SUB.code)
 	]);
 	t.breakAt(3);
 	t.assert_break([], 3, Result.Value([Values.box_i(-11)]));
@@ -68,9 +70,9 @@ def test_timeout0(t: DebugTester) {
 	Instrumentation.reset();
 	t.sig(SigCache.v_i);
 	t.code([
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_CONST.code, 33,
-		Opcode.I32_SUB.code
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.I32_SUB.code)
 	]);
 	var p = TimeoutProbe.new(2);
 	Instrumentation.insertGlobalProbe(p);
@@ -92,9 +94,9 @@ class FrameAsserter(t: Tester, expected_func: FuncDecl, expected_pc: int) extend
 def test_frame0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		Opcode.I32_CONST.code, 22,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_SUB.code
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 5, FrameAsserter.new(t.t, t.func, 5));
@@ -116,9 +118,9 @@ class LocalsAsserter(t: Tester, expected_vals: Array<Value>) extends Probe {
 def test_locals0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		Opcode.I32_CONST.code, 22,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_SUB.code
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 5, LocalsAsserter.new(t.t, [Values.box_i(44)]));
@@ -140,9 +142,9 @@ class StackAsserter(t: Tester, expected_vals: Array<Value>) extends Probe {
 def test_stack0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		Opcode.I32_CONST.code, 22,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_SUB.code
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 5, StackAsserter.new(t.t, [Values.box_i(77), Values.box_i(22)]));
@@ -160,9 +162,9 @@ class LocalSetter(i: int, v: Value) extends Probe {
 def test_setlocal0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		Opcode.I32_CONST.code, 22,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_SUB.code
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 3, LocalSetter.new(0, Values.box_i(-33)));

--- a/test/unittest/DebugTest.v3
+++ b/test/unittest/DebugTest.v3
@@ -12,7 +12,7 @@ def X_ = void(
 	()
 );
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 class DebugBreak(t: DebugTester) extends Probe {
 	def fire(dynamicLoc: DynamicLoc) -> Resumption {

--- a/test/unittest/DebugTest.v3
+++ b/test/unittest/DebugTest.v3
@@ -12,8 +12,6 @@ def X_ = void(
 	()
 );
 
-def op8 = Opcodes.op8;
-
 class DebugBreak(t: DebugTester) extends Probe {
 	def fire(dynamicLoc: DynamicLoc) -> Resumption {
 		t.breaks.put(dynamicLoc.func, dynamicLoc.pc);
@@ -56,9 +54,9 @@ class DebugTester(t: Tester) extends ModuleBuilder {
 def test_break0(t: DebugTester) {
 	t.sig(SigCache.v_i);
 	t.code([
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	t.breakAt(3);
 	t.assert_break([], 3, Result.Value([Values.box_i(-11)]));
@@ -70,9 +68,9 @@ def test_timeout0(t: DebugTester) {
 	Instrumentation.reset();
 	t.sig(SigCache.v_i);
 	t.code([
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	var p = TimeoutProbe.new(2);
 	Instrumentation.insertGlobalProbe(p);
@@ -94,9 +92,9 @@ class FrameAsserter(t: Tester, expected_func: FuncDecl, expected_pc: int) extend
 def test_frame0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 5, FrameAsserter.new(t.t, t.func, 5));
@@ -118,9 +116,9 @@ class LocalsAsserter(t: Tester, expected_vals: Array<Value>) extends Probe {
 def test_locals0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 5, LocalsAsserter.new(t.t, [Values.box_i(44)]));
@@ -142,9 +140,9 @@ class StackAsserter(t: Tester, expected_vals: Array<Value>) extends Probe {
 def test_stack0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 5, StackAsserter.new(t.t, [Values.box_i(77), Values.box_i(22)]));
@@ -162,9 +160,9 @@ class LocalSetter(i: int, v: Value) extends Probe {
 def test_setlocal0(t: DebugTester) {
 	t.sig(SigCache.i_i);
 	t.code([
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	Instrumentation.reset();
 	Instrumentation.insertLocalProbe(t.module, t.func.func_index, 3, LocalSetter.new(0, Values.box_i(-33)));

--- a/test/unittest/ExeCallTest.v3
+++ b/test/unittest/ExeCallTest.v3
@@ -32,37 +32,39 @@ def X_ = TestTiers.addTests([
 	("force_gc2", test_force_gc2)
 ]);
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 def test_call0(i: ExeTester) {
 	var f17 = byte.!(i.newFunction(SigCache.v_v, []).func_index);
-	i.code([Opcode.I32_CONST.code, 17, Opcode.CALL.code, f17]).noargs().assert2_i(17);
+	i.code([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17]).noargs().assert2_i(17);
 }
 def test_call1(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 17]).func_index);
-	var f18 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 18]).func_index);
-	var f19 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 19]).func_index);
-	i.code([Opcode.CALL.code, f17]).noargs().assert2_i(17);
-	i.code([Opcode.CALL.code, f18]).noargs().assert2_i(18);
-	i.code([Opcode.CALL.code, f19]).noargs().assert2_i(19);
+	var f17 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]).func_index);
+	var f18 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 18]).func_index);
+	var f19 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 19]).func_index);
+	i.code([op8(Opcode.CALL.code), f17]).noargs().assert2_i(17);
+	i.code([op8(Opcode.CALL.code), f18]).noargs().assert2_i(18);
+	i.code([op8(Opcode.CALL.code), f19]).noargs().assert2_i(19);
 }
 def test_call2(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	var f1 = byte.!(i.newFunction(SigCache.i_i, [Opcode.LOCAL_GET.code, 0]).func_index);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.CALL.code, f1]);
+	var f1 = byte.!(i.newFunction(SigCache.i_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL.code), f1]);
 	i.args_i(197).assert2_i(197);
 	i.args_i(36).assert2_i(36);
 	i.args_i(31337).assert2_i(31337);
 
 	i.sig(SigCache.ii_i);
-	var f2 = byte.!(i.newFunction(SigCache.ii_i, [Opcode.LOCAL_GET.code, 0]).func_index);
-	var f3 = byte.!(i.newFunction(SigCache.ii_i, [Opcode.LOCAL_GET.code, 1]).func_index);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL.code, f2]);
+	var f2 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
+	var f3 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 1]).func_index);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL.code), f2]);
 	i.args_ii(22, 33).assert2_i(22);
 	i.args_ii(44, 55).assert2_i(44);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-	Opcode.CALL.code, f3]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+	op8(Opcode.CALL.code), f3]);
 	i.args_ii(77, 88).assert2_i(88);
 	i.args_ii(88, 99).assert2_i(99);
 }
@@ -71,14 +73,14 @@ def test_callN(i: ExeTester) {
 	var sig_iiiii_i = ValueTypes.newSig([I, I, I, I, I], [I]);
 	i.sig(sig_iiiii_i);
 	for (j < byte.!(5)) {
-		var body = [Opcode.LOCAL_GET.code, j];
+		var body = [op8(Opcode.LOCAL_GET.code), j];
 		var fx = byte.!(i.newFunction(sig_iiiii_i, body).func_index);
-		i.codev([Opcode.LOCAL_GET.code, 0,
-			Opcode.LOCAL_GET.code, 1,
-			Opcode.LOCAL_GET.code, 2,
-			Opcode.LOCAL_GET.code, 3,
-			Opcode.LOCAL_GET.code, 4,
-			Opcode.CALL.code, fx]);
+		i.codev([op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.LOCAL_GET.code), 1,
+			op8(Opcode.LOCAL_GET.code), 2,
+			op8(Opcode.LOCAL_GET.code), 3,
+			op8(Opcode.LOCAL_GET.code), 4,
+			op8(Opcode.CALL.code), fx]);
 		var args: Array<Value> = [Value.I32(j + 100u),
 				Value.I32(j + 200u),
 				Value.I32(j + 300u),
@@ -89,23 +91,23 @@ def test_callN(i: ExeTester) {
 	}
 }
 def test_call_trap(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_v, [Opcode.UNREACHABLE.code]).func_index);
-	i.code([Opcode.I32_CONST.code, 17, Opcode.CALL.code, f17])
+	var f17 = byte.!(i.newFunction(SigCache.v_v, [op8(Opcode.UNREACHABLE.code)]).func_index);
+	i.code([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17])
 		.noargs().assert2_trap(TrapReason.UNREACHABLE);
 }
 def test_call_indirect(i: ExeTester) {
 	i.sig(SigCache.ii_i);
-	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_ADD.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL_INDIRECT.code, byte.!(f1.sig_index), 0]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
 	i.args_ii(44, 1).assert2_i(66);
@@ -146,22 +148,22 @@ def test_call_indirect_subtype(i: ExeTester) {
 	var sig_i_i_sub = Canon.sig(SigDecl.new(false, [HeapType.Func(SigCache.i_i)], SigCache.arr_i, SigCache.arr_i));
 	i.addSig(sig_i_i_sub);
 
-	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_ADD.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(sig_i_i_sub, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 33,
-		Opcode.I32_SUB.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.I32_SUB.code)
 	]);
 	var f4 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f4.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL_INDIRECT.code, byte.!(f1.sig_index), 0]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 4).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
@@ -184,10 +186,10 @@ def test_call_host(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_call_host_callback", sig, test_call_host_callback)];
-	i.code([Opcode.I32_CONST.code, 33,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL.code, byte.!(fd.func_index)]);
+	i.code([op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_ii(44, 33).assert2_i(22);
 	i.args_ii(1090909, 0xFAAA0123).assert2_i(88431075);
@@ -203,10 +205,10 @@ def test_call_host_throw(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_call_host_throw", sig, host_throw)];
-	i.code([Opcode.I32_CONST.code, 33,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL.code, byte.!(fd.func_index)]);
+	i.code([op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_uu(44, 9999).assert2_trap_at(TrapReason.HOST, [7]);
 	i.args_uu(4224, 911999).assert2_trap_at(TrapReason.HOST, [7]);
@@ -234,16 +236,16 @@ def test_reenter_wasm(wf: WasmFunction, args: Range<Value>) -> HostResult {
 def test_reenter(i: ExeTester) {
 	var sig = i.newSig(SigCache.arr_i, SigCache.arr_i);
 	i.sig(sig);
-	var sub17 = i.newFunction(sig, [Opcode.I32_CONST.code, 17, Opcode.LOCAL_GET.code, 0, Opcode.I32_SUB.code]);
-	i.code([Opcode.I32_CONST.code, 0]);
+	var sub17 = i.newFunction(sig, [op8(Opcode.I32_CONST.code), 17, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_SUB.code)]);
+	i.code([op8(Opcode.I32_CONST.code), 0]);
 	var t = i.run(array_u(99)); // run the first test just to get an instance+function
 	var wf = WasmFunction.!(t.0.functions[sub17.func_index]);
 
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_reenter_wasm", sig, test_reenter_wasm(wf, _))];
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.CALL.code, byte.!(fd.func_index)]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_i(44).assert2_u(4294967269u);
 	i.args_i(1090909).assert2_u(4293876404u);
@@ -251,17 +253,17 @@ def test_reenter(i: ExeTester) {
 
 def test_call_ref(i: ExeTester) {
 	var sig_v_i = i.addSig(SigCache.v_i);
-	var f17 = i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 17]);
+	var f17 = i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]);
 	i.code([
-		Opcode.REF_FUNC.code, byte.!(f17.func_index),
-		Opcode.CALL_REF.code, heapIndexByte(sig_v_i)
+		op8(Opcode.REF_FUNC.code), byte.!(f17.func_index),
+		op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_i(17);
 
 	i.code([
-		Opcode.REF_NULL.code, BpTypeCode.FUNCREF.code,
-		Opcode.CALL_REF.code, heapIndexByte(sig_v_i)
+		op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
+		op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_trap(TrapReason.NULL_DEREF);
@@ -269,17 +271,17 @@ def test_call_ref(i: ExeTester) {
 
 def test_rcall1(i: ExeTester) {
 	i.sig(SigCache.v_i);
-	var f17 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 17]).func_index);
-	var f18 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 18]).func_index);
-	var f19 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 19]).func_index);
-	i.code([Opcode.RETURN_CALL.code, f17]).noargs().assert2_i(17);
-	i.code([Opcode.RETURN_CALL.code, f18]).noargs().assert2_i(18);
-	i.code([Opcode.RETURN_CALL.code, f19]).noargs().assert2_i(19);
+	var f17 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]).func_index);
+	var f18 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 18]).func_index);
+	var f19 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 19]).func_index);
+	i.code([op8(Opcode.RETURN_CALL.code), f17]).noargs().assert2_i(17);
+	i.code([op8(Opcode.RETURN_CALL.code), f18]).noargs().assert2_i(18);
+	i.code([op8(Opcode.RETURN_CALL.code), f19]).noargs().assert2_i(19);
 }
 def test_rcall2(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	var f1 = byte.!(i.newFunction(SigCache.i_i, [Opcode.LOCAL_GET.code, 0]).func_index);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.RETURN_CALL.code, f1]);
+	var f1 = byte.!(i.newFunction(SigCache.i_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.RETURN_CALL.code), f1]);
 	i.args_i(197).assert2_i(197);
 	i.args_i(36).assert2_i(36);
 	i.args_i(31337).assert2_i(31337);
@@ -287,19 +289,19 @@ def test_rcall2(i: ExeTester) {
 
 def test_rcall3(i: ExeTester) {
 	i.sig(SigCache.ii_i);
-	var f2 = byte.!(i.newFunction(SigCache.ii_i, [Opcode.LOCAL_GET.code, 0]).func_index);
-	var f3 = byte.!(i.newFunction(SigCache.ii_i, [Opcode.LOCAL_GET.code, 1]).func_index);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.RETURN_CALL.code, f2,
-		Opcode.UNREACHABLE.code]);
+	var f2 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
+	var f3 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 1]).func_index);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.RETURN_CALL.code), f2,
+		op8(Opcode.UNREACHABLE.code)]);
 	i.args_ii(22, 33).assert2_i(22);
 	i.args_ii(44, 55).assert2_i(44);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.RETURN_CALL.code, f3,
-		Opcode.UNREACHABLE.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.RETURN_CALL.code), f3,
+		op8(Opcode.UNREACHABLE.code)]);
 	i.args_ii(77, 88).assert2_i(88);
 	i.args_ii(88, 99).assert2_i(99);
 }
@@ -309,15 +311,15 @@ def test_rcallN(i: ExeTester) {
 	i.extensions |= Extension.TAIL_CALL;
 	i.sig(sig_iiiii_i);
 	for (j < byte.!(5)) {
-		var body = [Opcode.LOCAL_GET.code, j];
+		var body = [op8(Opcode.LOCAL_GET.code), j];
 		var fx = byte.!(i.newFunction(sig_iiiii_i, body).func_index);
-		i.codev([Opcode.LOCAL_GET.code, 0,
-			Opcode.LOCAL_GET.code, 1,
-			Opcode.LOCAL_GET.code, 2,
-			Opcode.LOCAL_GET.code, 3,
-			Opcode.LOCAL_GET.code, 4,
-			Opcode.RETURN_CALL.code, fx,
-			Opcode.UNREACHABLE.code]);
+		i.codev([op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.LOCAL_GET.code), 1,
+			op8(Opcode.LOCAL_GET.code), 2,
+			op8(Opcode.LOCAL_GET.code), 3,
+			op8(Opcode.LOCAL_GET.code), 4,
+			op8(Opcode.RETURN_CALL.code), fx,
+			op8(Opcode.UNREACHABLE.code)]);
 		var args: Array<Value> = [Value.I32(j + 100u),
 				Value.I32(j + 200u),
 				Value.I32(j + 300u),
@@ -333,10 +335,10 @@ def test_rcall_host(i: ExeTester) {
 	var imp = i.newFunc(sig);
 	i.module.addImport("", "", imp);
 	i.imports = [HostFunction.new("test_call_host_callback", sig, test_call_host_callback)];
-	i.code([Opcode.I32_CONST.code, 33,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.RETURN_CALL.code, byte.!(imp.func_index)]);
+	i.code([op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.RETURN_CALL.code), byte.!(imp.func_index)]);
 
 	i.args_ii(44, 33).assert2_i(22);
 	i.args_ii(1090909, 0xFAAA0123).assert2_i(88431075);
@@ -349,13 +351,13 @@ def test_rcall_host2(i: ExeTester) {
 	i.imports = [HostFunction.new("test_call_host_callback", imp.sig, test_call_host_callback)];
 
 	var f2 = i.newFunction(SigCache.v_i, [
-		Opcode.I32_CONST.code, 66,
-		Opcode.I32_CONST.code, 55,
-		Opcode.RETURN_CALL.code, byte.!(imp.func_index)
+		op8(Opcode.I32_CONST.code), 66,
+		op8(Opcode.I32_CONST.code), 55,
+		op8(Opcode.RETURN_CALL.code), byte.!(imp.func_index)
 	]);
 	i.sig(SigCache.v_i);
 	i.code([
-		Opcode.CALL.code, byte.!(f2.func_index)]);
+		op8(Opcode.CALL.code), byte.!(f2.func_index)]);
 
 	i.noargs().assert2_i(106);
 }
@@ -365,23 +367,23 @@ def test_rcall_indirect(i: ExeTester) {
 	var sig_i_i_sub = Canon.sig(SigDecl.new(false, [HeapType.Func(SigCache.i_i)], SigCache.arr_i, SigCache.arr_i));
 	i.addSig(sig_i_i_sub);
 
-	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_ADD.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(sig_i_i_sub, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 44,
-		Opcode.I32_SUB.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 44,
+		op8(Opcode.I32_SUB.code)
 	]);
 	var f4 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f4.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.RETURN_CALL_INDIRECT.code, byte.!(f1.sig_index), 0,
-		Opcode.UNREACHABLE.code]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.!(f1.sig_index), 0,
+		op8(Opcode.UNREACHABLE.code)]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 4).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
@@ -398,18 +400,18 @@ def test_rcall_indirect(i: ExeTester) {
 def test_rcall_indirect_subtype(i: ExeTester) {
 	i.sig(SigCache.ii_i);
 	i.extensions |= Extension.TAIL_CALL;
-	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_ADD.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.RETURN_CALL_INDIRECT.code, byte.!(f1.sig_index), 0,
-		Opcode.UNREACHABLE.code]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.!(f1.sig_index), 0,
+		op8(Opcode.UNREACHABLE.code)]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
 	i.args_ii(44, 1).assert2_i(66);
@@ -423,17 +425,17 @@ def test_rcall_indirect_subtype(i: ExeTester) {
 }
 def test_rcall_ref(i: ExeTester) {
 	var sig_v_i = i.addSig(SigCache.v_i);
-	var f17 = i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 17]);
+	var f17 = i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]);
 	i.code([
-		Opcode.REF_FUNC.code, byte.!(f17.func_index),
-		Opcode.RETURN_CALL_REF.code, heapIndexByte(sig_v_i)
+		op8(Opcode.REF_FUNC.code), byte.!(f17.func_index),
+		op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_i(17);
 
 	i.code([
-		Opcode.REF_NULL.code, BpTypeCode.FUNCREF.code,
-		Opcode.RETURN_CALL_REF.code, heapIndexByte(sig_v_i)
+		op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
+		op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_trap(TrapReason.NULL_DEREF);
@@ -445,9 +447,9 @@ def test_rcall_host_rcall_wasm(i: ExeTester) {
 		var t = ModuleBuilder.new();
 		t.sig(sig);
 		var c37 = t.newFunction(SigCache.i_i, [
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.I32_CONST.code, 37,
-			Opcode.I32_SUB.code
+			op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.I32_CONST.code), 37,
+			op8(Opcode.I32_SUB.code)
 		]);
 		var instance = Instantiator.new(t.extensions, t.module, [], ErrorGen.new("InterpreterTest.v3")).run();
 		f37 = instance.functions[c37.func_index];
@@ -458,7 +460,7 @@ def test_rcall_host_rcall_wasm(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new(null, sig, fw_host_call(f37, _))];
-	i.code([Opcode.RETURN_CALL.code, byte.!(fd.func_index)]);
+	i.code([op8(Opcode.RETURN_CALL.code), byte.!(fd.func_index)]);
 
 	i.args_i(33).assert2_i(-4);
 	i.args_i(1090939).assert2_i(1090902);
@@ -472,7 +474,7 @@ def fw_host_call(f: Function, args: Range<Value>) -> HostResult {
 
 def test_host_tail_call1(t: ExeTester) {
 	t.sig(SigCache.i_i);
-	t.code([Opcode.LOCAL_GET.code, 0, Opcode.I32_CONST.code, 5, Opcode.I32_ADD.code]);
+	t.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_CONST.code), 5, op8(Opcode.I32_ADD.code)]);
 	var instance = Instantiator.new(t.extensions, t.module, [], ErrorGen.new("InterpreterTest.v3")).run();
 	var f = instance.functions[0];
 
@@ -498,8 +500,8 @@ def test_host_tail_call2(t: ExeTester) {
 def test_stack_overflow1(i: ExeTester) {
 	i.sig(SigCache.i_v);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.CALL.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.CALL.code), 0
 	]);
 	i.max_call_depth = 10;
 	i.args_u(0).assert2_trap(TrapReason.STACK_OVERFLOW);
@@ -509,8 +511,8 @@ def test_stack_overflow2(i: ExeTester) {
 	i.sig(SigCache.i_v);
 	i.addLocals(2000, ValueType.I32);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.CALL.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.CALL.code), 0
 	]);
 	i.max_call_depth = 10;
 	i.args_u(2).assert2_trap(TrapReason.STACK_OVERFLOW);
@@ -538,9 +540,9 @@ def test_force_gc1(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_force_gc_callback", sig, test_force_gc_callback)];
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL.code, byte.!(fd.func_index)]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_ii(44, 33).assert2_i(22);
 	i.args_ii(1090909, 0xFAAA0123).assert2_i(88431075);
@@ -565,12 +567,12 @@ def test_force_gc2(i: ExeTester) {
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_force_gc_callback2", sig, test_force_gc_callback2)];
 	i.code([
-		Opcode.I32_CONST.code, 33,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.CALL.code, byte.!(fd.func_index), // local 0 should be scanned by gc
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.CALL.code, byte.!(fd.func_index), // local 0 should be scanned by gc
-		Opcode.LOCAL_GET.code, 0]);
+		op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.CALL.code), byte.!(fd.func_index), // local 0 should be scanned by gc
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.CALL.code), byte.!(fd.func_index), // local 0 should be scanned by gc
+		op8(Opcode.LOCAL_GET.code), 0]);
 
 	var r = TestObject.new("force_gc2_object"), v = Value.Ref(r), vs: Array<Value> = [v];
 	i.argsN(vs).assert2_res(Result.Value([v, v, v]));

--- a/test/unittest/ExeCallTest.v3
+++ b/test/unittest/ExeCallTest.v3
@@ -32,7 +32,7 @@ def X_ = TestTiers.addTests([
 	("force_gc2", test_force_gc2)
 ]);
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 def test_call0(i: ExeTester) {
 	var f17 = byte.!(i.newFunction(SigCache.v_v, []).func_index);

--- a/test/unittest/ExeCallTest.v3
+++ b/test/unittest/ExeCallTest.v3
@@ -119,17 +119,17 @@ def test_call_indirect(i: ExeTester) {
 }
 def test_call_indirect_extended(i: ExeTester) {
 	i.sig(SigCache.ii_i);
-	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f1 = i.newFunction(SigCache.i_i, [u8.!(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 22,
-		Opcode.I32_ADD.code
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL_INDIRECT.code, byte.!(f1.sig_index | 0x80), 0x80, 0, 0x80, 0x80, 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index | 0x80), 0x80, 0, 0x80, 0x80, 0]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
 	i.args_ii(44, 1).assert2_i(66);

--- a/test/unittest/ExeCallTest.v3
+++ b/test/unittest/ExeCallTest.v3
@@ -32,39 +32,37 @@ def X_ = TestTiers.addTests([
 	("force_gc2", test_force_gc2)
 ]);
 
-def op8 = Opcodes.op8;
-
 def test_call0(i: ExeTester) {
 	var f17 = byte.!(i.newFunction(SigCache.v_v, []).func_index);
-	i.code([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17]).noargs().assert2_i(17);
+	i.code([u8.!(Opcode.I32_CONST.code), 17, u8.!(Opcode.CALL.code), f17]).noargs().assert2_i(17);
 }
 def test_call1(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]).func_index);
-	var f18 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 18]).func_index);
-	var f19 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 19]).func_index);
-	i.code([op8(Opcode.CALL.code), f17]).noargs().assert2_i(17);
-	i.code([op8(Opcode.CALL.code), f18]).noargs().assert2_i(18);
-	i.code([op8(Opcode.CALL.code), f19]).noargs().assert2_i(19);
+	var f17 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 17]).func_index);
+	var f18 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 18]).func_index);
+	var f19 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 19]).func_index);
+	i.code([u8.!(Opcode.CALL.code), f17]).noargs().assert2_i(17);
+	i.code([u8.!(Opcode.CALL.code), f18]).noargs().assert2_i(18);
+	i.code([u8.!(Opcode.CALL.code), f19]).noargs().assert2_i(19);
 }
 def test_call2(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	var f1 = byte.!(i.newFunction(SigCache.i_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.CALL.code), f1]);
+	var f1 = byte.!(i.newFunction(SigCache.i_i, [u8.!(Opcode.LOCAL_GET.code), 0]).func_index);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.CALL.code), f1]);
 	i.args_i(197).assert2_i(197);
 	i.args_i(36).assert2_i(36);
 	i.args_i(31337).assert2_i(31337);
 
 	i.sig(SigCache.ii_i);
-	var f2 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
-	var f3 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 1]).func_index);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL.code), f2]);
+	var f2 = byte.!(i.newFunction(SigCache.ii_i, [u8.!(Opcode.LOCAL_GET.code), 0]).func_index);
+	var f3 = byte.!(i.newFunction(SigCache.ii_i, [u8.!(Opcode.LOCAL_GET.code), 1]).func_index);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL.code), f2]);
 	i.args_ii(22, 33).assert2_i(22);
 	i.args_ii(44, 55).assert2_i(44);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-	op8(Opcode.CALL.code), f3]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+	u8.!(Opcode.CALL.code), f3]);
 	i.args_ii(77, 88).assert2_i(88);
 	i.args_ii(88, 99).assert2_i(99);
 }
@@ -73,14 +71,14 @@ def test_callN(i: ExeTester) {
 	var sig_iiiii_i = ValueTypes.newSig([I, I, I, I, I], [I]);
 	i.sig(sig_iiiii_i);
 	for (j < byte.!(5)) {
-		var body = [op8(Opcode.LOCAL_GET.code), j];
+		var body = [u8.!(Opcode.LOCAL_GET.code), j];
 		var fx = byte.!(i.newFunction(sig_iiiii_i, body).func_index);
-		i.codev([op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.LOCAL_GET.code), 1,
-			op8(Opcode.LOCAL_GET.code), 2,
-			op8(Opcode.LOCAL_GET.code), 3,
-			op8(Opcode.LOCAL_GET.code), 4,
-			op8(Opcode.CALL.code), fx]);
+		i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.LOCAL_GET.code), 1,
+			u8.!(Opcode.LOCAL_GET.code), 2,
+			u8.!(Opcode.LOCAL_GET.code), 3,
+			u8.!(Opcode.LOCAL_GET.code), 4,
+			u8.!(Opcode.CALL.code), fx]);
 		var args: Array<Value> = [Value.I32(j + 100u),
 				Value.I32(j + 200u),
 				Value.I32(j + 300u),
@@ -91,23 +89,23 @@ def test_callN(i: ExeTester) {
 	}
 }
 def test_call_trap(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_v, [op8(Opcode.UNREACHABLE.code)]).func_index);
-	i.code([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17])
+	var f17 = byte.!(i.newFunction(SigCache.v_v, [u8.!(Opcode.UNREACHABLE.code)]).func_index);
+	i.code([u8.!(Opcode.I32_CONST.code), 17, u8.!(Opcode.CALL.code), f17])
 		.noargs().assert2_trap(TrapReason.UNREACHABLE);
 }
 def test_call_indirect(i: ExeTester) {
 	i.sig(SigCache.ii_i);
-	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
+	var f1 = i.newFunction(SigCache.i_i, [u8.!(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.I32_ADD.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
 	i.args_ii(44, 1).assert2_i(66);
@@ -148,22 +146,22 @@ def test_call_indirect_subtype(i: ExeTester) {
 	var sig_i_i_sub = Canon.sig(SigDecl.new(false, [HeapType.Func(SigCache.i_i)], SigCache.arr_i, SigCache.arr_i));
 	i.addSig(sig_i_i_sub);
 
-	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
+	var f1 = i.newFunction(SigCache.i_i, [u8.!(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.I32_ADD.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(sig_i_i_sub, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	var f4 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f4.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 4).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
@@ -186,10 +184,10 @@ def test_call_host(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_call_host_callback", sig, test_call_host_callback)];
-	i.code([op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
+	i.code([u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_ii(44, 33).assert2_i(22);
 	i.args_ii(1090909, 0xFAAA0123).assert2_i(88431075);
@@ -205,10 +203,10 @@ def test_call_host_throw(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_call_host_throw", sig, host_throw)];
-	i.code([op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
+	i.code([u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_uu(44, 9999).assert2_trap_at(TrapReason.HOST, [7]);
 	i.args_uu(4224, 911999).assert2_trap_at(TrapReason.HOST, [7]);
@@ -236,16 +234,16 @@ def test_reenter_wasm(wf: WasmFunction, args: Range<Value>) -> HostResult {
 def test_reenter(i: ExeTester) {
 	var sig = i.newSig(SigCache.arr_i, SigCache.arr_i);
 	i.sig(sig);
-	var sub17 = i.newFunction(sig, [op8(Opcode.I32_CONST.code), 17, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_SUB.code)]);
-	i.code([op8(Opcode.I32_CONST.code), 0]);
+	var sub17 = i.newFunction(sig, [u8.!(Opcode.I32_CONST.code), 17, u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I32_SUB.code)]);
+	i.code([u8.!(Opcode.I32_CONST.code), 0]);
 	var t = i.run(array_u(99)); // run the first test just to get an instance+function
 	var wf = WasmFunction.!(t.0.functions[sub17.func_index]);
 
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_reenter_wasm", sig, test_reenter_wasm(wf, _))];
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_i(44).assert2_u(4294967269u);
 	i.args_i(1090909).assert2_u(4293876404u);
@@ -253,17 +251,17 @@ def test_reenter(i: ExeTester) {
 
 def test_call_ref(i: ExeTester) {
 	var sig_v_i = i.addSig(SigCache.v_i);
-	var f17 = i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]);
+	var f17 = i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 17]);
 	i.code([
-		op8(Opcode.REF_FUNC.code), byte.!(f17.func_index),
-		op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
+		u8.!(Opcode.REF_FUNC.code), byte.!(f17.func_index),
+		u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_i(17);
 
 	i.code([
-		op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
-		op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
+		u8.!(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
+		u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_trap(TrapReason.NULL_DEREF);
@@ -271,17 +269,17 @@ def test_call_ref(i: ExeTester) {
 
 def test_rcall1(i: ExeTester) {
 	i.sig(SigCache.v_i);
-	var f17 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]).func_index);
-	var f18 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 18]).func_index);
-	var f19 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 19]).func_index);
-	i.code([op8(Opcode.RETURN_CALL.code), f17]).noargs().assert2_i(17);
-	i.code([op8(Opcode.RETURN_CALL.code), f18]).noargs().assert2_i(18);
-	i.code([op8(Opcode.RETURN_CALL.code), f19]).noargs().assert2_i(19);
+	var f17 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 17]).func_index);
+	var f18 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 18]).func_index);
+	var f19 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 19]).func_index);
+	i.code([u8.!(Opcode.RETURN_CALL.code), f17]).noargs().assert2_i(17);
+	i.code([u8.!(Opcode.RETURN_CALL.code), f18]).noargs().assert2_i(18);
+	i.code([u8.!(Opcode.RETURN_CALL.code), f19]).noargs().assert2_i(19);
 }
 def test_rcall2(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	var f1 = byte.!(i.newFunction(SigCache.i_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.RETURN_CALL.code), f1]);
+	var f1 = byte.!(i.newFunction(SigCache.i_i, [u8.!(Opcode.LOCAL_GET.code), 0]).func_index);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.RETURN_CALL.code), f1]);
 	i.args_i(197).assert2_i(197);
 	i.args_i(36).assert2_i(36);
 	i.args_i(31337).assert2_i(31337);
@@ -289,19 +287,19 @@ def test_rcall2(i: ExeTester) {
 
 def test_rcall3(i: ExeTester) {
 	i.sig(SigCache.ii_i);
-	var f2 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 0]).func_index);
-	var f3 = byte.!(i.newFunction(SigCache.ii_i, [op8(Opcode.LOCAL_GET.code), 1]).func_index);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.RETURN_CALL.code), f2,
-		op8(Opcode.UNREACHABLE.code)]);
+	var f2 = byte.!(i.newFunction(SigCache.ii_i, [u8.!(Opcode.LOCAL_GET.code), 0]).func_index);
+	var f3 = byte.!(i.newFunction(SigCache.ii_i, [u8.!(Opcode.LOCAL_GET.code), 1]).func_index);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.RETURN_CALL.code), f2,
+		u8.!(Opcode.UNREACHABLE.code)]);
 	i.args_ii(22, 33).assert2_i(22);
 	i.args_ii(44, 55).assert2_i(44);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.RETURN_CALL.code), f3,
-		op8(Opcode.UNREACHABLE.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.RETURN_CALL.code), f3,
+		u8.!(Opcode.UNREACHABLE.code)]);
 	i.args_ii(77, 88).assert2_i(88);
 	i.args_ii(88, 99).assert2_i(99);
 }
@@ -311,15 +309,15 @@ def test_rcallN(i: ExeTester) {
 	i.extensions |= Extension.TAIL_CALL;
 	i.sig(sig_iiiii_i);
 	for (j < byte.!(5)) {
-		var body = [op8(Opcode.LOCAL_GET.code), j];
+		var body = [u8.!(Opcode.LOCAL_GET.code), j];
 		var fx = byte.!(i.newFunction(sig_iiiii_i, body).func_index);
-		i.codev([op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.LOCAL_GET.code), 1,
-			op8(Opcode.LOCAL_GET.code), 2,
-			op8(Opcode.LOCAL_GET.code), 3,
-			op8(Opcode.LOCAL_GET.code), 4,
-			op8(Opcode.RETURN_CALL.code), fx,
-			op8(Opcode.UNREACHABLE.code)]);
+		i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.LOCAL_GET.code), 1,
+			u8.!(Opcode.LOCAL_GET.code), 2,
+			u8.!(Opcode.LOCAL_GET.code), 3,
+			u8.!(Opcode.LOCAL_GET.code), 4,
+			u8.!(Opcode.RETURN_CALL.code), fx,
+			u8.!(Opcode.UNREACHABLE.code)]);
 		var args: Array<Value> = [Value.I32(j + 100u),
 				Value.I32(j + 200u),
 				Value.I32(j + 300u),
@@ -335,10 +333,10 @@ def test_rcall_host(i: ExeTester) {
 	var imp = i.newFunc(sig);
 	i.module.addImport("", "", imp);
 	i.imports = [HostFunction.new("test_call_host_callback", sig, test_call_host_callback)];
-	i.code([op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.RETURN_CALL.code), byte.!(imp.func_index)]);
+	i.code([u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.RETURN_CALL.code), byte.!(imp.func_index)]);
 
 	i.args_ii(44, 33).assert2_i(22);
 	i.args_ii(1090909, 0xFAAA0123).assert2_i(88431075);
@@ -351,13 +349,13 @@ def test_rcall_host2(i: ExeTester) {
 	i.imports = [HostFunction.new("test_call_host_callback", imp.sig, test_call_host_callback)];
 
 	var f2 = i.newFunction(SigCache.v_i, [
-		op8(Opcode.I32_CONST.code), 66,
-		op8(Opcode.I32_CONST.code), 55,
-		op8(Opcode.RETURN_CALL.code), byte.!(imp.func_index)
+		u8.!(Opcode.I32_CONST.code), 66,
+		u8.!(Opcode.I32_CONST.code), 55,
+		u8.!(Opcode.RETURN_CALL.code), byte.!(imp.func_index)
 	]);
 	i.sig(SigCache.v_i);
 	i.code([
-		op8(Opcode.CALL.code), byte.!(f2.func_index)]);
+		u8.!(Opcode.CALL.code), byte.!(f2.func_index)]);
 
 	i.noargs().assert2_i(106);
 }
@@ -367,23 +365,23 @@ def test_rcall_indirect(i: ExeTester) {
 	var sig_i_i_sub = Canon.sig(SigDecl.new(false, [HeapType.Func(SigCache.i_i)], SigCache.arr_i, SigCache.arr_i));
 	i.addSig(sig_i_i_sub);
 
-	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
+	var f1 = i.newFunction(SigCache.i_i, [u8.!(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.I32_ADD.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(sig_i_i_sub, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 44,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 44,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	var f4 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f4.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.!(f1.sig_index), 0,
-		op8(Opcode.UNREACHABLE.code)]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.RETURN_CALL_INDIRECT.code), byte.!(f1.sig_index), 0,
+		u8.!(Opcode.UNREACHABLE.code)]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 4).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
@@ -400,18 +398,18 @@ def test_rcall_indirect(i: ExeTester) {
 def test_rcall_indirect_subtype(i: ExeTester) {
 	i.sig(SigCache.ii_i);
 	i.extensions |= Extension.TAIL_CALL;
-	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
+	var f1 = i.newFunction(SigCache.i_i, [u8.!(Opcode.I32_CONST.code), 11]);
 	var f2 = i.newFunction(SigCache.i_i, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.I32_ADD.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.I32_ADD.code)
 	]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f1.func_index, f2.func_index, f3.func_index]);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.RETURN_CALL_INDIRECT.code), byte.!(f1.sig_index), 0,
-		op8(Opcode.UNREACHABLE.code)]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.RETURN_CALL_INDIRECT.code), byte.!(f1.sig_index), 0,
+		u8.!(Opcode.UNREACHABLE.code)]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
 	i.args_ii(44, 1).assert2_i(66);
@@ -425,17 +423,17 @@ def test_rcall_indirect_subtype(i: ExeTester) {
 }
 def test_rcall_ref(i: ExeTester) {
 	var sig_v_i = i.addSig(SigCache.v_i);
-	var f17 = i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]);
+	var f17 = i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 17]);
 	i.code([
-		op8(Opcode.REF_FUNC.code), byte.!(f17.func_index),
-		op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_v_i)
+		u8.!(Opcode.REF_FUNC.code), byte.!(f17.func_index),
+		u8.!(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_i(17);
 
 	i.code([
-		op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
-		op8(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_v_i)
+		u8.!(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
+		u8.!(Opcode.RETURN_CALL_REF.code), heapIndexByte(sig_v_i)
 	]);
 
 	i.noargs().assert2_trap(TrapReason.NULL_DEREF);
@@ -447,9 +445,9 @@ def test_rcall_host_rcall_wasm(i: ExeTester) {
 		var t = ModuleBuilder.new();
 		t.sig(sig);
 		var c37 = t.newFunction(SigCache.i_i, [
-			op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.I32_CONST.code), 37,
-			op8(Opcode.I32_SUB.code)
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.I32_CONST.code), 37,
+			u8.!(Opcode.I32_SUB.code)
 		]);
 		var instance = Instantiator.new(t.extensions, t.module, [], ErrorGen.new("InterpreterTest.v3")).run();
 		f37 = instance.functions[c37.func_index];
@@ -460,7 +458,7 @@ def test_rcall_host_rcall_wasm(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new(null, sig, fw_host_call(f37, _))];
-	i.code([op8(Opcode.RETURN_CALL.code), byte.!(fd.func_index)]);
+	i.code([u8.!(Opcode.RETURN_CALL.code), byte.!(fd.func_index)]);
 
 	i.args_i(33).assert2_i(-4);
 	i.args_i(1090939).assert2_i(1090902);
@@ -474,7 +472,7 @@ def fw_host_call(f: Function, args: Range<Value>) -> HostResult {
 
 def test_host_tail_call1(t: ExeTester) {
 	t.sig(SigCache.i_i);
-	t.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_CONST.code), 5, op8(Opcode.I32_ADD.code)]);
+	t.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I32_CONST.code), 5, u8.!(Opcode.I32_ADD.code)]);
 	var instance = Instantiator.new(t.extensions, t.module, [], ErrorGen.new("InterpreterTest.v3")).run();
 	var f = instance.functions[0];
 
@@ -500,8 +498,8 @@ def test_host_tail_call2(t: ExeTester) {
 def test_stack_overflow1(i: ExeTester) {
 	i.sig(SigCache.i_v);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.CALL.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.CALL.code), 0
 	]);
 	i.max_call_depth = 10;
 	i.args_u(0).assert2_trap(TrapReason.STACK_OVERFLOW);
@@ -511,8 +509,8 @@ def test_stack_overflow2(i: ExeTester) {
 	i.sig(SigCache.i_v);
 	i.addLocals(2000, ValueType.I32);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.CALL.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.CALL.code), 0
 	]);
 	i.max_call_depth = 10;
 	i.args_u(2).assert2_trap(TrapReason.STACK_OVERFLOW);
@@ -540,9 +538,9 @@ def test_force_gc1(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_force_gc_callback", sig, test_force_gc_callback)];
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index)]);
 
 	i.args_ii(44, 33).assert2_i(22);
 	i.args_ii(1090909, 0xFAAA0123).assert2_i(88431075);
@@ -567,12 +565,12 @@ def test_force_gc2(i: ExeTester) {
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_force_gc_callback2", sig, test_force_gc_callback2)];
 	i.code([
-		op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.CALL.code), byte.!(fd.func_index), // local 0 should be scanned by gc
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.CALL.code), byte.!(fd.func_index), // local 0 should be scanned by gc
-		op8(Opcode.LOCAL_GET.code), 0]);
+		u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index), // local 0 should be scanned by gc
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index), // local 0 should be scanned by gc
+		u8.!(Opcode.LOCAL_GET.code), 0]);
 
 	var r = TestObject.new("force_gc2_object"), v = Value.Ref(r), vs: Array<Value> = [v];
 	i.argsN(vs).assert2_res(Result.Value([v, v, v]));

--- a/test/unittest/ExeCallTest.v3
+++ b/test/unittest/ExeCallTest.v3
@@ -8,6 +8,7 @@ def X_ = TestTiers.addTests([
 	("callN", test_callN),
 	("call_trap", test_call_trap),
 	("call_indirect", test_call_indirect),
+	("call_indirect_extended", test_call_indirect_extended),
 	("call_indirect_subtype", test_call_indirect_subtype),
 	("call_host", test_call_host),
 	("call_host_throw", test_call_host_throw),
@@ -105,6 +106,30 @@ def test_call_indirect(i: ExeTester) {
 	i.codev([Opcode.LOCAL_GET.code, 0,
 		Opcode.LOCAL_GET.code, 1,
 		Opcode.CALL_INDIRECT.code, byte.!(f1.sig_index), 0]);
+	i.args_ii(0, 0).assert2_i(11);
+	i.args_ii(0, 1).assert2_i(22);
+	i.args_ii(44, 1).assert2_i(66);
+	i.args_ii(0, 3).assert2_i(11);
+	i.args_ii(0, 4).assert2_i(22);
+	i.args_ii(49, 4).assert2_i(71);
+	i.args_uu(0, 2).assert2_trap(TrapReason.FUNC_SIG_MISMATCH);
+	i.args_uu(0, 5).assert2_trap(TrapReason.FUNC_SIG_MISMATCH);
+	i.args_uu(0, 6).assert2_trap(TrapReason.FUNC_INVALID);
+	i.args_uu(0, 7).assert2_trap(TrapReason.FUNC_INVALID);
+}
+def test_call_indirect_extended(i: ExeTester) {
+	i.sig(SigCache.ii_i);
+	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f2 = i.newFunction(SigCache.i_i, [
+		Opcode.LOCAL_GET.code, 0,
+		Opcode.I32_CONST.code, 22,
+		Opcode.I32_ADD.code
+	]);
+	var f3 = i.newFunction(SigCache.v_v, []);
+	i.addTable(7, 0, [f1.func_index, f2.func_index, f3.func_index, f1.func_index, f2.func_index, f3.func_index]);
+	i.codev([Opcode.LOCAL_GET.code, 0,
+		Opcode.LOCAL_GET.code, 1,
+		Opcode.CALL_INDIRECT.code, byte.!(f1.sig_index | 0x80), 0x80, 0, 0x80, 0x80, 0]);
 	i.args_ii(0, 0).assert2_i(11);
 	i.args_ii(0, 1).assert2_i(22);
 	i.args_ii(44, 1).assert2_i(66);

--- a/test/unittest/ExeProbeTest.v3
+++ b/test/unittest/ExeProbeTest.v3
@@ -10,7 +10,7 @@ def X_ = TestTiers.addTests([
 	("entry_probe1", test_entry_probe1)
 ]);
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 def test_force_gc_callback(args: Range<Value>) -> HostResult {
 	// Allocations and forced GCs help randomize the heap layout to catch bugs in walking interpreter frames

--- a/test/unittest/ExeProbeTest.v3
+++ b/test/unittest/ExeProbeTest.v3
@@ -10,8 +10,6 @@ def X_ = TestTiers.addTests([
 	("entry_probe1", test_entry_probe1)
 ]);
 
-def op8 = Opcodes.op8;
-
 def test_force_gc_callback(args: Range<Value>) -> HostResult {
 	// Allocations and forced GCs help randomize the heap layout to catch bugs in walking interpreter frames
 	var a = args[0], b = args[1];
@@ -38,9 +36,9 @@ def test_gc_CountProbe(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_gcCountProbe_callback", sig, test_force_gc_callback)];
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL.code), byte.!(fd.func_index)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 1, count);
 
 	i.args_ii(44, 33).assert2_i(22);
@@ -72,9 +70,9 @@ def test_gc_OperandProbe_i_v(i: ExeTester) {
 	var p1 = RecordTosProbe.new(), p2 = RecordTosProbe.new();
 
 	i.sig(SigCache.ii_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_ADD.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_ADD.code)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 3, p1);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 5, p2);
 
@@ -94,9 +92,9 @@ def test_dyn_probe_insert(i: ExeTester) {
 	var p1 = ClosureProbe.new(Instrumentation.insertLocalProbe, (i.module, i.func.func_index, 1, counter));
 
 	i.sig(SigCache.ii_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_ADD.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_ADD.code)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 3, p1);
 
 	i.args_ii(44, 33).assert2_i(77);
@@ -114,9 +112,9 @@ def test_dyn_probe_insert_osr(i: ExeTester) {
 	var p1 = ClosureProbe.new(Instrumentation.insertLocalProbe, (i.module, i.func.func_index, 3, counter));
 
 	i.sig(SigCache.ii_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_ADD.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_ADD.code)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 1, p1);
 
 	i.args_ii(44, 33).assert2_i(77);
@@ -140,17 +138,17 @@ def test_entry_probe0(i: ExeTester) {
 	var counter = TraceProbe2.new();
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.I32_CONST.code), 17,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_SUB.code),
-		op8(Opcode.LOCAL_TEE.code), 0,
-		op8(Opcode.I32_EQZ.code),
-		op8(Opcode.BR_IF.code), 1,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.I32_CONST.code), 17,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_SUB.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0,
+		u8.!(Opcode.I32_EQZ.code),
+		u8.!(Opcode.BR_IF.code), 1,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 0, counter);
 	i.args_i(5).assert2_i(17);
@@ -163,17 +161,17 @@ def test_entry_probe1(i: ExeTester) {
 	var counter = TraceProbe2.new();
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.I32_CONST.code), 17,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_SUB.code),
-		op8(Opcode.LOCAL_TEE.code), 0,
-		op8(Opcode.I32_EQZ.code),
-		op8(Opcode.BR_IF.code), 1,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.I32_CONST.code), 17,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_SUB.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0,
+		u8.!(Opcode.I32_EQZ.code),
+		u8.!(Opcode.BR_IF.code), 1,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	Instrumentation.insertFuncEntryProbe(i.module, i.func.func_index, counter);
 	i.args_i(5).assert2_i(17);

--- a/test/unittest/ExeProbeTest.v3
+++ b/test/unittest/ExeProbeTest.v3
@@ -10,6 +10,8 @@ def X_ = TestTiers.addTests([
 	("entry_probe1", test_entry_probe1)
 ]);
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 def test_force_gc_callback(args: Range<Value>) -> HostResult {
 	// Allocations and forced GCs help randomize the heap layout to catch bugs in walking interpreter frames
 	var a = args[0], b = args[1];
@@ -36,9 +38,9 @@ def test_gc_CountProbe(i: ExeTester) {
 	var fd = i.newFunc(sig);
 	i.module.addImport("", "", fd);
 	i.imports = [HostFunction.new("test_gcCountProbe_callback", sig, test_force_gc_callback)];
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL.code, byte.!(fd.func_index)]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL.code), byte.!(fd.func_index)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 1, count);
 
 	i.args_ii(44, 33).assert2_i(22);
@@ -70,9 +72,9 @@ def test_gc_OperandProbe_i_v(i: ExeTester) {
 	var p1 = RecordTosProbe.new(), p2 = RecordTosProbe.new();
 
 	i.sig(SigCache.ii_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_ADD.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_ADD.code)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 3, p1);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 5, p2);
 
@@ -92,9 +94,9 @@ def test_dyn_probe_insert(i: ExeTester) {
 	var p1 = ClosureProbe.new(Instrumentation.insertLocalProbe, (i.module, i.func.func_index, 1, counter));
 
 	i.sig(SigCache.ii_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_ADD.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_ADD.code)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 3, p1);
 
 	i.args_ii(44, 33).assert2_i(77);
@@ -112,9 +114,9 @@ def test_dyn_probe_insert_osr(i: ExeTester) {
 	var p1 = ClosureProbe.new(Instrumentation.insertLocalProbe, (i.module, i.func.func_index, 3, counter));
 
 	i.sig(SigCache.ii_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_ADD.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_ADD.code)]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 1, p1);
 
 	i.args_ii(44, 33).assert2_i(77);
@@ -138,17 +140,17 @@ def test_entry_probe0(i: ExeTester) {
 	var counter = TraceProbe2.new();
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.LOOP.code, BpTypeCode.EmptyBlock.code,
-		Opcode.I32_CONST.code, 17,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_SUB.code,
-		Opcode.LOCAL_TEE.code, 0,
-		Opcode.I32_EQZ.code,
-		Opcode.BR_IF.code, 1,
-		Opcode.BR.code, 0,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.I32_CONST.code), 17,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_SUB.code),
+		op8(Opcode.LOCAL_TEE.code), 0,
+		op8(Opcode.I32_EQZ.code),
+		op8(Opcode.BR_IF.code), 1,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	Instrumentation.insertLocalProbe(i.module, i.func.func_index, 0, counter);
 	i.args_i(5).assert2_i(17);
@@ -161,17 +163,17 @@ def test_entry_probe1(i: ExeTester) {
 	var counter = TraceProbe2.new();
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.LOOP.code, BpTypeCode.EmptyBlock.code,
-		Opcode.I32_CONST.code, 17,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_SUB.code,
-		Opcode.LOCAL_TEE.code, 0,
-		Opcode.I32_EQZ.code,
-		Opcode.BR_IF.code, 1,
-		Opcode.BR.code, 0,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.I32_CONST.code), 17,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_SUB.code),
+		op8(Opcode.LOCAL_TEE.code), 0,
+		op8(Opcode.I32_EQZ.code),
+		op8(Opcode.BR_IF.code), 1,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	Instrumentation.insertFuncEntryProbe(i.module, i.func.func_index, counter);
 	i.args_i(5).assert2_i(17);

--- a/test/unittest/ExeTest.v3
+++ b/test/unittest/ExeTest.v3
@@ -5,6 +5,8 @@ def X: Array<Value>;
 var NO_CODE: Array<byte> = [];
 def NONE = BpTypeCode.EmptyBlock.code;
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 // Registers a "unop" opcode test
 def reg1<X, Z>(opcode: Opcode,
 		f: (ExeTester, Opcode, Array<(Z, X)>) -> void,
@@ -1005,47 +1007,47 @@ def test_empty(i: ExeTester) {
 }
 
 def test_unreachable(i: ExeTester) {
-	i.code([Opcode.UNREACHABLE.code])
+	i.code([op8(Opcode.UNREACHABLE.code)])
 		.noargs().assert2_trap(TrapReason.UNREACHABLE);
 }
 
 def test_nop(i: ExeTester) {
-	i.sig(SigCache.v_v).code([Opcode.NOP.code]).noargs().assert2_none();
+	i.sig(SigCache.v_v).code([op8(Opcode.NOP.code)]).noargs().assert2_none();
 }
 
 def test_block0(i: ExeTester) {
 	i.sig(SigCache.v_v);
-	i.code([Opcode.BLOCK.code, NONE,
-		Opcode.END.code]);
+	i.code([op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.END.code)]);
 	i.noargs().assert2_none();
 
 	i.sig(SigCache.i_i);
-	i.code([Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code]);
+	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_i(9).assert2_i(9);
 	i.args_i(7).assert2_i(7);
 
 	i.sig(SigCache.l_l);
-	i.code([Opcode.BLOCK.code, BpTypeCode.I64.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code]);
+	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I64.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_l(9).assert2_l(9);
 	i.args_l(7).assert2_l(7);
 }
 
 def test_block1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([Opcode.BLOCK.code, BpTypeCode.I32.code | byte.view(0x80), 0x7f, // 2-byte signed LEB
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code]);
+	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I32.code | byte.view(0x80), 0x7f, // 2-byte signed LEB
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_i(9).assert2_i(9);
 	i.args_i(7).assert2_i(7);
 
 	i.sig(SigCache.l_l);
-	i.code([Opcode.BLOCK.code, BpTypeCode.I64.code | byte.view(0x80), 0xff, 0x7f, // 3-byte signed LEB
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code]);
+	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I64.code | byte.view(0x80), 0xff, 0x7f, // 3-byte signed LEB
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_l(9).assert2_l(9);
 	i.args_l(7).assert2_l(7);
 }
@@ -1053,9 +1055,9 @@ def test_block1(i: ExeTester) {
 def test_block2(i: ExeTester) {
 	i.extensions |= Extension.GC;
 	i.sig(newSig(SigCache.arr_g, SigCache.arr_g));
-	i.code([Opcode.BLOCK.code, BpTypeCode.REF_NULL.code,  BpTypeCode.FUNCREF.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code]);
+	i.code([op8(Opcode.BLOCK.code), BpTypeCode.REF_NULL.code,  BpTypeCode.FUNCREF.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_r(null).assert2_r(null);
 	def hf = HostFunction.new(null, SigCache.i_i, null);
 	i.args_r(hf).assert2_r(hf);
@@ -1063,29 +1065,29 @@ def test_block2(i: ExeTester) {
 
 def test_loop0(i: ExeTester) {
 	i.sig(SigCache.v_v);
-	i.code([Opcode.LOOP.code, NONE, Opcode.END.code]);
+	i.code([op8(Opcode.LOOP.code), NONE, op8(Opcode.END.code)]);
 	i.noargs().assert2_none();
 
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.LOOP.code, NONE,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_SUB.code,
-		Opcode.LOCAL_TEE.code, 0,
-		Opcode.BR_IF.code, 0,
-		Opcode.END.code,
-		Opcode.LOCAL_GET.code, 0]);
+	i.codev([op8(Opcode.LOOP.code), NONE,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_SUB.code),
+		op8(Opcode.LOCAL_TEE.code), 0,
+		op8(Opcode.BR_IF.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(1).assert2_i(0);
 	i.args_i(5).assert2_i(0);
 
-	i.codev([Opcode.LOOP.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_SUB.code,
-		Opcode.LOCAL_TEE.code, 0,
-		Opcode.BR_IF.code, 0,
-		Opcode.END.code]);
+	i.codev([op8(Opcode.LOOP.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_SUB.code),
+		op8(Opcode.LOCAL_TEE.code), 0,
+		op8(Opcode.BR_IF.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_i(1).assert2_i(1);
 	i.args_i(5).assert2_i(1);
 }
@@ -1093,15 +1095,15 @@ def test_loop0(i: ExeTester) {
 def test_loop1(i: ExeTester) {
 	i.sig(SigCache.i_v);
 	i.codev([
-		Opcode.I32_CONST.code, 10,
-		Opcode.LOCAL_SET.code, 0,
-		Opcode.LOOP.code, NONE,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_SUB.code,
-		Opcode.LOCAL_TEE.code, 0,
-		Opcode.BR_IF.code, 0,
-		Opcode.END.code]);
+		op8(Opcode.I32_CONST.code), 10,
+		op8(Opcode.LOCAL_SET.code), 0,
+		op8(Opcode.LOOP.code), NONE,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_SUB.code),
+		op8(Opcode.LOCAL_TEE.code), 0,
+		op8(Opcode.BR_IF.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_u(99).assert2_none();
 }
 
@@ -1110,121 +1112,121 @@ def test_loop1(i: ExeTester) {
 
 def test_if0(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, NONE,
-		Opcode.I32_CONST.code, 11,
-		Opcode.RETURN.code,
-		Opcode.ELSE.code,
-		Opcode.I32_CONST.code, 22,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 33]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), NONE,
+		op8(Opcode.I32_CONST.code), 11,
+		op8(Opcode.RETURN.code),
+		op8(Opcode.ELSE.code),
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 33]);
 	i.args_i(9).assert2_i(11);
 	i.args_i(0).assert2_i(22);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, NONE,
-		Opcode.I32_CONST.code, 33,
-		Opcode.LOCAL_SET.code, 0,
-		Opcode.ELSE.code,
-		Opcode.I32_CONST.code, 44,
-		Opcode.LOCAL_SET.code, 0,
-		Opcode.END.code,
-		Opcode.LOCAL_GET.code, 0]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), NONE,
+		op8(Opcode.I32_CONST.code), 33,
+		op8(Opcode.LOCAL_SET.code), 0,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.I32_CONST.code), 44,
+		op8(Opcode.LOCAL_SET.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(7).assert2_i(33);
 	i.args_i(0).assert2_i(44);
 
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, NONE,
-		Opcode.I32_CONST.code, 13,
-		Opcode.LOCAL_SET.code, 0,
-		Opcode.END.code,
-		Opcode.LOCAL_GET.code, 0]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), NONE,
+		op8(Opcode.I32_CONST.code), 13,
+		op8(Opcode.LOCAL_SET.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(7).assert2_i(13);
 	i.args_i(0).assert2_i(0);
 }
 def test_if1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 17,
-		Opcode.ELSE.code,
-		Opcode.I32_CONST.code, 27,
-		Opcode.END.code]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 17,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.I32_CONST.code), 27,
+		op8(Opcode.END.code)]);
 	i.args_i(6).assert2_i(17);
 	i.args_i(0).assert2_i(27);
 
-	i.codev([Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 18,
-		Opcode.BR.code, 0,
-		Opcode.ELSE.code,
-		Opcode.I32_CONST.code, 28,
-		Opcode.BR.code, 0,
-		Opcode.END.code]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 18,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.ELSE.code),
+		op8(Opcode.I32_CONST.code), 28,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_i(4).assert2_i(18);
 	i.args_i(0).assert2_i(28);
 }
 def test_br0(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.LOCAL_GET.code, 0, Opcode.BR.code, 0]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR.code), 0]);
 	i.args_i(3).assert2_i(3);
 	i.args_i(9).assert2_i(9);
 
 	i.sig(SigCache.ii_i);
-	i.codev([Opcode.LOCAL_GET.code, 1, Opcode.LOCAL_GET.code, 0, Opcode.BR.code, 0]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR.code), 0]);
 	i.args_ii(7, 11).assert2_i(7);
 	i.args_ii(5, 99).assert2_i(5);
 }
 def test_br1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR.code, 0,
-		Opcode.END.code]);
+	i.codev([op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code)]);
 	i.args_i(37).assert2_i(37);
 	i.args_i(94).assert2_i(94);
 
 	i.sig(SigCache.ii_i);
-	i.codev([Opcode.LOCAL_GET.code, 1,
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR.code, 0,
-		Opcode.END.code,
-		Opcode.RETURN.code]);
+	i.codev([op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.RETURN.code)]);
 	i.args_ii(71, 11).assert2_i(71);
 	i.args_ii(52, 99).assert2_i(52);
 }
 def test_br2(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.I32_CONST.code, 9,
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 5,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR.code, 0,
-		Opcode.END.code,
-		Opcode.I32_ADD.code]);
+		op8(Opcode.I32_CONST.code), 9,
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.I32_ADD.code)]);
 	i.args_i(37).assert2_i(46);
 	i.args_i(94).assert2_i(103);
 }
 def test_br_if1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.I32_CONST.code, 7,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_IF.code, 0,
-		Opcode.DROP.code,
-		Opcode.I32_CONST.code, 8]);
+	i.codev([op8(Opcode.I32_CONST.code), 7,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_IF.code), 0,
+		op8(Opcode.DROP.code),
+		op8(Opcode.I32_CONST.code), 8]);
 	i.args_i(11).assert2_i(7);
 	i.args_i(0).assert2_i(8);
 
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.BLOCK.code, NONE,
-		Opcode.I32_CONST.code, 9,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_IF.code, 1,
-		Opcode.DROP.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 5]);
+	i.codev([op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.I32_CONST.code), 9,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_IF.code), 1,
+		op8(Opcode.DROP.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 5]);
 	i.args_i(17).assert2_i(9);
 	i.args_i(0).assert2_i(5);
 }
@@ -1232,21 +1234,21 @@ def make_br_ifN(i: ExeTester, depth: int) {
 	i.sig(SigCache.i_i);
 	var w = DataWriter.new();
 	for (j < depth) {
-		w.putbb(Opcode.BLOCK.code, NONE);
+		w.putbb(op8(Opcode.BLOCK.code), NONE);
 	}
 	for (j < depth) {
-		w.putbb(Opcode.LOCAL_GET.code, 0);
-		w.putb(Opcode.I32_CONST.code);
+		w.putbb(op8(Opcode.LOCAL_GET.code), 0);
+		w.putb(op8(Opcode.I32_CONST.code));
 		w.put_sleb32(j);
-		w.putb(Opcode.I32_EQ.code);
-		w.putb(Opcode.BR_IF.code);
+		w.putb(op8(Opcode.I32_EQ.code));
+		w.putb(op8(Opcode.BR_IF.code));
 		w.put_sleb32(j);
 	}
 	for (j < depth) {
-		w.putb(Opcode.END.code);
-		w.putb(Opcode.I32_CONST.code);
+		w.putb(op8(Opcode.END.code));
+		w.putb(op8(Opcode.I32_CONST.code));
 		w.put_sleb32(j + 13);
-		w.putb(Opcode.RETURN.code);
+		w.putb(op8(Opcode.RETURN.code));
 	}
 	i.codev(w.extract());
 }
@@ -1284,11 +1286,11 @@ def test_br_ifN3(i: ExeTester) {
 }
 def test_br_table0(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([Opcode.I32_CONST.code, 7,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2,
+	i.codev([op8(Opcode.I32_CONST.code), 7,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2,
 		0, 0, 0,
-		Opcode.UNREACHABLE.code]);
+		op8(Opcode.UNREACHABLE.code)]);
 	i.args_i(0).assert2_i(7);
 	i.args_i(1).assert2_i(7);
 	i.args_i(2).assert2_i(7);
@@ -1296,25 +1298,25 @@ def test_br_table0(i: ExeTester) {
 	i.args_i(4).assert2_i(7);
 	i.args_i(0xFFFFFFFF).assert2_i(7);
 
-	i.codev([Opcode.BLOCK.code, NONE,
-		Opcode.BLOCK.code, NONE,
-		Opcode.BLOCK.code, NONE,
-		Opcode.BLOCK.code, NONE,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2,
+	i.codev([op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2,
 		0, 2, 1,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 16,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 17,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 18,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 16,
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 17,
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 18,
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 		]);
 	i.args_i(0).assert2_i(16);
 	i.args_i(1).assert2_i(18);
@@ -1326,28 +1328,28 @@ def test_br_table0(i: ExeTester) {
 def test_br_table1(i: ExeTester) {
 	i.sig(SigCache.ii_i);
 
-	i.codev([Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2,
+	i.codev([op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2,
 		0, 2, 1,
-		Opcode.UNREACHABLE.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 16,
-		Opcode.I32_ADD.code,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 17,
-		Opcode.I32_ADD.code,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 18,
-		Opcode.I32_ADD.code,
-		Opcode.RETURN.code,
-		Opcode.END.code
+		op8(Opcode.UNREACHABLE.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 16,
+		op8(Opcode.I32_ADD.code),
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 17,
+		op8(Opcode.I32_ADD.code),
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 18,
+		op8(Opcode.I32_ADD.code),
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code)
 		]);
 	i.args_ii(0, 0).assert2_i(16);
 	i.args_ii(0, 10).assert2_i(26);
@@ -1365,16 +1367,16 @@ def test_br_table1(i: ExeTester) {
 def test_br_table2(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.I32_CONST.code, 9,
-		Opcode.BLOCK.code, BpTypeCode.I32.code,
-		Opcode.I32_CONST.code, 42,
-		Opcode.I32_CONST.code, 42,
-		Opcode.I32_CONST.code, 42,
-		Opcode.I32_CONST.code, 5,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 0, 0,
-		Opcode.END.code,
-		Opcode.I32_ADD.code]);
+		op8(Opcode.I32_CONST.code), 9,
+		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		op8(Opcode.I32_CONST.code), 42,
+		op8(Opcode.I32_CONST.code), 42,
+		op8(Opcode.I32_CONST.code), 42,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 0, 0,
+		op8(Opcode.END.code),
+		op8(Opcode.I32_ADD.code)]);
 	i.args_i(0).assert2_i(14);
 	i.args_i(1).assert2_i(14);
 	i.args_i(444).assert2_i(14);
@@ -1382,113 +1384,113 @@ def test_br_table2(i: ExeTester) {
 def test_br_table3(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.BLOCK.code, NONE,
-		Opcode.BLOCK.code, NONE,
-		Opcode.BLOCK.code, NONE,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_TABLE.code, 2, 2, 1, 0,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 44,
-		Opcode.BR.code, 2,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 43,
-		Opcode.BR.code, 1,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 42,
-		Opcode.BR.code, 0,
-		Opcode.I32_CONST.code, 41]);
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_TABLE.code), 2, 2, 1, 0,
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 44,
+		op8(Opcode.BR.code), 2,
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 43,
+		op8(Opcode.BR.code), 1,
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 42,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.I32_CONST.code), 41]);
 	i.args_i(0).assert2_i(42);
 	i.args_i(1).assert2_i(43);
 	i.args_i(2).assert2_i(44);
 	i.args_i(3).assert2_i(44);
 }
 def test_return0(i: ExeTester) {
-	i.sig(SigCache.v_v).code([Opcode.RETURN.code]).noargs().assert2_none();
+	i.sig(SigCache.v_v).code([op8(Opcode.RETURN.code)]).noargs().assert2_none();
 }
 def test_return1(i: ExeTester) {
-	i.sig(SigCache.i_i).code([Opcode.LOCAL_GET.code, 0,
-				  Opcode.RETURN.code]).args_i(97).assert2_i(97);
+	i.sig(SigCache.i_i).code([op8(Opcode.LOCAL_GET.code), 0,
+				  op8(Opcode.RETURN.code)]).args_i(97).assert2_i(97);
 }
 def test_return2(i: ExeTester) {
-	i.sig(SigCache.v_v).code([Opcode.I32_CONST.code, 0,
-				  Opcode.RETURN.code]).noargs().assert2_none();
-	i.sig(SigCache.v_i).code([Opcode.I32_CONST.code, 9,
-				  Opcode.RETURN.code]).noargs().assert2_i(9);
-	i.sig(SigCache.v_i).code([Opcode.I32_CONST.code, 7,
-				  Opcode.I32_CONST.code, 13,
-				  Opcode.RETURN.code]).noargs().assert2_i(13);
+	i.sig(SigCache.v_v).code([op8(Opcode.I32_CONST.code), 0,
+				  op8(Opcode.RETURN.code)]).noargs().assert2_none();
+	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 9,
+				  op8(Opcode.RETURN.code)]).noargs().assert2_i(9);
+	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 7,
+				  op8(Opcode.I32_CONST.code), 13,
+				  op8(Opcode.RETURN.code)]).noargs().assert2_i(13);
 }
 def test_return3(i: ExeTester) {
 	var sig_v_il = newSig(SigCache.arr_v, [ValueType.I32, ValueType.I64]);
 	i.sig(sig_v_il);
 	i.addLocals(1, ValueType.I32);
-	i.code([Opcode.I32_CONST.code, 11, Opcode.I64_CONST.code, 22]);
+	i.code([op8(Opcode.I32_CONST.code), 11, op8(Opcode.I64_CONST.code), 22]);
 	i.noargs().assert2_res(Result.Value([Value.I32(11), Value.I64(22)]));
 }
 def test_drop(i: ExeTester) {
-	i.sig(SigCache.v_v).code([Opcode.I32_CONST.code, 0, Opcode.DROP.code])
+	i.sig(SigCache.v_v).code([op8(Opcode.I32_CONST.code), 0, op8(Opcode.DROP.code)])
 		.noargs().assert2_none();
-	i.sig(SigCache.v_i).code([Opcode.I32_CONST.code, 3,
-				  Opcode.DROP.code,
-				  Opcode.I32_CONST.code, 11])
+	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 3,
+				  op8(Opcode.DROP.code),
+				  op8(Opcode.I32_CONST.code), 11])
 		.noargs().assert2_i(11);
-	i.sig(SigCache.v_i).code([Opcode.I32_CONST.code, 4,
-				  Opcode.I32_CONST.code, 5,
-				  Opcode.DROP.code])
+	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 4,
+				  op8(Opcode.I32_CONST.code), 5,
+				  op8(Opcode.DROP.code)])
 		.noargs().assert2_i(4);
 }
 def test_select(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([Opcode.I32_CONST.code, 11,
-		Opcode.I32_CONST.code, 22,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.SELECT.code]);
+	i.code([op8(Opcode.I32_CONST.code), 11,
+		op8(Opcode.I32_CONST.code), 22,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.SELECT.code)]);
 	i.args_i(1).assert2_i(11);
 	i.args_i(108).assert2_i(11);
 	i.args_i(0).assert2_i(22);
 
 	i.sig(SigCache.i_l);
-	i.code([Opcode.I64_CONST.code, 33,
-		Opcode.I64_CONST.code, 44,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.SELECT.code]);
+	i.code([op8(Opcode.I64_CONST.code), 33,
+		op8(Opcode.I64_CONST.code), 44,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_w(33);
 	i.args_u(109).assert2_w(33);
 	i.args_u(0).assert2_w(44);
 
 	i.sig(SigCache.i_f);
-	i.code([Opcode.F32_CONST.code, 0x11, 0x22, 0x33, 0x44,
-		Opcode.F32_CONST.code, 0x55, 0x66, 0x77, 0x88,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.SELECT.code]);
+	i.code([op8(Opcode.F32_CONST.code), 0x11, 0x22, 0x33, 0x44,
+		op8(Opcode.F32_CONST.code), 0x55, 0x66, 0x77, 0x88,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_f(0x44332211);
 	i.args_u(66).assert2_f(0x44332211);
 	i.args_u(0).assert2_f(0x88776655);
 
 	i.sig(SigCache.i_d);
-	i.code([Opcode.F64_CONST.code, 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,
-		Opcode.F64_CONST.code, 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.SELECT.code]);
+	i.code([op8(Opcode.F64_CONST.code), 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,
+		op8(Opcode.F64_CONST.code), 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_d(0x8877665544332211);
 	i.args_u(66).assert2_d(0x8877665544332211);
 	i.args_u(0).assert2_d(0x0807060504030201);
 
 	i.sig(SigCache.i_s);
-	i.code([Opcode.V128_CONST.prefix, Opcode.V128_CONST.code, 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF,0x00,
-		Opcode.V128_CONST.prefix, Opcode.V128_CONST.code, 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x00,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.SELECT.code]);
+	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code), 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF,0x00,
+		Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code), 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x00,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_s(0x8877665544332211, 0x00FFEEDDCCBBAA99);
 	i.args_u(66).assert2_s(0x8877665544332211, 0x00FFEEDDCCBBAA99);
 	i.args_u(0).assert2_s(0x0807060504030201, 0x000F0E0D0C0B0A09);
 }
 def test_selectt(i: ExeTester) {
 	i.sig0([ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueType.I32], SigCache.arr_e);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.SELECT_T.code, 1, BpTypeCode.EXTERNREF.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		op8(Opcode.SELECT_T.code), 1, BpTypeCode.EXTERNREF.code]);
 	var v1: Value = Value.Ref(HostObject.new());
 	var v2: Value = Value.Ref(HostObject.new());
 	i.argsN([v1, v2, Value.I32(0)]).assert2_val(v2);
@@ -1500,72 +1502,72 @@ def test_selectt(i: ExeTester) {
 	i.sig0(
 		[ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueType.I32],
 		[ValueTypes.EXTERNREF, ValueTypes.EXTERNREF]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.LOCAL_GET.code, 3,
-		Opcode.LOCAL_GET.code, 4,
-		Opcode.SELECT_T.code, 2, BpTypeCode.EXTERNREF.code, BpTypeCode.EXTERNREF.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		op8(Opcode.LOCAL_GET.code), 3,
+		op8(Opcode.LOCAL_GET.code), 4,
+		op8(Opcode.SELECT_T.code), 2, BpTypeCode.EXTERNREF.code, BpTypeCode.EXTERNREF.code]);
 	i.argsN([v1, v2, v3, v4, Value.I32(0)]).assert2_res(Result.Value([v3, v4]));
 	i.argsN([v1, v2, v3, v4, Value.I32(1)]).assert2_res(Result.Value([v1, v2]));
 }
 
 def test_locals0(i: ExeTester) {
-	i.sig(SigCache.i_i).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.i_i).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(11).assert2_i(11);
 
-	i.sig(SigCache.l_l).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.l_l).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_l(99887766554433).assert2_l(99887766554433);
 
-	i.sig(SigCache.f_f).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.f_f).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_f(0x11223344).assert2_f(0x11223344);
 
-	i.sig(SigCache.d_d).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.d_d).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_d(0x5566778811223344).assert2_d(0x5566778811223344);
 
-	i.sig(SigCache.s_s).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.s_s).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_s(0x55337788_44223311, 0x11223344_55667788).assert2_s(0x55337788_44223311, 0x11223344_55667788);
 }
 def test_locals1(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	var i1 = byte.!(i.addLocal(ValueType.I32));
-	i.code([Opcode.LOCAL_GET.code, i1]);
+	i.code([op8(Opcode.LOCAL_GET.code), i1]);
 	i.args_i(17).assert2_i(0);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_SET.code, i1,
-		Opcode.LOCAL_GET.code, i1]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_SET.code), i1,
+		op8(Opcode.LOCAL_GET.code), i1]);
 	i.args_i(19).assert2_i(19);
 
 	var i2 = byte.!(i.addLocal(ValueType.I32));
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_SET.code, i1,
-		Opcode.LOCAL_GET.code, i2]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_SET.code), i1,
+		op8(Opcode.LOCAL_GET.code), i2]);
 	i.args_i(23).assert2_i(0);
 }
 def test_locals2(i: ExeTester) {
 	var l1 = byte.!(i.addLocal(ValueType.I64));
 	i.sig(SigCache.v_l).code([
-		Opcode.LOCAL_GET.code, l1
+		op8(Opcode.LOCAL_GET.code), l1
 	]);
 	i.noargs().assert2_w(0);
 
 	var f1 = byte.!(i.addLocal(ValueType.F32));
 	i.sig(SigCache.v_f).code([
-		Opcode.LOCAL_GET.code, f1
+		op8(Opcode.LOCAL_GET.code), f1
 	]);
 	i.noargs().assert2_f(0);
 
 	var d1 = byte.!(i.addLocal(ValueType.F64));
 	i.sig(SigCache.v_d).code([
-		Opcode.LOCAL_GET.code, d1
+		op8(Opcode.LOCAL_GET.code), d1
 	]);
 	i.noargs().assert2_d(0);
 }
 def test_locals3(i: ExeTester) {
 	i.sig(SigCache.ii_i).code([
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_TEE.code, 0
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_TEE.code), 0
 	]);
 	i.args_ii(0, 1).assert2_i(1);
 	i.args_ii(0, 7).assert2_i(7);
@@ -1575,14 +1577,14 @@ def test_locals4(i: ExeTester) {
 	i.sig(SigCache.ii_i);
 	i.addLocals(260, ValueType.I32);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_ADD.code,
-		Opcode.LOCAL_TEE.code, 0xC0, 0x0,
-		Opcode.LOCAL_SET.code, 0xC0, 0x1,
-		Opcode.LOCAL_GET.code, 0xC0, 0x0,
-		Opcode.LOCAL_GET.code, 0xC0, 0x1,
-		Opcode.I32_MUL.code]);
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_ADD.code),
+		op8(Opcode.LOCAL_TEE.code), 0xC0, 0x0,
+		op8(Opcode.LOCAL_SET.code), 0xC0, 0x1,
+		op8(Opcode.LOCAL_GET.code), 0xC0, 0x0,
+		op8(Opcode.LOCAL_GET.code), 0xC0, 0x1,
+		op8(Opcode.I32_MUL.code)]);
 	i.args_ii(1, 2).assert2_i(9);
 	i.args_ii(65, 993).assert2_i(1119364);
 }
@@ -1592,84 +1594,84 @@ def test_locals5(i: ExeTester) {
 	i.sig(newSig(SigCache.arr_g, SigCache.arr_g));
 	var l = i.addLocals(1, ft);
 	i.code([
-		Opcode.LOCAL_GET.code, byte.!(l)
+		op8(Opcode.LOCAL_GET.code), byte.!(l)
 	]);
 	i.args_r(null).assert2_r(null);
 }
 def test_params(i: ExeTester) {
-	i.sig(SigCache.i_i).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.i_i).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(13).assert2_i(13);
 	i.args_i(9991).assert2_i(9991);
 
-	i.sig(SigCache.l_l).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.l_l).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_l(137).assert2_l(137);
 	i.args_l(999145).assert2_l(999145);
 
-	i.sig(SigCache.f_f).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.f_f).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_f(137u).assert2_f(137u);
 	i.args_f(999145u).assert2_f(999145u);
 
-	i.sig(SigCache.d_d).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.d_d).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_d(137u).assert2_d(137u);
 	i.args_d(999145u).assert2_d(999145u);
 
-	i.sig(SigCache.s_s).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.s_s).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_s(139, 141).assert2_s(139, 141);
 	i.args_s(0x12345678_abcdef90, 99).assert2_s(0x12345678_abcdef90, 99);
 
-	i.sig(SigCache.ii_i).code([Opcode.LOCAL_GET.code, 0]);
+	i.sig(SigCache.ii_i).code([op8(Opcode.LOCAL_GET.code), 0]);
 	i.args_ii(12, 15).assert2_i(12);
 	i.args_ii(9791, 66).assert2_i(9791);
 
-	i.sig(SigCache.ii_i).code([Opcode.LOCAL_GET.code, 1]);
+	i.sig(SigCache.ii_i).code([op8(Opcode.LOCAL_GET.code), 1]);
 	i.args_ii(12, 157).assert2_i(157);
 	i.args_ii(9791, 8791).assert2_i(8791);
 }
 def test_global_get(i: ExeTester) {
 	var index = byte.!(i.newGlobal(ValueType.I32, InitExpr.I32(34)).global_index);
-	i.code([Opcode.GLOBAL_GET.code, index]).noargs().assert2_i(34);
+	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(34);
 
 	i.sig(SigCache.v_l);
 	index = byte.!(i.newGlobal(ValueType.I64, InitExpr.I64(55)).global_index);
-	i.code([Opcode.GLOBAL_GET.code, index]).noargs().assert2_w(55);
+	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(55);
 }
 def test_global_set(i: ExeTester) {
 	var index = byte.!(i.newGlobal(ValueType.I32, InitExpr.I32(34)).global_index);
-	i.code([Opcode.I32_CONST.code, 55,
-		Opcode.GLOBAL_SET.code, index,
-		Opcode.GLOBAL_GET.code, index]).noargs().assert2_i(55);
+	i.code([op8(Opcode.I32_CONST.code), 55,
+		op8(Opcode.GLOBAL_SET.code), index,
+		op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(55);
 
 	i.sig(SigCache.v_l);
 	index = byte.!(i.newGlobal(ValueType.I64, InitExpr.I64(77)).global_index);
-	i.code([Opcode.I64_CONST.code, 47,
-		Opcode.GLOBAL_SET.code, index,
-		Opcode.GLOBAL_GET.code, index]).noargs().assert2_w(47);
+	i.code([op8(Opcode.I64_CONST.code), 47,
+		op8(Opcode.GLOBAL_SET.code), index,
+		op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(47);
 }
 def test_imm_global(i: ExeTester) {
 	var index = byte.!(i.newImmGlobal(ValueType.I32, InitExpr.I32(9999)).global_index);
-	i.code([Opcode.GLOBAL_GET.code, index]).noargs().assert2_i(9999);
+	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(9999);
 
 	i.sig(SigCache.v_l);
 	index = byte.!(i.newImmGlobal(ValueType.I64, InitExpr.I64(777788889999)).global_index);
-	i.code([Opcode.GLOBAL_GET.code, index]).noargs().assert2_w(777788889999);
+	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(777788889999);
 }
 
 
 def test_i32_const(i: ExeTester) {
 	i.sig(SigCache.v_i);
-	i.code([Opcode.I32_CONST.code, 1]).noargs().assert2_i(1);
-	i.code([Opcode.I32_CONST.code, 33]).noargs().assert2_i(33);
-	i.code([Opcode.I32_CONST.code, 0xA7, 0x7F]).noargs().assert2_i(-89);
-	i.code([Opcode.I32_CONST.code, 0x70]).noargs().assert2_i(-16);
-	i.code([Opcode.I32_CONST.code, 0xA7, 0xF0, 0xF1, 0xF2,
+	i.code([op8(Opcode.I32_CONST.code), 1]).noargs().assert2_i(1);
+	i.code([op8(Opcode.I32_CONST.code), 33]).noargs().assert2_i(33);
+	i.code([op8(Opcode.I32_CONST.code), 0xA7, 0x7F]).noargs().assert2_i(-89);
+	i.code([op8(Opcode.I32_CONST.code), 0x70]).noargs().assert2_i(-16);
+	i.code([op8(Opcode.I32_CONST.code), 0xA7, 0xF0, 0xF1, 0xF2,
 		0x7E]).noargs().assert2_u(3999037479u);
 }
 def test_i64_const(i: ExeTester) {
 	i.sig(SigCache.v_l);
-	i.code([Opcode.I64_CONST.code, 1]).noargs().assert2_l(1);
-	i.code([Opcode.I64_CONST.code, 33]).noargs().assert2_l(33);
-	i.code([Opcode.I64_CONST.code, 0x70]).noargs().assert2_l(-16);
-	i.code([Opcode.I64_CONST.code, 0x81, 0x82, 0x83, 0x84,
+	i.code([op8(Opcode.I64_CONST.code), 1]).noargs().assert2_l(1);
+	i.code([op8(Opcode.I64_CONST.code), 33]).noargs().assert2_l(33);
+	i.code([op8(Opcode.I64_CONST.code), 0x70]).noargs().assert2_l(-16);
+	i.code([op8(Opcode.I64_CONST.code), 0x81, 0x82, 0x83, 0x84,
 		0x85, 0x86, 0x87, 0x88, 0x09]).noargs().assert2_w(653052939803345153);
 
 	var inputs: Array<long> = [
@@ -1685,7 +1687,7 @@ def test_i64_const(i: ExeTester) {
 	];
 	var w = DataWriter.new();
 	for (v in inputs) {
-		w.putb(Opcode.I64_CONST.code);
+		w.putb(op8(Opcode.I64_CONST.code));
 		w.put_sleb64(v);
 		i.code(w.extract());
 		i.noargs().assert2_w(u64.view(v));
@@ -1693,35 +1695,35 @@ def test_i64_const(i: ExeTester) {
 }
 def test_f32_const(i: ExeTester) {
 	i.sig(SigCache.v_f);
-	i.code([Opcode.F32_CONST.code, 0x44, 0x33, 0x22, 0x11]).noargs().assert2_f(0x11223344);
-	i.code([Opcode.F32_CONST.code, 0x66, 0x77, 0x88, 0x99]).noargs().assert2_f(0x99887766);
-	i.code([Opcode.F32_CONST.code, 0x11, 0x00, 0x00, 0x00]).noargs().assert2_f(0x00000011);
-	i.code([Opcode.F32_CONST.code, 0x00, 0x00, 0x00, 0x22]).noargs().assert2_f(0x22000000);
-	i.code([Opcode.F32_CONST.code, 0xF1, 0xFF, 0xFF, 0xFF]).noargs().assert2_f(0xFFFFFFF1);
+	i.code([op8(Opcode.F32_CONST.code), 0x44, 0x33, 0x22, 0x11]).noargs().assert2_f(0x11223344);
+	i.code([op8(Opcode.F32_CONST.code), 0x66, 0x77, 0x88, 0x99]).noargs().assert2_f(0x99887766);
+	i.code([op8(Opcode.F32_CONST.code), 0x11, 0x00, 0x00, 0x00]).noargs().assert2_f(0x00000011);
+	i.code([op8(Opcode.F32_CONST.code), 0x00, 0x00, 0x00, 0x22]).noargs().assert2_f(0x22000000);
+	i.code([op8(Opcode.F32_CONST.code), 0xF1, 0xFF, 0xFF, 0xFF]).noargs().assert2_f(0xFFFFFFF1);
 }
 
 def test_f64_const(i: ExeTester) {
 	i.sig(SigCache.v_d);
-	i.code([Opcode.F64_CONST.code, 0x44, 0x33, 0x22, 0x11, 0, 0, 0, 0]).noargs().assert2_d(0x11223344);
-	i.code([Opcode.F64_CONST.code, 0x66, 0x77, 0x88, 0x99, 0, 0, 0, 0]).noargs().assert2_d(0x99887766);
-	i.code([Opcode.F64_CONST.code, 0x11, 0x00, 0x00, 0x00, 0, 0, 0, 0]).noargs().assert2_d(0x00000011);
-	i.code([Opcode.F64_CONST.code, 0x00, 0x00, 0x00, 0x22, 0, 0, 0, 0]).noargs().assert2_d(0x22000000);
-	i.code([Opcode.F64_CONST.code, 0xF1, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0]).noargs().assert2_d(0xFFFFFFF1);
+	i.code([op8(Opcode.F64_CONST.code), 0x44, 0x33, 0x22, 0x11, 0, 0, 0, 0]).noargs().assert2_d(0x11223344);
+	i.code([op8(Opcode.F64_CONST.code), 0x66, 0x77, 0x88, 0x99, 0, 0, 0, 0]).noargs().assert2_d(0x99887766);
+	i.code([op8(Opcode.F64_CONST.code), 0x11, 0x00, 0x00, 0x00, 0, 0, 0, 0]).noargs().assert2_d(0x00000011);
+	i.code([op8(Opcode.F64_CONST.code), 0x00, 0x00, 0x00, 0x22, 0, 0, 0, 0]).noargs().assert2_d(0x22000000);
+	i.code([op8(Opcode.F64_CONST.code), 0xF1, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0]).noargs().assert2_d(0xFFFFFFF1);
 
-	i.code([Opcode.F64_CONST.code, 1, 0x44, 0x33, 0x22, 0x11, 0, 0, 0]).noargs().assert2_d(0x00000011_22334401);
-	i.code([Opcode.F64_CONST.code, 2, 3, 0x66, 0x77, 0x88, 0x99, 0, 0]).noargs().assert2_d(0x00009988_77660302);
-	i.code([Opcode.F64_CONST.code, 4, 5, 6, 0x11, 0x00, 0x00, 0x00, 0]).noargs().assert2_d(0x00000000_11060504);
-	i.code([Opcode.F64_CONST.code, 7, 8, 9, 1, 0x00, 0x00, 0x00, 0x22]).noargs().assert2_d(0x22000000_01090807);
+	i.code([op8(Opcode.F64_CONST.code), 1, 0x44, 0x33, 0x22, 0x11, 0, 0, 0]).noargs().assert2_d(0x00000011_22334401);
+	i.code([op8(Opcode.F64_CONST.code), 2, 3, 0x66, 0x77, 0x88, 0x99, 0, 0]).noargs().assert2_d(0x00009988_77660302);
+	i.code([op8(Opcode.F64_CONST.code), 4, 5, 6, 0x11, 0x00, 0x00, 0x00, 0]).noargs().assert2_d(0x00000000_11060504);
+	i.code([op8(Opcode.F64_CONST.code), 7, 8, 9, 1, 0x00, 0x00, 0x00, 0x22]).noargs().assert2_d(0x22000000_01090807);
 
 }
 
 def test_v128_const(i: ExeTester) {
 	i.sig(SigCache.v_s);
-	i.code([Opcode.V128_CONST.prefix, Opcode.V128_CONST.code,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00])
+	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code),0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00])
 		.noargs().assert2_s(0x00000000_00000000, 0x00000000_00000000);
-	i.code([Opcode.V128_CONST.prefix, Opcode.V128_CONST.code,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x10])
+	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code),0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x10])
 		.noargs().assert2_s(0x08070605_04030201, 0x100F0E0D_0C0B0A09);
-	i.code([Opcode.V128_CONST.prefix, Opcode.V128_CONST.code,0x10,0x20,0x30,0x40,0x50,0x60,0x70,0x80,0x90,0xA0,0xB0,0xC0,0xD0,0xE0,0xF0,0x01])
+	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code),0x10,0x20,0x30,0x40,0x50,0x60,0x70,0x80,0x90,0xA0,0xB0,0xC0,0xD0,0xE0,0xF0,0x01])
 		.noargs().assert2_s(0x80706050_40302010, 0x01F0E0D0_C0B0A090);
 }
 
@@ -1729,29 +1731,29 @@ def test_load8(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.addMemory(1, Max.Set(1));
 	i.addData(4, [0xF0, 0xF1]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD8_U.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD8_U.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(3).assert2_i(0);
 	i.args_i(4).assert2_i(0xF0);
 	i.args_i(5).assert2_i(0xF1);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD8_S.code, 0, 2]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD8_S.code), 0, 2]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(0);
 	i.args_i(2).assert2_i(0xFFFFFFF0);
 	i.args_i(3).assert2_i(0xFFFFFFF1);
 
 	i.sig(SigCache.i_l);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD8_U.code, 0, 1]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD8_U.code), 0, 1]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(3).assert2_l(0xF0);
 	i.args_i(4).assert2_l(0xF1);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD8_S.code, 0, 3]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD8_S.code), 0, 3]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(1).assert2_l(0xFFFFFFFFFFFFFFF0);
 	i.args_i(2).assert2_l(0xFFFFFFFFFFFFFFF1);
@@ -1760,29 +1762,29 @@ def test_load16(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.addMemory(1, Max.Set(1));
 	i.addData(8, [0xF2, 0xF3, 0xCC, 0xDD]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD16_U.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD16_U.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(3).assert2_i(0);
 	i.args_i(8).assert2_i(0xF3F2);
 	i.args_i(9).assert2_i(0xCCF3);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD16_S.code, 0, 2]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD16_S.code), 0, 2]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(4).assert2_i(0);
 	i.args_i(6).assert2_i(0xFFFFF3F2);
 	i.args_i(7).assert2_i(0xFFFFCCF3);
 
 	i.sig(SigCache.i_l);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD16_U.code, 0, 1]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD16_U.code), 0, 1]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(7).assert2_l(0xF3F2);
 	i.args_i(9).assert2_l(0xDDCC);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD16_S.code, 0, 3]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD16_S.code), 0, 3]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(5).assert2_l(0xFFFFFFFFFFFFF3F2);
 	i.args_i(7).assert2_l(0xFFFFFFFFFFFFDDCC);
@@ -1791,26 +1793,26 @@ def test_load32(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.addMemory(1, Max.Set(1));
 	i.addData(10, [0xF5, 0xF6, 0xAA, 0xBB, 0xCC, 0xDD]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(6).assert2_i(0);
 	i.args_i(10).assert2_i(0xBBAAF6F5);
 	i.args_i(12).assert2_i(0xDDCCBBAA);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD.code, 0, 8]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD.code), 0, 8]);
 	i.args_i(0).assert2_i(0xF6F50000);
 	i.args_i(6).assert2_i(0x0000DDCC);
 
 	i.sig(SigCache.i_l);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD32_U.code, 0, 1]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD32_U.code), 0, 1]);
 	i.args_i(0).assert2_w(0);
 	i.args_i(8).assert2_w(0xAAF6F500);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD32_S.code, 0, 3]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD32_S.code), 0, 3]);
 	i.args_i(0).assert2_w(0);
 	i.args_i(7).assert2_w(0xFFFFFFFFBBAAF6F5);
 	i.args_i(9).assert2_w(0xFFFFFFFFDDCCBBAA);
@@ -1819,8 +1821,8 @@ def test_load64(i: ExeTester) {
 	i.sig(SigCache.i_l);
 	i.addMemory(1, Max.Set(1));
 	i.addData(12, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I64_LOAD.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I64_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(3).assert2_l(0);
 	i.args_i(12).assert2_l(0x8877665544332211);
@@ -1829,15 +1831,15 @@ def test_load64(i: ExeTester) {
 def test_load_oob0(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_u(0).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
 }
 def test_load_oob1(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(65532).assert2_i(0);
 	i.args_u(65533).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
@@ -1846,9 +1848,9 @@ def test_store8(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig0(SigCache.arr_i, SigCache.arr_v);
 	i.addData(5, [0x99, 0x88, 0x77]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 3,
-		Opcode.I32_STORE8.code, 0, 2]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 3,
+		op8(Opcode.I32_STORE8.code), 0, 2]);
 	i.args_u(3).assert2_mem(4, [0,    3, 0x88, 0x77, 0]);
 	i.args_u(4).assert2_mem(4, [0, 0x99,    3, 0x77, 0]);
 	i.args_u(5).assert2_mem(4, [0, 0x99, 0x88,    3, 0]);
@@ -1858,9 +1860,9 @@ def test_store16(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_v);
 	i.addData(11, [0x99, 0x88, 0x77]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 0x83, 0x08,
-		Opcode.I32_STORE16.code, 0, 7]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 0x83, 0x08,
+		op8(Opcode.I32_STORE16.code), 0, 7]);
 	i.args_u(4).assert2_mem(10, [0,    3,    4, 0x77, 0, 0]);
 	i.args_u(5).assert2_mem(10, [0, 0x99,    3,    4, 0, 0]);
 	i.args_u(6).assert2_mem(10, [0, 0x99, 0x88,    3, 4, 0]);
@@ -1870,9 +1872,9 @@ def test_store32(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_v);
 	i.addData(19, [0x99, 0x88, 0x77, 0x66, 0x55]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 0x91, 0xC4, 0xCC, 0xA1, 0x04,
-		Opcode.I32_STORE.code, 0, 9]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 0x91, 0xC4, 0xCC, 0xA1, 0x04,
+		op8(Opcode.I32_STORE.code), 0, 9]);
 	i.args_u(10).assert2_mem(18, [0, 0x11, 0x22, 0x33, 0x44, 0x55, 0, 0]);
 	i.args_u(11).assert2_mem(18, [0, 0x99, 0x11, 0x22, 0x33, 0x44, 0, 0]);
 	i.args_u(12).assert2_mem(18, [0, 0x99, 0x88, 0x11, 0x22, 0x33, 0x44, 0]);
@@ -1881,28 +1883,28 @@ def test_store64(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig0([ValueType.I32, ValueType.I64], SigCache.arr_v);
 	i.addData(33, [0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22]);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I64_STORE.code, 0, 22]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I64_STORE.code), 0, 22]);
 	i.argsN([Value.I32(12), Value.I64(0x0807060504030201)]).assert2_mem(32, [0, 0x99, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
 	i.argsN([Value.I32(14), Value.I64(0xA8B7C6D5E4F30201)]).assert2_mem(32, [0, 0x99, 0x88, 0x77, 0x01, 0x02, 0xF3, 0xE4, 0xD5, 0xC6, 0xB7, 0xA8]);
 }
 def test_store_oob0(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 5,
-		Opcode.I32_STORE.code, 0, 0,
-		Opcode.I32_CONST.code, 3]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.I32_STORE.code), 0, 0,
+		op8(Opcode.I32_CONST.code), 3]);
 	i.args_u(0).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
 }
 def test_store_oob1(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 5,
-		Opcode.I32_STORE.code, 0, 0,
-		Opcode.I32_CONST.code, 42]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 5,
+		op8(Opcode.I32_STORE.code), 0, 0,
+		op8(Opcode.I32_CONST.code), 42]);
 	i.args_i(0).assert2_i(42);
 	i.args_i(65532).assert2_i(42);
 	i.args_u(65533).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
@@ -1910,28 +1912,28 @@ def test_store_oob1(i: ExeTester) {
 def test_memory_size(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.v_i);
-	i.code([Opcode.MEMORY_SIZE.code, 0]);
+	i.code([op8(Opcode.MEMORY_SIZE.code), 0]);
 	i.noargs().assert2_i(0);
 
 	i.addMemory(2, Max.Set(2));
 	i.sig(SigCache.v_i);
-	i.code([Opcode.MEMORY_SIZE.code, 1]);
+	i.code([op8(Opcode.MEMORY_SIZE.code), 1]);
 	i.noargs().assert2_i(2);
 }
 def test_memory_grow1(i: ExeTester) {
 	i.addMemory(0, Max.Set(5));
 	i.sig(SigCache.i_i);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.MEMORY_GROW.code, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(0);
 	i.args_i(5).assert2_i(0);
 	i.args_i(6).assert2_i(0xFFFFFFFF);
 
 	i.addMemory(1, Max.Set(2));
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.MEMORY_GROW.code, 1]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 1]);
 	i.args_i(0).assert2_i(1);
 	i.args_i(1).assert2_i(1);
 	i.args_i(2).assert2_i(0xFFFFFFFF);
@@ -1941,8 +1943,8 @@ def test_memory_grow2(i: ExeTester) {
 	i.addMemory(0, Max.None);
 	i.sig(SigCache.i_i);
 
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.MEMORY_GROW.code, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.MEMORY_GROW.code), 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(0);
 	i.args_u(Target.limit_memory_pages + 1).assert2_i(0xFFFFFFFF);
@@ -1950,14 +1952,14 @@ def test_memory_grow2(i: ExeTester) {
 
 def test_sign_ext(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.I32_EXTEND8_S.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_EXTEND8_S.code)]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(1);
 	i.args_i(127).assert2_i(127);
 	i.args_i(0x80).assert2_i(0xFFFFFF80);
 	i.args_i(0x100).assert2_i(0);
 
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.I32_EXTEND16_S.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_EXTEND16_S.code)]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(1);
 	i.args_i(127).assert2_i(127);
@@ -1966,14 +1968,14 @@ def test_sign_ext(i: ExeTester) {
 	i.args_i(0x10000).assert2_i(0);
 
 	i.sig(SigCache.l_l);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.I64_EXTEND8_S.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_EXTEND8_S.code)]);
 	i.args_l(0).assert2_l(0);
 	i.args_l(1).assert2_l(1);
 	i.args_l(127).assert2_l(127);
 	i.args_l(0x87).assert2_l(0xFFFFFFFFFFFFFF87);
 	i.args_l(0x300).assert2_l(0);
 
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.I64_EXTEND16_S.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_EXTEND16_S.code)]);
 	i.args_l(0).assert2_l(0);
 	i.args_l(1).assert2_l(1);
 	i.args_l(0x7FFF).assert2_l(0x7FFF);
@@ -1981,7 +1983,7 @@ def test_sign_ext(i: ExeTester) {
 	i.args_l(0x8720).assert2_l(0xFFFFFFFFFFFF8720);
 	i.args_l(0x50000).assert2_l(0);
 
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.I64_EXTEND32_S.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_EXTEND32_S.code)]);
 	i.args_l(0).assert2_l(0);
 	i.args_l(1).assert2_l(1);
 	i.args_l(0x7FFF).assert2_l(0x7FFF);
@@ -1993,41 +1995,41 @@ def test_sign_ext(i: ExeTester) {
 def test_reinterpret(i: ExeTester) {
 	for (bits in [0x11223344u, 0x55662233u]) {
 		i.sig(SigCache.f_i);
-		i.code([Opcode.LOCAL_GET.code, 0, Opcode.I32_REINTERPRET_F32.code]);
+		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_REINTERPRET_F32.code)]);
 		i.args_f(bits).assert2_u(bits);
 
 		i.sig(SigCache.i_f);
-		i.code([Opcode.LOCAL_GET.code, 0, Opcode.F32_REINTERPRET_I32.code]);
+		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.F32_REINTERPRET_I32.code)]);
 		i.args_u(bits).assert2_f(bits);
 	}
 	for (bits in [0x1122334455667788u, 0x5566223344117799u]) {
 		i.sig(SigCache.d_l);
-		i.code([Opcode.LOCAL_GET.code, 0, Opcode.I64_REINTERPRET_F64.code]);
+		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_REINTERPRET_F64.code)]);
 		i.args_d(bits).assert2_w(bits);
 
 		i.sig(SigCache.l_d);
-		i.code([Opcode.LOCAL_GET.code, 0, Opcode.F64_REINTERPRET_I64.code]);
+		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.F64_REINTERPRET_I64.code)]);
 		i.args_w(bits).assert2_d(bits);
 	}
 }
 
 def test_invalid(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0, 0xFF]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, 0xFF]);
 	i.args_u(33).assert2_trap(TrapReason.INVALID_OPCODE);
 
 	for (page in Opcodes.code_pages) {
 		if (page.prefix == 0xFD) continue; // TODO: SIMD space fully filled?
-		i.code([Opcode.LOCAL_GET.code, 0, page.prefix, 0x7F]);
+		i.code([op8(Opcode.LOCAL_GET.code), 0, page.prefix, 0x7F]);
 		i.args_u(37).assert2_trap(TrapReason.INVALID_OPCODE);
 	}
 }
 
 def test_extleb(i: ExeTester) {
 	i.sig(SigCache.f_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.I32_TRUNC_SAT_F32_S.prefix,
-		Opcode.I32_TRUNC_SAT_F32_S.code | byte.!(0x80u), // manually extended LEB
+		op8(Opcode.I32_TRUNC_SAT_F32_S.code) | byte.!(0x80u), // manually extended LEB
 		0]);
 	i.args_f(Floats.f_1p31).assert2_i(i32.max);
 }
@@ -2043,48 +2045,48 @@ def test_ref_default(i: ExeTester) {
 	for (t in [ValueTypes.ANYREF, ValueTypes.I31REF, ValueTypes.FUNCREF, ValueTypes.EXTERNREF]) {
 		i.sig(newSig(SigCache.arr_v, [t]));
 		i.addLocal(t);
-		i.code([Opcode.LOCAL_GET.code, 0]);
+		i.code([op8(Opcode.LOCAL_GET.code), 0]);
 		i.noargs().assert2_r(null);
 	}
 }
 
 def test_ref_null_extern(i: ExeTester) {
 	i.sig(SigCache.v_e);
-	i.code([Opcode.REF_NULL.code, BpTypeCode.EXTERNREF.code]);
+	i.code([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code]);
 	i.noargs().assert2_r(null);
 }
 
 def test_ref_null_func(i: ExeTester) {
 	i.sig(SigCache.v_g);
-	i.code([Opcode.REF_NULL.code, BpTypeCode.FUNCREF.code]);
+	i.code([op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code]);
 	i.noargs().assert2_r(null);
 }
 
 def test_ref_is_null(i: ExeTester) {
 	// externs
 	i.sig(SigCache.e_i);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.REF_IS_NULL.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.REF_IS_NULL.code)]);
 	i.args_r(null).assert2_i(1);
 	i.args_r(null).assert2_i(1);
 	i.args_r(HostObject.new()).assert2_i(0);
 	// funcs
 	i.sig(SigCache.g_i);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.REF_IS_NULL.code]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.REF_IS_NULL.code)]);
 	i.args_r(null).assert2_i(1);
 	i.args_r(Function.new(SigCache.i_i)).assert2_i(0);
 }
 
 def test_ref_func(i: ExeTester) {
 	i.sig(SigCache.v_g);
-	i.code([Opcode.REF_FUNC.code, 0]);
+	i.code([op8(Opcode.REF_FUNC.code), 0]);
 	i.noargs().assert2_func(0);
 }
 
 def test_ref_as_non_null(i: ExeTester) {
 	i.sig(SigCache.r_r);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_AS_NON_NULL.code]);
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.REF_AS_NON_NULL.code)]);
 	i.args_r(null).assert2_trap(TrapReason.NULL_DEREF);
 	var f = Function.new(SigCache.i_i);
 	i.args_r(f).assert2_r(f);
@@ -2095,10 +2097,10 @@ def test_memory_init(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.addPassiveData([11, 22, 33, 44, 55]);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.MEMORY_INIT.prefix, Opcode.MEMORY_INIT.code, 0, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0
 	]);
 	i.args_uuu(0, 0, 5).assert2_mem(0, [11, 22, 33, 44, 55]);
 	i.args_uuu(0, 1, 3).assert2_mem(0, [22, 33, 44, 0]);
@@ -2116,7 +2118,7 @@ def test_data_drop(i: ExeTester) {
 	i.sig(SigCache.v_v);
 	i.addMemory(1, Max.Set(1));
 	i.addData(0, [0]);
-	i.code([Opcode.DATA_DROP.prefix, Opcode.DATA_DROP.code, 0]);
+	i.code([Opcode.DATA_DROP.prefix, op8(Opcode.DATA_DROP.code), 0]);
 	var t = i.run(X), instance = t.0;
 	if (instance.dropped_data[0] != true) i.t.fail("expected dropped data[0]");
 }
@@ -2126,7 +2128,7 @@ def test_memory_copy(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	var init: Array<byte> = [33, 44, 55];
 	i.addData(3, init);
-	i.code([Opcode.MEMORY_COPY.prefix, Opcode.MEMORY_COPY.code, 0, 0]);
+	i.code([Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 0, 0]);
 	i.args_uuu(0, 0, 0).assert2_mem(3, init);
 	i.args_uuu(0, 2, 5).assert2_mem(0, [0, 33, 44, 55, 0, 55, 0]);
 	i.args_uuu(7, 3, 3).assert2_mem(0, [0, 0, 0, 33, 44, 55, 0, 33, 44, 55]);
@@ -2144,7 +2146,7 @@ def test_memory_copy(i: ExeTester) {
 def test_memory_fill(i: ExeTester) {
 	i.sig(SigCache.iii_v);
 	i.addMemory(1, Max.Set(1));
-	i.code([Opcode.MEMORY_FILL.prefix, Opcode.MEMORY_FILL.code, 0]);
+	i.code([Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 0]);
 	i.args_uuu(0, 0, 0).assert2_mem(0, [0]);
 	i.args_uuu(3, 77, 2).assert2_mem(0, [0, 0, 0, 77, 77, 0]);
 	i.args_uuu(4, 99, 4).assert2_mem(0, [0, 0, 0, 0, 99, 99, 99, 99, 0]);
@@ -2165,10 +2167,10 @@ def test_table_init(i: ExeTester) {
 	i.addTable(6, 0, null);
 	i.addPassiveElems([f2.func_index, f3.func_index, f4.func_index, f5.func_index]);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.TABLE_INIT.prefix, Opcode.TABLE_INIT.code, 0, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 0, 0
 	]);
 	i.args_uuu(0, 0, 0).assert2_ftable(0, []);
 	i.args_uuu(0, 0, 1).assert2_ftable(0, [f2]);
@@ -2182,7 +2184,7 @@ def test_table_init(i: ExeTester) {
 def test_elem_drop(i: ExeTester) {
 	i.sig(SigCache.v_v);
 	i.addTable(1, 0, [0]);
-	i.code([Opcode.ELEM_DROP.prefix, Opcode.ELEM_DROP.code, 0]);
+	i.code([Opcode.ELEM_DROP.prefix, op8(Opcode.ELEM_DROP.code), 0]);
 	var t = i.run(X), instance = t.0;
 	if (instance.dropped_elems[0] != true) i.t.fail("expected dropped elems[0]");
 }
@@ -2192,7 +2194,7 @@ def test_table_get(i: ExeTester) {
 	var f3 = i.newFunction(SigCache.v_v, NO_CODE);
 	i.addTable(3, 0, [0, f2.func_index, f3.func_index]);
 	i.sig0(SigCache.arr_i, [ValueTypes.FUNCREF]);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.TABLE_GET.code, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.TABLE_GET.code), 0]);
 	i.args_u(0).assert2_func(0);
 	i.args_u(1).assert2_func(f2.func_index);
 	i.args_u(2).assert2_func(f3.func_index);
@@ -2204,7 +2206,7 @@ def test_table_set(i: ExeTester) {
 	var f3 = i.newFunction(SigCache.v_v, NO_CODE);
 	i.addTable(3, 0, [0, f2.func_index, f3.func_index]);
 	i.sig0([ValueType.I32, ValueTypes.FUNCREF], SigCache.arr_v);
-	i.code([Opcode.LOCAL_GET.code, 0, Opcode.LOCAL_GET.code, 1, Opcode.TABLE_SET.code, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.TABLE_SET.code), 0]);
 
 	var gv1 = Value.Ref(WasmFunction.new(null, f3));
 	var t = i.run([Value.I32(1), gv1]), instance = t.0;
@@ -2221,7 +2223,7 @@ def test_table_copy(i: ExeTester) {
 	i.addTable(3, 0, [0, f2.func_index, f3.func_index]);
 
 	i.sig(SigCache.iii_v);
-	i.code([Opcode.TABLE_COPY.prefix, Opcode.TABLE_COPY.code, 0, 1]);
+	i.code([Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 0, 1]);
 
 	i.args_uuu(0, 0, 1).assert2_ftable(0, [i.func, null, null]);
 	i.args_uuu(1, 2, 1).assert2_ftable(0, [null, f3, null]);
@@ -2241,9 +2243,9 @@ def test_table_grow1(i: ExeTester) {
 	i.addTableOfSize(3, Max.Set(5));
 	i.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_i);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.TABLE_GROW.prefix, Opcode.TABLE_GROW.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0
 	]);
 	var n = Values.FUNCREF_NULL;
 	i.argsN([n, Value.I32(1)]).assert2_i(3);
@@ -2252,10 +2254,10 @@ def test_table_grow1(i: ExeTester) {
 
 	i.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_v);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.TABLE_GROW.prefix, Opcode.TABLE_GROW.code, 0,
-		Opcode.DROP.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0,
+		op8(Opcode.DROP.code)
 	]);
 	var fv = Value.Ref(WasmFunction.new(null, i.func));
 	i.argsN([fv, Value.I32(1)]).assert2_ftable(0, [null, null, null, i.func]);
@@ -2266,9 +2268,9 @@ def test_table_grow2(i: ExeTester) {
 	i.addTableOfSize(3, Max.None);
 	i.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_i);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.TABLE_GROW.prefix, Opcode.TABLE_GROW.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0
 	]);
 	var n = Values.FUNCREF_NULL;
 	i.argsN([n, Value.I32(GlobalLimits.limit_table_size + 1)]).assert2_i(0xFFFFFFFF);
@@ -2277,7 +2279,7 @@ def test_table_grow2(i: ExeTester) {
 def test_table_size(i: ExeTester) {
 	i.addTable(3, 0, [0, 0, 0]);
 	i.sig(SigCache.v_i);
-	i.code([Opcode.TABLE_SIZE.prefix, Opcode.TABLE_SIZE.code, 0]);
+	i.code([Opcode.TABLE_SIZE.prefix, op8(Opcode.TABLE_SIZE.code), 0]);
 	i.noargs().assert2_i(3);
 }
 
@@ -2289,10 +2291,10 @@ def test_table_fill(i: ExeTester) {
 	i.sig(newSig([ValueType.I32, ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_v));
 	i.addTable(6, 0, []);
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.TABLE_FILL.prefix, Opcode.TABLE_FILL.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_FILL.prefix, op8(Opcode.TABLE_FILL.code), 0
 	]);
 	var f1 = Value.Ref(WasmFunction.new(null, i.func));
 	i.argsN(uvu(0, f1, 0)).assert2_ftable(0, [null]);
@@ -2328,9 +2330,9 @@ def test_struct_new(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0(SigCache.arr_i, [ValueTypes.RefStruct(false, st)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		Opcode.STRUCT_NEW.code,
+		op8(Opcode.STRUCT_NEW.code),
 		heapIndexByte(st)
 	]);
 	for (i in [666u, 777u, 0x88776655u]) {
@@ -2349,7 +2351,7 @@ def test_struct_new_default(t: ExeTester) {
 	t.sig0(SigCache.arr_v, [ValueTypes.RefStruct(false, st)]);
 	t.codev([
 		Opcode.STRUCT_NEW_DEFAULT.prefix,
-		Opcode.STRUCT_NEW_DEFAULT.code,
+		op8(Opcode.STRUCT_NEW_DEFAULT.code),
 		heapIndexByte(st)
 	]);
 	var rtt = (st);
@@ -2369,8 +2371,8 @@ def test_struct_get(t: ExeTester) {
 	var obj = HeapStruct.new(st, array_uuu(99, 98, 97));
 	for (f < st.field_types.length) {
 		t.codev([
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.STRUCT_GET.prefix, Opcode.STRUCT_GET.code,
+			op8(Opcode.LOCAL_GET.code), 0,
+			Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code),
 			heapIndexByte(st), byte.view(f)
 		]);
 		for (i in [366u, 2777u, 0x18776655u]) {
@@ -2400,8 +2402,8 @@ def test_struct_get_su(t: ExeTester) {
 		var shift: u5 = if(f == 0, 24, 16);
 		for (opcode in [Opcode.STRUCT_GET_S, Opcode.STRUCT_GET_U]) {
 			t.codev([
-				Opcode.LOCAL_GET.code, 0,
-				opcode.prefix, opcode.code,
+				op8(Opcode.LOCAL_GET.code), 0,
+				opcode.prefix, op8(opcode.code),
 				heapIndexByte(st), byte.view(f)
 			]);
 			var expected = unpackI32(vals[f], st.field_types[f].pack, opcode == Opcode.STRUCT_GET_S);
@@ -2421,9 +2423,9 @@ def test_struct_set(t: ExeTester) {
 	var obj = HeapStruct.new(st, array_uuu(99, 98, 97));
 	for (f < st.field_types.length) {
 		t.codev([
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.LOCAL_GET.code, 1,
-			Opcode.STRUCT_SET.prefix, Opcode.STRUCT_SET.code,
+			op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.LOCAL_GET.code), 1,
+			Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code),
 			heapIndexByte(st), byte.view(f)
 		]);
 		for (i in [366u, 2777u, 0x18776655u]) {
@@ -2440,9 +2442,9 @@ def test_array_new(t: ExeTester) {
 	var at = t.newArray([I32_FIELD]);
 	t.sig0(SigCache.arr_i, [ValueTypes.RefArray(false, at)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ARRAY_NEW.prefix, Opcode.ARRAY_NEW.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_NEW.prefix, op8(Opcode.ARRAY_NEW.code), heapIndexByte(at)
 	]);
 	for (i < 5u) {
 		var v = Value.I32(i);
@@ -2460,8 +2462,8 @@ def test_array_new_default(t: ExeTester) {
 	]);
 	t.sig0(SigCache.arr_i, [ValueTypes.RefArray(false, at)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ARRAY_NEW_DEFAULT.prefix, Opcode.ARRAY_NEW_DEFAULT.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_NEW_DEFAULT.prefix, op8(Opcode.ARRAY_NEW_DEFAULT.code), heapIndexByte(at)
 	]);
 	var rtt = (at);
 	for (i < 5u) {
@@ -2479,9 +2481,9 @@ def test_array_get(t: ExeTester) {
 	]);
 	t.sig0([ValueTypes.RefArray(false, at), ValueType.I32], SigCache.arr_d);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.ARRAY_GET.prefix, Opcode.ARRAY_GET.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_GET.prefix, op8(Opcode.ARRAY_GET.code), heapIndexByte(at)
 	]);
 	for (len < 5) {
 		var elems = Array<Value>.new(len);
@@ -2509,9 +2511,9 @@ def test_array_get_su(t: ExeTester) {
 		t.sig0([ValueTypes.RefArray(false, at), ValueType.I32], SigCache.arr_i);
 		for (opcode in [Opcode.ARRAY_GET_S, Opcode.ARRAY_GET_U]) {
 			t.codev([
-				Opcode.LOCAL_GET.code, 0,
-				Opcode.LOCAL_GET.code, 1,
-				opcode.prefix, opcode.code, heapIndexByte(at)
+				op8(Opcode.LOCAL_GET.code), 0,
+				op8(Opcode.LOCAL_GET.code), 1,
+				opcode.prefix, op8(opcode.code), heapIndexByte(at)
 			]);
 			for (len < 5) {
 				var elems = Array<Value>.new(len);
@@ -2538,10 +2540,10 @@ def test_array_set(t: ExeTester) {
 	]);
 	t.sig0([ValueTypes.RefArray(false, at), ValueType.I32, ValueType.F64], SigCache.arr_v);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.ARRAY_SET.prefix, Opcode.ARRAY_SET.code, heapIndexByte(at)
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.ARRAY_SET.prefix, op8(Opcode.ARRAY_SET.code), heapIndexByte(at)
 	]);
 	var obj = HeapArray.new(at, [Value.F64(0x99999), Value.F64(55)]);
 	var ref = Value.Ref(obj);
@@ -2566,8 +2568,8 @@ def test_array_len(t: ExeTester) {
 	]);
 	t.sig0([ValueTypes.RefArray(false, at)], SigCache.arr_i);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ARRAY_LEN.prefix, Opcode.ARRAY_LEN.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_LEN.prefix, op8(Opcode.ARRAY_LEN.code)
 	]);
 	for (i < 5) {
 		var obj = Value.Ref(HeapArray.new(at, Array<Value>.new(i)));
@@ -2592,11 +2594,11 @@ def test_array_new_fixed(t: ExeTester) {
 	for (i < byte.view(5)) {
 		var v = Value.I64(9999999u + i);
 		for (j < i) {
-			code.put(Opcode.LOCAL_GET.code).put(j);
+			code.put(op8(Opcode.LOCAL_GET.code)).put(j);
 			params.put(ValueType.I64);
 			args.put(v);
 		}
-		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, Opcode.ARRAY_NEW_FIXED.code, heapIndexByte(at), i]);
+		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, op8(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), i]);
 		var expected = args.copy();
 
 		t.sig0(params.extract(), results);
@@ -2610,8 +2612,8 @@ def test_ref_i31(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0(SigCache.arr_i, [ValueTypes.I31REF]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_I31.prefix, Opcode.REF_I31.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_I31.prefix, op8(Opcode.REF_I31.code)
 	]);
 	for (v in [0x8u, 0x99u, 0x12345678u, 0x87654321u]) {
 		t.args_u(v).assert2_val(Value.I31(u31.view(v)));
@@ -2622,8 +2624,8 @@ def test_i31_get_s(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0([ValueTypes.I31REF], SigCache.arr_i);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I31_GET_S.prefix, Opcode.I31_GET_S.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.I31_GET_S.prefix, op8(Opcode.I31_GET_S.code)
 	]);
 	for (v in [0x8u, 0x99u, 0x12345678u, 0x80000000u, 0xF7654321u]) {
 		var ext = (i32.view(v) << 1) >> 1;
@@ -2637,8 +2639,8 @@ def test_i31_get_u(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0([ValueTypes.I31REF], SigCache.arr_i);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I31_GET_U.prefix, Opcode.I31_GET_U.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.I31_GET_U.prefix, op8(Opcode.I31_GET_U.code)
 	]);
 	for (v in [0x8u, 0x99u, 0x12345678u, 0x80000000u, 0xF7654321u]) {
 		var ext = (u32.view(v) << 1) >> 1;
@@ -2663,8 +2665,8 @@ def test_ref_test(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], SigCache.arr_i);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_TEST.prefix, Opcode.REF_TEST.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_TEST.prefix, op8(Opcode.REF_TEST.code),
 		heapIndexByte(x.st1)
 	]);
 
@@ -2678,8 +2680,8 @@ def test_ref_test_null(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], SigCache.arr_i);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_TEST_NULL.prefix, Opcode.REF_TEST_NULL.code,
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_TEST_NULL.prefix, op8(Opcode.REF_TEST_NULL.code),
 		heapIndexByte(x.st1)
 	]);
 
@@ -2693,8 +2695,8 @@ def test_ref_cast(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], [ValueTypes.RefStruct(false, x.st2)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_CAST.prefix, Opcode.REF_CAST.code, heapIndexByte(x.st2)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_CAST.prefix, op8(Opcode.REF_CAST.code), heapIndexByte(x.st2)
 	]);
 
 	var fail = TrapReason.FAILED_CAST;
@@ -2709,8 +2711,8 @@ def test_ref_cast_null(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], [ValueTypes.RefStruct(true, x.st2)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_CAST_NULL.prefix, Opcode.REF_CAST_NULL.code, heapIndexByte(x.st2)
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_CAST_NULL.prefix, op8(Opcode.REF_CAST_NULL.code), heapIndexByte(x.st2)
 	]);
 
 	var fail = TrapReason.FAILED_CAST;
@@ -2729,9 +2731,9 @@ def test_br_on_cast(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], [ValueTypes.RefStruct(false, x.st2)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST.prefix, Opcode.BR_ON_CAST.code, NULL1, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), NULL1, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(x.o2a).assert2_r(x.o2a);
@@ -2746,9 +2748,9 @@ def test_br_on_cast_null(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], [ValueTypes.RefStruct(true, x.st2)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST.prefix, Opcode.BR_ON_CAST.code, NULL1 | NULL2, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), NULL1 | NULL2, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(null).assert2_r(null);
@@ -2763,9 +2765,9 @@ def test_br_on_cast_fail(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], [ValueTypes.RefStruct(false, x.st1)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST.prefix, Opcode.BR_ON_CAST_FAIL.code, NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(null).assert2_trap(TrapReason.UNREACHABLE);
@@ -2780,9 +2782,9 @@ def test_br_on_cast_fail_null(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], [ValueTypes.RefStruct(true, x.st1)]);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_CAST.prefix, Opcode.BR_ON_CAST_FAIL.code, NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(null).assert2_trap(fail);
@@ -2796,10 +2798,10 @@ def test_br_on_null(t: ExeTester) {
 
 	t.sig(SigCache.r_i);
 	t.codev([
-		Opcode.I32_CONST.code, 11,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_NULL.code, 0,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.I32_CONST.code), 11,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_ON_NULL.code), 0,
+		op8(Opcode.UNREACHABLE.code)
 	]);
 
 	t.args_r(null).assert2_i(11);
@@ -2812,9 +2814,9 @@ def test_br_on_non_null(t: ExeTester) {
 
 	t.sig(SigCache.r_r);
 	t.codev([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.BR_ON_NON_NULL.code, 0,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.BR_ON_NON_NULL.code), 0,
+		op8(Opcode.UNREACHABLE.code)
 	]);
 
 	t.args_r(null).assert2_trap(TrapReason.UNREACHABLE);
@@ -2828,9 +2830,9 @@ def test_ref_eq(t: ExeTester) {
 
 	t.sig(SigCache.rr_i);
 	t.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.REF_EQ.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.REF_EQ.code)
 	]);
 
 	var nil = Values.REF_NULL, obj1 = Value.Ref(HostObject.new()), obj2 = Value.Ref(HostObject.new());
@@ -2852,8 +2854,8 @@ def test_internalize(i: ExeTester) {
 	i.extensions |= Extension.GC;
 	i.sig(newSig([ValueTypes.EXTERNREF], [ValueTypes.ANYREF]));
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ANY_CONVERT_EXTERN.prefix, Opcode.ANY_CONVERT_EXTERN.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ANY_CONVERT_EXTERN.prefix, op8(Opcode.ANY_CONVERT_EXTERN.code)
 	]);
 	i.args_r(null).assert2_r(null);
 	var hobj = HostObject.new();
@@ -2864,8 +2866,8 @@ def test_externalize(i: ExeTester) {
 	i.extensions |= Extension.GC;
 	i.sig(newSig([ValueTypes.ANYREF], [ValueTypes.EXTERNREF]));
 	i.code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.ANY_CONVERT_EXTERN.prefix, Opcode.ANY_CONVERT_EXTERN.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		Opcode.ANY_CONVERT_EXTERN.prefix, op8(Opcode.ANY_CONVERT_EXTERN.code)
 	]);
 	i.args_r(null).assert2_r(null);
 	var hostref = Value.Ref(HostObject.new());
@@ -2880,9 +2882,9 @@ def test_try_table0(i: ExeTester) {
 	i.extensions |= Extension.EXCEPTION_HANDLING;
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.TRY_TABLE.code, NONE, 0,
-		Opcode.END.code,
-		Opcode.LOCAL_GET.code, 0
+		op8(Opcode.TRY_TABLE.code), NONE, 0,
+		op8(Opcode.END.code),
+		op8(Opcode.LOCAL_GET.code), 0
 	]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(145555).assert2_i(145555);
@@ -2894,16 +2896,16 @@ def test_try_tableN(i: ExeTester) {
 	var code = Vector<byte>.new();
 	for (j = 1; j < 127; j = (j + 1) * 3) {
 		code.puta([
-			Opcode.BLOCK.code, NONE,
-			Opcode.TRY_TABLE.code, NONE, byte.view(j)
+			op8(Opcode.BLOCK.code), NONE,
+			op8(Opcode.TRY_TABLE.code), NONE, byte.view(j)
 		]);
 		for (k < j) {
 			code.put(BpCatchKind.CATCH_ALL.code).put(0);
 		}
 		code.puta([
-			Opcode.END.code,
-			Opcode.END.code,
-			Opcode.LOCAL_GET.code, 0
+			op8(Opcode.END.code),
+			op8(Opcode.END.code),
+			op8(Opcode.LOCAL_GET.code), 0
 		]);
 		i.codev(code.extract());
 		i.args_i(0).assert2_i(0);
@@ -2915,9 +2917,9 @@ def test_try_tablei(i: ExeTester) {
 	i.extensions |= Extension.EXCEPTION_HANDLING;
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.TRY_TABLE.code, BpTypeCode.I32.code, 0,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.END.code
+		op8(Opcode.TRY_TABLE.code), BpTypeCode.I32.code, 0,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.END.code)
 	]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(3145566).assert2_i(3145566);
@@ -2927,16 +2929,16 @@ def test_try_table_if(i: ExeTester) {
 	i.extensions |= Extension.EXCEPTION_HANDLING;
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.BLOCK.code, NONE,
-		Opcode.TRY_TABLE.code, NONE, 1, BpCatchKind.CATCH_ALL.code, 0,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.IF.code, NONE,
-		Opcode.I32_CONST.code, 11,
-		Opcode.RETURN.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 22
+		op8(Opcode.BLOCK.code), NONE,
+		op8(Opcode.TRY_TABLE.code), NONE, 1, BpCatchKind.CATCH_ALL.code, 0,
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.IF.code), NONE,
+		op8(Opcode.I32_CONST.code), 11,
+		op8(Opcode.RETURN.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 22
 	]);
 	i.args_i(0).assert2_i(22);
 	i.args_i(3145566).assert2_i(11);
@@ -2945,7 +2947,7 @@ def test_try_table_if(i: ExeTester) {
 def test_traplocs(i: ExeTester, offset: int, instrs: Array<byte>, reason: TrapReason) {
 	var code = Vector<byte>.new();
 	for (pc in [1, 2, 4, 13]) {
-		code.putn(Opcode.NOP.code, pc - 1);
+		code.putn(op8(Opcode.NOP.code), pc - 1);
 		code.puta(instrs);
 		i.code(code.extract());
 		i.assert2_trap_at(reason, [pc + offset]); // arguments should be set by caller
@@ -2955,29 +2957,29 @@ def test_traplocs(i: ExeTester, offset: int, instrs: Array<byte>, reason: TrapRe
 def test_unreachable_traploc(i: ExeTester) {
 	var code = Vector<byte>.new();
 	for (pc in [1, 2, 3, 4, 5, 11, 17, 199, 701]) {
-		code.putn(Opcode.NOP.code, pc - 1);
-		code.put(Opcode.UNREACHABLE.code);
+		code.putn(op8(Opcode.NOP.code), pc - 1);
+		code.put(op8(Opcode.UNREACHABLE.code));
 		i.code(code.extract());
 		i.noargs().assert2_trap_at(TrapReason.UNREACHABLE, [pc]);
 	}
 }
 
 def test_call1_traploc(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_v, [Opcode.UNREACHABLE.code]).func_index);
-	i.code([Opcode.I32_CONST.code, 17, Opcode.CALL.code, f17]);
+	var f17 = byte.!(i.newFunction(SigCache.v_v, [op8(Opcode.UNREACHABLE.code)]).func_index);
+	i.code([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17]);
 	i.noargs().assert2_trap_at(TrapReason.UNREACHABLE, [3, 1]);
 }
 
 def test_call2_traploc(i: ExeTester) {
 	var buf = Vector<byte>.new();
 	for (j in [2, 3, 9]) {
-		buf.putn(Opcode.NOP.code, j - 1);
-		buf.put(Opcode.UNREACHABLE.code);
+		buf.putn(op8(Opcode.NOP.code), j - 1);
+		buf.put(op8(Opcode.UNREACHABLE.code));
 
 		var f17 = byte.!(i.newFunction(SigCache.v_v, buf.extract()).func_index);
 		for (k in [2, 6, 11]) {
-			buf.putn(Opcode.NOP.code, k - 1);
-			buf.puta([Opcode.I32_CONST.code, 17, Opcode.CALL.code, f17]);
+			buf.putn(op8(Opcode.NOP.code), k - 1);
+			buf.puta([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17]);
 			i.code(buf.extract());
 			i.noargs().assert2_trap_at(TrapReason.UNREACHABLE, [2 + k, 0 + j]);
 		}
@@ -2987,8 +2989,8 @@ def test_call2_traploc(i: ExeTester) {
 def test_ref_as_non_null_traploc(i: ExeTester) {
 	i.sig(SigCache.r_r);
 	test_traplocs(i.args_r(null), 2, [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.REF_AS_NON_NULL.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.REF_AS_NON_NULL.code)
 	], TrapReason.NULL_DEREF);
 }
 
@@ -3027,21 +3029,21 @@ def test_load_oob0_traploc(i: ExeTester) {
 	i.sig(SigCache.i_i);
 
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD.code, 0, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD.code), 0, 0
 	];
 	test_traplocs(i.args_u(0), 2, code, TrapReason.MEM_OUT_OF_BOUNDS);
 }
 
 def test_call_indirect_traploc(i: ExeTester) { // TODO: return_call_indirect, call_ref
 	i.sig(SigCache.ii_i);
-	var f1 = i.newFunction(SigCache.i_i, [Opcode.I32_CONST.code, 11]);
+	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f3.func_index]);
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.CALL_INDIRECT.code, byte.!(f1.sig_index), 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0
 	];
 	test_traplocs(i.args_uu(0, 1), 4, code, TrapReason.FUNC_SIG_MISMATCH);
 	test_traplocs(i.args_uu(0, 3), 4, code, TrapReason.FUNC_INVALID);
@@ -3056,8 +3058,8 @@ def test_i_trunc_f_traploc(i: ExeTester) {
 def test_call_ref_traploc(i: ExeTester) {
 	var sig_v_i = i.addSig(SigCache.v_i);
 	var code: Array<byte> = [
-		Opcode.REF_NULL.code, BpTypeCode.FUNCREF.code,
-		Opcode.CALL_REF.code, heapIndexByte(sig_v_i)
+		op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
+		op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
 	];
 	test_traplocs(i.noargs(), 2, code, TrapReason.NULL_DEREF);
 }
@@ -3067,10 +3069,10 @@ def test_memory_init_traploc(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.addPassiveData([11, 22, 33, 44, 55]);
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2,
-		Opcode.MEMORY_INIT.prefix, Opcode.MEMORY_INIT.code, 0, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2,
+		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0
 	];
 	test_traplocs(i.args_uuu(65533, 0, 4), 6, code, TrapReason.MEM_OUT_OF_BOUNDS);
 }
@@ -3080,8 +3082,8 @@ def test_table_get_traploc(i: ExeTester) {
 	i.sig0(SigCache.arr_i, [ValueTypes.FUNCREF]);
 
 	var code: Array<byte> = [
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.TABLE_GET.code, 0
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.TABLE_GET.code), 0
 	];
 	test_traplocs(i.args_u(3), 2, code, TrapReason.TABLE_OUT_OF_BOUNDS);
 }

--- a/test/unittest/ExeTest.v3
+++ b/test/unittest/ExeTest.v3
@@ -5,8 +5,6 @@ def X: Array<Value>;
 var NO_CODE: Array<byte> = [];
 def NONE = BpTypeCode.EmptyBlock.code;
 
-def op8 = Opcodes.op8;
-
 // Registers a "unop" opcode test
 def reg1<X, Z>(opcode: Opcode,
 		f: (ExeTester, Opcode, Array<(Z, X)>) -> void,
@@ -1007,47 +1005,47 @@ def test_empty(i: ExeTester) {
 }
 
 def test_unreachable(i: ExeTester) {
-	i.code([op8(Opcode.UNREACHABLE.code)])
+	i.code([u8.!(Opcode.UNREACHABLE.code)])
 		.noargs().assert2_trap(TrapReason.UNREACHABLE);
 }
 
 def test_nop(i: ExeTester) {
-	i.sig(SigCache.v_v).code([op8(Opcode.NOP.code)]).noargs().assert2_none();
+	i.sig(SigCache.v_v).code([u8.!(Opcode.NOP.code)]).noargs().assert2_none();
 }
 
 def test_block0(i: ExeTester) {
 	i.sig(SigCache.v_v);
-	i.code([op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.END.code)]);
 	i.noargs().assert2_none();
 
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_i(9).assert2_i(9);
 	i.args_i(7).assert2_i(7);
 
 	i.sig(SigCache.l_l);
-	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I64.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.BLOCK.code), BpTypeCode.I64.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_l(9).assert2_l(9);
 	i.args_l(7).assert2_l(7);
 }
 
 def test_block1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I32.code | byte.view(0x80), 0x7f, // 2-byte signed LEB
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code | byte.view(0x80), 0x7f, // 2-byte signed LEB
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_i(9).assert2_i(9);
 	i.args_i(7).assert2_i(7);
 
 	i.sig(SigCache.l_l);
-	i.code([op8(Opcode.BLOCK.code), BpTypeCode.I64.code | byte.view(0x80), 0xff, 0x7f, // 3-byte signed LEB
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.BLOCK.code), BpTypeCode.I64.code | byte.view(0x80), 0xff, 0x7f, // 3-byte signed LEB
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_l(9).assert2_l(9);
 	i.args_l(7).assert2_l(7);
 }
@@ -1055,9 +1053,9 @@ def test_block1(i: ExeTester) {
 def test_block2(i: ExeTester) {
 	i.extensions |= Extension.GC;
 	i.sig(newSig(SigCache.arr_g, SigCache.arr_g));
-	i.code([op8(Opcode.BLOCK.code), BpTypeCode.REF_NULL.code,  BpTypeCode.FUNCREF.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.BLOCK.code), BpTypeCode.REF_NULL.code,  BpTypeCode.FUNCREF.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_r(null).assert2_r(null);
 	def hf = HostFunction.new(null, SigCache.i_i, null);
 	i.args_r(hf).assert2_r(hf);
@@ -1065,29 +1063,29 @@ def test_block2(i: ExeTester) {
 
 def test_loop0(i: ExeTester) {
 	i.sig(SigCache.v_v);
-	i.code([op8(Opcode.LOOP.code), NONE, op8(Opcode.END.code)]);
+	i.code([u8.!(Opcode.LOOP.code), NONE, u8.!(Opcode.END.code)]);
 	i.noargs().assert2_none();
 
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.LOOP.code), NONE,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_SUB.code),
-		op8(Opcode.LOCAL_TEE.code), 0,
-		op8(Opcode.BR_IF.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.LOCAL_GET.code), 0]);
+	i.codev([u8.!(Opcode.LOOP.code), NONE,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_SUB.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0,
+		u8.!(Opcode.BR_IF.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(1).assert2_i(0);
 	i.args_i(5).assert2_i(0);
 
-	i.codev([op8(Opcode.LOOP.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_SUB.code),
-		op8(Opcode.LOCAL_TEE.code), 0,
-		op8(Opcode.BR_IF.code), 0,
-		op8(Opcode.END.code)]);
+	i.codev([u8.!(Opcode.LOOP.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_SUB.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0,
+		u8.!(Opcode.BR_IF.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_i(1).assert2_i(1);
 	i.args_i(5).assert2_i(1);
 }
@@ -1095,15 +1093,15 @@ def test_loop0(i: ExeTester) {
 def test_loop1(i: ExeTester) {
 	i.sig(SigCache.i_v);
 	i.codev([
-		op8(Opcode.I32_CONST.code), 10,
-		op8(Opcode.LOCAL_SET.code), 0,
-		op8(Opcode.LOOP.code), NONE,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_SUB.code),
-		op8(Opcode.LOCAL_TEE.code), 0,
-		op8(Opcode.BR_IF.code), 0,
-		op8(Opcode.END.code)]);
+		u8.!(Opcode.I32_CONST.code), 10,
+		u8.!(Opcode.LOCAL_SET.code), 0,
+		u8.!(Opcode.LOOP.code), NONE,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_SUB.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0,
+		u8.!(Opcode.BR_IF.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_u(99).assert2_none();
 }
 
@@ -1112,121 +1110,121 @@ def test_loop1(i: ExeTester) {
 
 def test_if0(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), NONE,
-		op8(Opcode.I32_CONST.code), 11,
-		op8(Opcode.RETURN.code),
-		op8(Opcode.ELSE.code),
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 33]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), NONE,
+		u8.!(Opcode.I32_CONST.code), 11,
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 33]);
 	i.args_i(9).assert2_i(11);
 	i.args_i(0).assert2_i(22);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), NONE,
-		op8(Opcode.I32_CONST.code), 33,
-		op8(Opcode.LOCAL_SET.code), 0,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.I32_CONST.code), 44,
-		op8(Opcode.LOCAL_SET.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.LOCAL_GET.code), 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), NONE,
+		u8.!(Opcode.I32_CONST.code), 33,
+		u8.!(Opcode.LOCAL_SET.code), 0,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.I32_CONST.code), 44,
+		u8.!(Opcode.LOCAL_SET.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(7).assert2_i(33);
 	i.args_i(0).assert2_i(44);
 
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), NONE,
-		op8(Opcode.I32_CONST.code), 13,
-		op8(Opcode.LOCAL_SET.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.LOCAL_GET.code), 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), NONE,
+		u8.!(Opcode.I32_CONST.code), 13,
+		u8.!(Opcode.LOCAL_SET.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(7).assert2_i(13);
 	i.args_i(0).assert2_i(0);
 }
 def test_if1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 17,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.I32_CONST.code), 27,
-		op8(Opcode.END.code)]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 17,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.I32_CONST.code), 27,
+		u8.!(Opcode.END.code)]);
 	i.args_i(6).assert2_i(17);
 	i.args_i(0).assert2_i(27);
 
-	i.codev([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 18,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.ELSE.code),
-		op8(Opcode.I32_CONST.code), 28,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code)]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 18,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.ELSE.code),
+		u8.!(Opcode.I32_CONST.code), 28,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_i(4).assert2_i(18);
 	i.args_i(0).assert2_i(28);
 }
 def test_br0(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR.code), 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.BR.code), 0]);
 	i.args_i(3).assert2_i(3);
 	i.args_i(9).assert2_i(9);
 
 	i.sig(SigCache.ii_i);
-	i.codev([op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.BR.code), 0]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.BR.code), 0]);
 	i.args_ii(7, 11).assert2_i(7);
 	i.args_ii(5, 99).assert2_i(5);
 }
 def test_br1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code)]);
+	i.codev([u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code)]);
 	i.args_i(37).assert2_i(37);
 	i.args_i(94).assert2_i(94);
 
 	i.sig(SigCache.ii_i);
-	i.codev([op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.RETURN.code)]);
+	i.codev([u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.RETURN.code)]);
 	i.args_ii(71, 11).assert2_i(71);
 	i.args_ii(52, 99).assert2_i(52);
 }
 def test_br2(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.I32_CONST.code), 9,
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.I32_ADD.code)]);
+		u8.!(Opcode.I32_CONST.code), 9,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_ADD.code)]);
 	i.args_i(37).assert2_i(46);
 	i.args_i(94).assert2_i(103);
 }
 def test_br_if1(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.I32_CONST.code), 7,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_IF.code), 0,
-		op8(Opcode.DROP.code),
-		op8(Opcode.I32_CONST.code), 8]);
+	i.codev([u8.!(Opcode.I32_CONST.code), 7,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_IF.code), 0,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.I32_CONST.code), 8]);
 	i.args_i(11).assert2_i(7);
 	i.args_i(0).assert2_i(8);
 
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.I32_CONST.code), 9,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_IF.code), 1,
-		op8(Opcode.DROP.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 5]);
+	i.codev([u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.I32_CONST.code), 9,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_IF.code), 1,
+		u8.!(Opcode.DROP.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 5]);
 	i.args_i(17).assert2_i(9);
 	i.args_i(0).assert2_i(5);
 }
@@ -1234,21 +1232,21 @@ def make_br_ifN(i: ExeTester, depth: int) {
 	i.sig(SigCache.i_i);
 	var w = DataWriter.new();
 	for (j < depth) {
-		w.putbb(op8(Opcode.BLOCK.code), NONE);
+		w.putbb(u8.!(Opcode.BLOCK.code), NONE);
 	}
 	for (j < depth) {
-		w.putbb(op8(Opcode.LOCAL_GET.code), 0);
-		w.putb(op8(Opcode.I32_CONST.code));
+		w.putbb(u8.!(Opcode.LOCAL_GET.code), 0);
+		w.putb(u8.!(Opcode.I32_CONST.code));
 		w.put_sleb32(j);
-		w.putb(op8(Opcode.I32_EQ.code));
-		w.putb(op8(Opcode.BR_IF.code));
+		w.putb(u8.!(Opcode.I32_EQ.code));
+		w.putb(u8.!(Opcode.BR_IF.code));
 		w.put_sleb32(j);
 	}
 	for (j < depth) {
-		w.putb(op8(Opcode.END.code));
-		w.putb(op8(Opcode.I32_CONST.code));
+		w.putb(u8.!(Opcode.END.code));
+		w.putb(u8.!(Opcode.I32_CONST.code));
 		w.put_sleb32(j + 13);
-		w.putb(op8(Opcode.RETURN.code));
+		w.putb(u8.!(Opcode.RETURN.code));
 	}
 	i.codev(w.extract());
 }
@@ -1286,11 +1284,11 @@ def test_br_ifN3(i: ExeTester) {
 }
 def test_br_table0(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.codev([op8(Opcode.I32_CONST.code), 7,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2,
+	i.codev([u8.!(Opcode.I32_CONST.code), 7,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2,
 		0, 0, 0,
-		op8(Opcode.UNREACHABLE.code)]);
+		u8.!(Opcode.UNREACHABLE.code)]);
 	i.args_i(0).assert2_i(7);
 	i.args_i(1).assert2_i(7);
 	i.args_i(2).assert2_i(7);
@@ -1298,25 +1296,25 @@ def test_br_table0(i: ExeTester) {
 	i.args_i(4).assert2_i(7);
 	i.args_i(0xFFFFFFFF).assert2_i(7);
 
-	i.codev([op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2,
+	i.codev([u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2,
 		0, 2, 1,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 16,
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 17,
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 18,
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 16,
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 17,
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 18,
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 		]);
 	i.args_i(0).assert2_i(16);
 	i.args_i(1).assert2_i(18);
@@ -1328,28 +1326,28 @@ def test_br_table0(i: ExeTester) {
 def test_br_table1(i: ExeTester) {
 	i.sig(SigCache.ii_i);
 
-	i.codev([op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2,
+	i.codev([u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2,
 		0, 2, 1,
-		op8(Opcode.UNREACHABLE.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 16,
-		op8(Opcode.I32_ADD.code),
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 17,
-		op8(Opcode.I32_ADD.code),
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 18,
-		op8(Opcode.I32_ADD.code),
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.UNREACHABLE.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 16,
+		u8.!(Opcode.I32_ADD.code),
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 17,
+		u8.!(Opcode.I32_ADD.code),
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 18,
+		u8.!(Opcode.I32_ADD.code),
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code)
 		]);
 	i.args_ii(0, 0).assert2_i(16);
 	i.args_ii(0, 10).assert2_i(26);
@@ -1367,16 +1365,16 @@ def test_br_table1(i: ExeTester) {
 def test_br_table2(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.I32_CONST.code), 9,
-		op8(Opcode.BLOCK.code), BpTypeCode.I32.code,
-		op8(Opcode.I32_CONST.code), 42,
-		op8(Opcode.I32_CONST.code), 42,
-		op8(Opcode.I32_CONST.code), 42,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 0, 0,
-		op8(Opcode.END.code),
-		op8(Opcode.I32_ADD.code)]);
+		u8.!(Opcode.I32_CONST.code), 9,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.I32.code,
+		u8.!(Opcode.I32_CONST.code), 42,
+		u8.!(Opcode.I32_CONST.code), 42,
+		u8.!(Opcode.I32_CONST.code), 42,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 0, 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_ADD.code)]);
 	i.args_i(0).assert2_i(14);
 	i.args_i(1).assert2_i(14);
 	i.args_i(444).assert2_i(14);
@@ -1384,113 +1382,113 @@ def test_br_table2(i: ExeTester) {
 def test_br_table3(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_TABLE.code), 2, 2, 1, 0,
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 44,
-		op8(Opcode.BR.code), 2,
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 43,
-		op8(Opcode.BR.code), 1,
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 42,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.I32_CONST.code), 41]);
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_TABLE.code), 2, 2, 1, 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 44,
+		u8.!(Opcode.BR.code), 2,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 43,
+		u8.!(Opcode.BR.code), 1,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 42,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.I32_CONST.code), 41]);
 	i.args_i(0).assert2_i(42);
 	i.args_i(1).assert2_i(43);
 	i.args_i(2).assert2_i(44);
 	i.args_i(3).assert2_i(44);
 }
 def test_return0(i: ExeTester) {
-	i.sig(SigCache.v_v).code([op8(Opcode.RETURN.code)]).noargs().assert2_none();
+	i.sig(SigCache.v_v).code([u8.!(Opcode.RETURN.code)]).noargs().assert2_none();
 }
 def test_return1(i: ExeTester) {
-	i.sig(SigCache.i_i).code([op8(Opcode.LOCAL_GET.code), 0,
-				  op8(Opcode.RETURN.code)]).args_i(97).assert2_i(97);
+	i.sig(SigCache.i_i).code([u8.!(Opcode.LOCAL_GET.code), 0,
+				  u8.!(Opcode.RETURN.code)]).args_i(97).assert2_i(97);
 }
 def test_return2(i: ExeTester) {
-	i.sig(SigCache.v_v).code([op8(Opcode.I32_CONST.code), 0,
-				  op8(Opcode.RETURN.code)]).noargs().assert2_none();
-	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 9,
-				  op8(Opcode.RETURN.code)]).noargs().assert2_i(9);
-	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 7,
-				  op8(Opcode.I32_CONST.code), 13,
-				  op8(Opcode.RETURN.code)]).noargs().assert2_i(13);
+	i.sig(SigCache.v_v).code([u8.!(Opcode.I32_CONST.code), 0,
+				  u8.!(Opcode.RETURN.code)]).noargs().assert2_none();
+	i.sig(SigCache.v_i).code([u8.!(Opcode.I32_CONST.code), 9,
+				  u8.!(Opcode.RETURN.code)]).noargs().assert2_i(9);
+	i.sig(SigCache.v_i).code([u8.!(Opcode.I32_CONST.code), 7,
+				  u8.!(Opcode.I32_CONST.code), 13,
+				  u8.!(Opcode.RETURN.code)]).noargs().assert2_i(13);
 }
 def test_return3(i: ExeTester) {
 	var sig_v_il = newSig(SigCache.arr_v, [ValueType.I32, ValueType.I64]);
 	i.sig(sig_v_il);
 	i.addLocals(1, ValueType.I32);
-	i.code([op8(Opcode.I32_CONST.code), 11, op8(Opcode.I64_CONST.code), 22]);
+	i.code([u8.!(Opcode.I32_CONST.code), 11, u8.!(Opcode.I64_CONST.code), 22]);
 	i.noargs().assert2_res(Result.Value([Value.I32(11), Value.I64(22)]));
 }
 def test_drop(i: ExeTester) {
-	i.sig(SigCache.v_v).code([op8(Opcode.I32_CONST.code), 0, op8(Opcode.DROP.code)])
+	i.sig(SigCache.v_v).code([u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.DROP.code)])
 		.noargs().assert2_none();
-	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 3,
-				  op8(Opcode.DROP.code),
-				  op8(Opcode.I32_CONST.code), 11])
+	i.sig(SigCache.v_i).code([u8.!(Opcode.I32_CONST.code), 3,
+				  u8.!(Opcode.DROP.code),
+				  u8.!(Opcode.I32_CONST.code), 11])
 		.noargs().assert2_i(11);
-	i.sig(SigCache.v_i).code([op8(Opcode.I32_CONST.code), 4,
-				  op8(Opcode.I32_CONST.code), 5,
-				  op8(Opcode.DROP.code)])
+	i.sig(SigCache.v_i).code([u8.!(Opcode.I32_CONST.code), 4,
+				  u8.!(Opcode.I32_CONST.code), 5,
+				  u8.!(Opcode.DROP.code)])
 		.noargs().assert2_i(4);
 }
 def test_select(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.I32_CONST.code), 11,
-		op8(Opcode.I32_CONST.code), 22,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.SELECT.code)]);
+	i.code([u8.!(Opcode.I32_CONST.code), 11,
+		u8.!(Opcode.I32_CONST.code), 22,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.SELECT.code)]);
 	i.args_i(1).assert2_i(11);
 	i.args_i(108).assert2_i(11);
 	i.args_i(0).assert2_i(22);
 
 	i.sig(SigCache.i_l);
-	i.code([op8(Opcode.I64_CONST.code), 33,
-		op8(Opcode.I64_CONST.code), 44,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.SELECT.code)]);
+	i.code([u8.!(Opcode.I64_CONST.code), 33,
+		u8.!(Opcode.I64_CONST.code), 44,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_w(33);
 	i.args_u(109).assert2_w(33);
 	i.args_u(0).assert2_w(44);
 
 	i.sig(SigCache.i_f);
-	i.code([op8(Opcode.F32_CONST.code), 0x11, 0x22, 0x33, 0x44,
-		op8(Opcode.F32_CONST.code), 0x55, 0x66, 0x77, 0x88,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.SELECT.code)]);
+	i.code([u8.!(Opcode.F32_CONST.code), 0x11, 0x22, 0x33, 0x44,
+		u8.!(Opcode.F32_CONST.code), 0x55, 0x66, 0x77, 0x88,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_f(0x44332211);
 	i.args_u(66).assert2_f(0x44332211);
 	i.args_u(0).assert2_f(0x88776655);
 
 	i.sig(SigCache.i_d);
-	i.code([op8(Opcode.F64_CONST.code), 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,
-		op8(Opcode.F64_CONST.code), 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.SELECT.code)]);
+	i.code([u8.!(Opcode.F64_CONST.code), 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,
+		u8.!(Opcode.F64_CONST.code), 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_d(0x8877665544332211);
 	i.args_u(66).assert2_d(0x8877665544332211);
 	i.args_u(0).assert2_d(0x0807060504030201);
 
 	i.sig(SigCache.i_s);
-	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code), 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF,0x00,
-		Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code), 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x00,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.SELECT.code)]);
+	i.code([Opcode.V128_CONST.prefix, u8.!(Opcode.V128_CONST.code), 0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF,0x00,
+		Opcode.V128_CONST.prefix, u8.!(Opcode.V128_CONST.code), 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x00,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.SELECT.code)]);
 	i.args_u(1).assert2_s(0x8877665544332211, 0x00FFEEDDCCBBAA99);
 	i.args_u(66).assert2_s(0x8877665544332211, 0x00FFEEDDCCBBAA99);
 	i.args_u(0).assert2_s(0x0807060504030201, 0x000F0E0D0C0B0A09);
 }
 def test_selectt(i: ExeTester) {
 	i.sig0([ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueType.I32], SigCache.arr_e);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		op8(Opcode.SELECT_T.code), 1, BpTypeCode.EXTERNREF.code]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		u8.!(Opcode.SELECT_T.code), 1, BpTypeCode.EXTERNREF.code]);
 	var v1: Value = Value.Ref(HostObject.new());
 	var v2: Value = Value.Ref(HostObject.new());
 	i.argsN([v1, v2, Value.I32(0)]).assert2_val(v2);
@@ -1502,72 +1500,72 @@ def test_selectt(i: ExeTester) {
 	i.sig0(
 		[ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueTypes.EXTERNREF, ValueType.I32],
 		[ValueTypes.EXTERNREF, ValueTypes.EXTERNREF]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		op8(Opcode.LOCAL_GET.code), 3,
-		op8(Opcode.LOCAL_GET.code), 4,
-		op8(Opcode.SELECT_T.code), 2, BpTypeCode.EXTERNREF.code, BpTypeCode.EXTERNREF.code]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		u8.!(Opcode.LOCAL_GET.code), 3,
+		u8.!(Opcode.LOCAL_GET.code), 4,
+		u8.!(Opcode.SELECT_T.code), 2, BpTypeCode.EXTERNREF.code, BpTypeCode.EXTERNREF.code]);
 	i.argsN([v1, v2, v3, v4, Value.I32(0)]).assert2_res(Result.Value([v3, v4]));
 	i.argsN([v1, v2, v3, v4, Value.I32(1)]).assert2_res(Result.Value([v1, v2]));
 }
 
 def test_locals0(i: ExeTester) {
-	i.sig(SigCache.i_i).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.i_i).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(11).assert2_i(11);
 
-	i.sig(SigCache.l_l).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.l_l).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_l(99887766554433).assert2_l(99887766554433);
 
-	i.sig(SigCache.f_f).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.f_f).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_f(0x11223344).assert2_f(0x11223344);
 
-	i.sig(SigCache.d_d).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.d_d).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_d(0x5566778811223344).assert2_d(0x5566778811223344);
 
-	i.sig(SigCache.s_s).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.s_s).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_s(0x55337788_44223311, 0x11223344_55667788).assert2_s(0x55337788_44223311, 0x11223344_55667788);
 }
 def test_locals1(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	var i1 = byte.!(i.addLocal(ValueType.I32));
-	i.code([op8(Opcode.LOCAL_GET.code), i1]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), i1]);
 	i.args_i(17).assert2_i(0);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_SET.code), i1,
-		op8(Opcode.LOCAL_GET.code), i1]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_SET.code), i1,
+		u8.!(Opcode.LOCAL_GET.code), i1]);
 	i.args_i(19).assert2_i(19);
 
 	var i2 = byte.!(i.addLocal(ValueType.I32));
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_SET.code), i1,
-		op8(Opcode.LOCAL_GET.code), i2]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_SET.code), i1,
+		u8.!(Opcode.LOCAL_GET.code), i2]);
 	i.args_i(23).assert2_i(0);
 }
 def test_locals2(i: ExeTester) {
 	var l1 = byte.!(i.addLocal(ValueType.I64));
 	i.sig(SigCache.v_l).code([
-		op8(Opcode.LOCAL_GET.code), l1
+		u8.!(Opcode.LOCAL_GET.code), l1
 	]);
 	i.noargs().assert2_w(0);
 
 	var f1 = byte.!(i.addLocal(ValueType.F32));
 	i.sig(SigCache.v_f).code([
-		op8(Opcode.LOCAL_GET.code), f1
+		u8.!(Opcode.LOCAL_GET.code), f1
 	]);
 	i.noargs().assert2_f(0);
 
 	var d1 = byte.!(i.addLocal(ValueType.F64));
 	i.sig(SigCache.v_d).code([
-		op8(Opcode.LOCAL_GET.code), d1
+		u8.!(Opcode.LOCAL_GET.code), d1
 	]);
 	i.noargs().assert2_d(0);
 }
 def test_locals3(i: ExeTester) {
 	i.sig(SigCache.ii_i).code([
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_TEE.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_TEE.code), 0
 	]);
 	i.args_ii(0, 1).assert2_i(1);
 	i.args_ii(0, 7).assert2_i(7);
@@ -1577,14 +1575,14 @@ def test_locals4(i: ExeTester) {
 	i.sig(SigCache.ii_i);
 	i.addLocals(260, ValueType.I32);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_ADD.code),
-		op8(Opcode.LOCAL_TEE.code), 0xC0, 0x0,
-		op8(Opcode.LOCAL_SET.code), 0xC0, 0x1,
-		op8(Opcode.LOCAL_GET.code), 0xC0, 0x0,
-		op8(Opcode.LOCAL_GET.code), 0xC0, 0x1,
-		op8(Opcode.I32_MUL.code)]);
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_ADD.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0xC0, 0x0,
+		u8.!(Opcode.LOCAL_SET.code), 0xC0, 0x1,
+		u8.!(Opcode.LOCAL_GET.code), 0xC0, 0x0,
+		u8.!(Opcode.LOCAL_GET.code), 0xC0, 0x1,
+		u8.!(Opcode.I32_MUL.code)]);
 	i.args_ii(1, 2).assert2_i(9);
 	i.args_ii(65, 993).assert2_i(1119364);
 }
@@ -1594,84 +1592,84 @@ def test_locals5(i: ExeTester) {
 	i.sig(newSig(SigCache.arr_g, SigCache.arr_g));
 	var l = i.addLocals(1, ft);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), byte.!(l)
+		u8.!(Opcode.LOCAL_GET.code), byte.!(l)
 	]);
 	i.args_r(null).assert2_r(null);
 }
 def test_params(i: ExeTester) {
-	i.sig(SigCache.i_i).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.i_i).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_i(13).assert2_i(13);
 	i.args_i(9991).assert2_i(9991);
 
-	i.sig(SigCache.l_l).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.l_l).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_l(137).assert2_l(137);
 	i.args_l(999145).assert2_l(999145);
 
-	i.sig(SigCache.f_f).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.f_f).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_f(137u).assert2_f(137u);
 	i.args_f(999145u).assert2_f(999145u);
 
-	i.sig(SigCache.d_d).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.d_d).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_d(137u).assert2_d(137u);
 	i.args_d(999145u).assert2_d(999145u);
 
-	i.sig(SigCache.s_s).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.s_s).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_s(139, 141).assert2_s(139, 141);
 	i.args_s(0x12345678_abcdef90, 99).assert2_s(0x12345678_abcdef90, 99);
 
-	i.sig(SigCache.ii_i).code([op8(Opcode.LOCAL_GET.code), 0]);
+	i.sig(SigCache.ii_i).code([u8.!(Opcode.LOCAL_GET.code), 0]);
 	i.args_ii(12, 15).assert2_i(12);
 	i.args_ii(9791, 66).assert2_i(9791);
 
-	i.sig(SigCache.ii_i).code([op8(Opcode.LOCAL_GET.code), 1]);
+	i.sig(SigCache.ii_i).code([u8.!(Opcode.LOCAL_GET.code), 1]);
 	i.args_ii(12, 157).assert2_i(157);
 	i.args_ii(9791, 8791).assert2_i(8791);
 }
 def test_global_get(i: ExeTester) {
 	var index = byte.!(i.newGlobal(ValueType.I32, InitExpr.I32(34)).global_index);
-	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(34);
+	i.code([u8.!(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(34);
 
 	i.sig(SigCache.v_l);
 	index = byte.!(i.newGlobal(ValueType.I64, InitExpr.I64(55)).global_index);
-	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(55);
+	i.code([u8.!(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(55);
 }
 def test_global_set(i: ExeTester) {
 	var index = byte.!(i.newGlobal(ValueType.I32, InitExpr.I32(34)).global_index);
-	i.code([op8(Opcode.I32_CONST.code), 55,
-		op8(Opcode.GLOBAL_SET.code), index,
-		op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(55);
+	i.code([u8.!(Opcode.I32_CONST.code), 55,
+		u8.!(Opcode.GLOBAL_SET.code), index,
+		u8.!(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(55);
 
 	i.sig(SigCache.v_l);
 	index = byte.!(i.newGlobal(ValueType.I64, InitExpr.I64(77)).global_index);
-	i.code([op8(Opcode.I64_CONST.code), 47,
-		op8(Opcode.GLOBAL_SET.code), index,
-		op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(47);
+	i.code([u8.!(Opcode.I64_CONST.code), 47,
+		u8.!(Opcode.GLOBAL_SET.code), index,
+		u8.!(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(47);
 }
 def test_imm_global(i: ExeTester) {
 	var index = byte.!(i.newImmGlobal(ValueType.I32, InitExpr.I32(9999)).global_index);
-	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(9999);
+	i.code([u8.!(Opcode.GLOBAL_GET.code), index]).noargs().assert2_i(9999);
 
 	i.sig(SigCache.v_l);
 	index = byte.!(i.newImmGlobal(ValueType.I64, InitExpr.I64(777788889999)).global_index);
-	i.code([op8(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(777788889999);
+	i.code([u8.!(Opcode.GLOBAL_GET.code), index]).noargs().assert2_w(777788889999);
 }
 
 
 def test_i32_const(i: ExeTester) {
 	i.sig(SigCache.v_i);
-	i.code([op8(Opcode.I32_CONST.code), 1]).noargs().assert2_i(1);
-	i.code([op8(Opcode.I32_CONST.code), 33]).noargs().assert2_i(33);
-	i.code([op8(Opcode.I32_CONST.code), 0xA7, 0x7F]).noargs().assert2_i(-89);
-	i.code([op8(Opcode.I32_CONST.code), 0x70]).noargs().assert2_i(-16);
-	i.code([op8(Opcode.I32_CONST.code), 0xA7, 0xF0, 0xF1, 0xF2,
+	i.code([u8.!(Opcode.I32_CONST.code), 1]).noargs().assert2_i(1);
+	i.code([u8.!(Opcode.I32_CONST.code), 33]).noargs().assert2_i(33);
+	i.code([u8.!(Opcode.I32_CONST.code), 0xA7, 0x7F]).noargs().assert2_i(-89);
+	i.code([u8.!(Opcode.I32_CONST.code), 0x70]).noargs().assert2_i(-16);
+	i.code([u8.!(Opcode.I32_CONST.code), 0xA7, 0xF0, 0xF1, 0xF2,
 		0x7E]).noargs().assert2_u(3999037479u);
 }
 def test_i64_const(i: ExeTester) {
 	i.sig(SigCache.v_l);
-	i.code([op8(Opcode.I64_CONST.code), 1]).noargs().assert2_l(1);
-	i.code([op8(Opcode.I64_CONST.code), 33]).noargs().assert2_l(33);
-	i.code([op8(Opcode.I64_CONST.code), 0x70]).noargs().assert2_l(-16);
-	i.code([op8(Opcode.I64_CONST.code), 0x81, 0x82, 0x83, 0x84,
+	i.code([u8.!(Opcode.I64_CONST.code), 1]).noargs().assert2_l(1);
+	i.code([u8.!(Opcode.I64_CONST.code), 33]).noargs().assert2_l(33);
+	i.code([u8.!(Opcode.I64_CONST.code), 0x70]).noargs().assert2_l(-16);
+	i.code([u8.!(Opcode.I64_CONST.code), 0x81, 0x82, 0x83, 0x84,
 		0x85, 0x86, 0x87, 0x88, 0x09]).noargs().assert2_w(653052939803345153);
 
 	var inputs: Array<long> = [
@@ -1687,7 +1685,7 @@ def test_i64_const(i: ExeTester) {
 	];
 	var w = DataWriter.new();
 	for (v in inputs) {
-		w.putb(op8(Opcode.I64_CONST.code));
+		w.putb(u8.!(Opcode.I64_CONST.code));
 		w.put_sleb64(v);
 		i.code(w.extract());
 		i.noargs().assert2_w(u64.view(v));
@@ -1695,35 +1693,35 @@ def test_i64_const(i: ExeTester) {
 }
 def test_f32_const(i: ExeTester) {
 	i.sig(SigCache.v_f);
-	i.code([op8(Opcode.F32_CONST.code), 0x44, 0x33, 0x22, 0x11]).noargs().assert2_f(0x11223344);
-	i.code([op8(Opcode.F32_CONST.code), 0x66, 0x77, 0x88, 0x99]).noargs().assert2_f(0x99887766);
-	i.code([op8(Opcode.F32_CONST.code), 0x11, 0x00, 0x00, 0x00]).noargs().assert2_f(0x00000011);
-	i.code([op8(Opcode.F32_CONST.code), 0x00, 0x00, 0x00, 0x22]).noargs().assert2_f(0x22000000);
-	i.code([op8(Opcode.F32_CONST.code), 0xF1, 0xFF, 0xFF, 0xFF]).noargs().assert2_f(0xFFFFFFF1);
+	i.code([u8.!(Opcode.F32_CONST.code), 0x44, 0x33, 0x22, 0x11]).noargs().assert2_f(0x11223344);
+	i.code([u8.!(Opcode.F32_CONST.code), 0x66, 0x77, 0x88, 0x99]).noargs().assert2_f(0x99887766);
+	i.code([u8.!(Opcode.F32_CONST.code), 0x11, 0x00, 0x00, 0x00]).noargs().assert2_f(0x00000011);
+	i.code([u8.!(Opcode.F32_CONST.code), 0x00, 0x00, 0x00, 0x22]).noargs().assert2_f(0x22000000);
+	i.code([u8.!(Opcode.F32_CONST.code), 0xF1, 0xFF, 0xFF, 0xFF]).noargs().assert2_f(0xFFFFFFF1);
 }
 
 def test_f64_const(i: ExeTester) {
 	i.sig(SigCache.v_d);
-	i.code([op8(Opcode.F64_CONST.code), 0x44, 0x33, 0x22, 0x11, 0, 0, 0, 0]).noargs().assert2_d(0x11223344);
-	i.code([op8(Opcode.F64_CONST.code), 0x66, 0x77, 0x88, 0x99, 0, 0, 0, 0]).noargs().assert2_d(0x99887766);
-	i.code([op8(Opcode.F64_CONST.code), 0x11, 0x00, 0x00, 0x00, 0, 0, 0, 0]).noargs().assert2_d(0x00000011);
-	i.code([op8(Opcode.F64_CONST.code), 0x00, 0x00, 0x00, 0x22, 0, 0, 0, 0]).noargs().assert2_d(0x22000000);
-	i.code([op8(Opcode.F64_CONST.code), 0xF1, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0]).noargs().assert2_d(0xFFFFFFF1);
+	i.code([u8.!(Opcode.F64_CONST.code), 0x44, 0x33, 0x22, 0x11, 0, 0, 0, 0]).noargs().assert2_d(0x11223344);
+	i.code([u8.!(Opcode.F64_CONST.code), 0x66, 0x77, 0x88, 0x99, 0, 0, 0, 0]).noargs().assert2_d(0x99887766);
+	i.code([u8.!(Opcode.F64_CONST.code), 0x11, 0x00, 0x00, 0x00, 0, 0, 0, 0]).noargs().assert2_d(0x00000011);
+	i.code([u8.!(Opcode.F64_CONST.code), 0x00, 0x00, 0x00, 0x22, 0, 0, 0, 0]).noargs().assert2_d(0x22000000);
+	i.code([u8.!(Opcode.F64_CONST.code), 0xF1, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0]).noargs().assert2_d(0xFFFFFFF1);
 
-	i.code([op8(Opcode.F64_CONST.code), 1, 0x44, 0x33, 0x22, 0x11, 0, 0, 0]).noargs().assert2_d(0x00000011_22334401);
-	i.code([op8(Opcode.F64_CONST.code), 2, 3, 0x66, 0x77, 0x88, 0x99, 0, 0]).noargs().assert2_d(0x00009988_77660302);
-	i.code([op8(Opcode.F64_CONST.code), 4, 5, 6, 0x11, 0x00, 0x00, 0x00, 0]).noargs().assert2_d(0x00000000_11060504);
-	i.code([op8(Opcode.F64_CONST.code), 7, 8, 9, 1, 0x00, 0x00, 0x00, 0x22]).noargs().assert2_d(0x22000000_01090807);
+	i.code([u8.!(Opcode.F64_CONST.code), 1, 0x44, 0x33, 0x22, 0x11, 0, 0, 0]).noargs().assert2_d(0x00000011_22334401);
+	i.code([u8.!(Opcode.F64_CONST.code), 2, 3, 0x66, 0x77, 0x88, 0x99, 0, 0]).noargs().assert2_d(0x00009988_77660302);
+	i.code([u8.!(Opcode.F64_CONST.code), 4, 5, 6, 0x11, 0x00, 0x00, 0x00, 0]).noargs().assert2_d(0x00000000_11060504);
+	i.code([u8.!(Opcode.F64_CONST.code), 7, 8, 9, 1, 0x00, 0x00, 0x00, 0x22]).noargs().assert2_d(0x22000000_01090807);
 
 }
 
 def test_v128_const(i: ExeTester) {
 	i.sig(SigCache.v_s);
-	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code),0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00])
+	i.code([Opcode.V128_CONST.prefix, u8.!(Opcode.V128_CONST.code),0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00])
 		.noargs().assert2_s(0x00000000_00000000, 0x00000000_00000000);
-	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code),0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x10])
+	i.code([Opcode.V128_CONST.prefix, u8.!(Opcode.V128_CONST.code),0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x10])
 		.noargs().assert2_s(0x08070605_04030201, 0x100F0E0D_0C0B0A09);
-	i.code([Opcode.V128_CONST.prefix, op8(Opcode.V128_CONST.code),0x10,0x20,0x30,0x40,0x50,0x60,0x70,0x80,0x90,0xA0,0xB0,0xC0,0xD0,0xE0,0xF0,0x01])
+	i.code([Opcode.V128_CONST.prefix, u8.!(Opcode.V128_CONST.code),0x10,0x20,0x30,0x40,0x50,0x60,0x70,0x80,0x90,0xA0,0xB0,0xC0,0xD0,0xE0,0xF0,0x01])
 		.noargs().assert2_s(0x80706050_40302010, 0x01F0E0D0_C0B0A090);
 }
 
@@ -1731,29 +1729,29 @@ def test_load8(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.addMemory(1, Max.Set(1));
 	i.addData(4, [0xF0, 0xF1]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD8_U.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD8_U.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(3).assert2_i(0);
 	i.args_i(4).assert2_i(0xF0);
 	i.args_i(5).assert2_i(0xF1);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD8_S.code), 0, 2]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD8_S.code), 0, 2]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(0);
 	i.args_i(2).assert2_i(0xFFFFFFF0);
 	i.args_i(3).assert2_i(0xFFFFFFF1);
 
 	i.sig(SigCache.i_l);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD8_U.code), 0, 1]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD8_U.code), 0, 1]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(3).assert2_l(0xF0);
 	i.args_i(4).assert2_l(0xF1);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD8_S.code), 0, 3]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD8_S.code), 0, 3]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(1).assert2_l(0xFFFFFFFFFFFFFFF0);
 	i.args_i(2).assert2_l(0xFFFFFFFFFFFFFFF1);
@@ -1762,29 +1760,29 @@ def test_load16(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.addMemory(1, Max.Set(1));
 	i.addData(8, [0xF2, 0xF3, 0xCC, 0xDD]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD16_U.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD16_U.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(3).assert2_i(0);
 	i.args_i(8).assert2_i(0xF3F2);
 	i.args_i(9).assert2_i(0xCCF3);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD16_S.code), 0, 2]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD16_S.code), 0, 2]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(4).assert2_i(0);
 	i.args_i(6).assert2_i(0xFFFFF3F2);
 	i.args_i(7).assert2_i(0xFFFFCCF3);
 
 	i.sig(SigCache.i_l);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD16_U.code), 0, 1]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD16_U.code), 0, 1]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(7).assert2_l(0xF3F2);
 	i.args_i(9).assert2_l(0xDDCC);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD16_S.code), 0, 3]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD16_S.code), 0, 3]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(5).assert2_l(0xFFFFFFFFFFFFF3F2);
 	i.args_i(7).assert2_l(0xFFFFFFFFFFFFDDCC);
@@ -1793,26 +1791,26 @@ def test_load32(i: ExeTester) {
 	i.sig(SigCache.i_i);
 	i.addMemory(1, Max.Set(1));
 	i.addData(10, [0xF5, 0xF6, 0xAA, 0xBB, 0xCC, 0xDD]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(6).assert2_i(0);
 	i.args_i(10).assert2_i(0xBBAAF6F5);
 	i.args_i(12).assert2_i(0xDDCCBBAA);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD.code), 0, 8]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD.code), 0, 8]);
 	i.args_i(0).assert2_i(0xF6F50000);
 	i.args_i(6).assert2_i(0x0000DDCC);
 
 	i.sig(SigCache.i_l);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD32_U.code), 0, 1]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD32_U.code), 0, 1]);
 	i.args_i(0).assert2_w(0);
 	i.args_i(8).assert2_w(0xAAF6F500);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD32_S.code), 0, 3]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD32_S.code), 0, 3]);
 	i.args_i(0).assert2_w(0);
 	i.args_i(7).assert2_w(0xFFFFFFFFBBAAF6F5);
 	i.args_i(9).assert2_w(0xFFFFFFFFDDCCBBAA);
@@ -1821,8 +1819,8 @@ def test_load64(i: ExeTester) {
 	i.sig(SigCache.i_l);
 	i.addMemory(1, Max.Set(1));
 	i.addData(12, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I64_LOAD.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I64_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_l(0);
 	i.args_i(3).assert2_l(0);
 	i.args_i(12).assert2_l(0x8877665544332211);
@@ -1831,15 +1829,15 @@ def test_load64(i: ExeTester) {
 def test_load_oob0(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_u(0).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
 }
 def test_load_oob1(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(65532).assert2_i(0);
 	i.args_u(65533).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
@@ -1848,9 +1846,9 @@ def test_store8(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig0(SigCache.arr_i, SigCache.arr_v);
 	i.addData(5, [0x99, 0x88, 0x77]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 3,
-		op8(Opcode.I32_STORE8.code), 0, 2]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 3,
+		u8.!(Opcode.I32_STORE8.code), 0, 2]);
 	i.args_u(3).assert2_mem(4, [0,    3, 0x88, 0x77, 0]);
 	i.args_u(4).assert2_mem(4, [0, 0x99,    3, 0x77, 0]);
 	i.args_u(5).assert2_mem(4, [0, 0x99, 0x88,    3, 0]);
@@ -1860,9 +1858,9 @@ def test_store16(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_v);
 	i.addData(11, [0x99, 0x88, 0x77]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 0x83, 0x08,
-		op8(Opcode.I32_STORE16.code), 0, 7]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 0x83, 0x08,
+		u8.!(Opcode.I32_STORE16.code), 0, 7]);
 	i.args_u(4).assert2_mem(10, [0,    3,    4, 0x77, 0, 0]);
 	i.args_u(5).assert2_mem(10, [0, 0x99,    3,    4, 0, 0]);
 	i.args_u(6).assert2_mem(10, [0, 0x99, 0x88,    3, 4, 0]);
@@ -1872,9 +1870,9 @@ def test_store32(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_v);
 	i.addData(19, [0x99, 0x88, 0x77, 0x66, 0x55]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 0x91, 0xC4, 0xCC, 0xA1, 0x04,
-		op8(Opcode.I32_STORE.code), 0, 9]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 0x91, 0xC4, 0xCC, 0xA1, 0x04,
+		u8.!(Opcode.I32_STORE.code), 0, 9]);
 	i.args_u(10).assert2_mem(18, [0, 0x11, 0x22, 0x33, 0x44, 0x55, 0, 0]);
 	i.args_u(11).assert2_mem(18, [0, 0x99, 0x11, 0x22, 0x33, 0x44, 0, 0]);
 	i.args_u(12).assert2_mem(18, [0, 0x99, 0x88, 0x11, 0x22, 0x33, 0x44, 0]);
@@ -1883,28 +1881,28 @@ def test_store64(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig0([ValueType.I32, ValueType.I64], SigCache.arr_v);
 	i.addData(33, [0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I64_STORE.code), 0, 22]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I64_STORE.code), 0, 22]);
 	i.argsN([Value.I32(12), Value.I64(0x0807060504030201)]).assert2_mem(32, [0, 0x99, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
 	i.argsN([Value.I32(14), Value.I64(0xA8B7C6D5E4F30201)]).assert2_mem(32, [0, 0x99, 0x88, 0x77, 0x01, 0x02, 0xF3, 0xE4, 0xD5, 0xC6, 0xB7, 0xA8]);
 }
 def test_store_oob0(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.I32_STORE.code), 0, 0,
-		op8(Opcode.I32_CONST.code), 3]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.I32_STORE.code), 0, 0,
+		u8.!(Opcode.I32_CONST.code), 3]);
 	i.args_u(0).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
 }
 def test_store_oob1(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 5,
-		op8(Opcode.I32_STORE.code), 0, 0,
-		op8(Opcode.I32_CONST.code), 42]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 5,
+		u8.!(Opcode.I32_STORE.code), 0, 0,
+		u8.!(Opcode.I32_CONST.code), 42]);
 	i.args_i(0).assert2_i(42);
 	i.args_i(65532).assert2_i(42);
 	i.args_u(65533).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
@@ -1912,28 +1910,28 @@ def test_store_oob1(i: ExeTester) {
 def test_memory_size(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.v_i);
-	i.code([op8(Opcode.MEMORY_SIZE.code), 0]);
+	i.code([u8.!(Opcode.MEMORY_SIZE.code), 0]);
 	i.noargs().assert2_i(0);
 
 	i.addMemory(2, Max.Set(2));
 	i.sig(SigCache.v_i);
-	i.code([op8(Opcode.MEMORY_SIZE.code), 1]);
+	i.code([u8.!(Opcode.MEMORY_SIZE.code), 1]);
 	i.noargs().assert2_i(2);
 }
 def test_memory_grow1(i: ExeTester) {
 	i.addMemory(0, Max.Set(5));
 	i.sig(SigCache.i_i);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(0);
 	i.args_i(5).assert2_i(0);
 	i.args_i(6).assert2_i(0xFFFFFFFF);
 
 	i.addMemory(1, Max.Set(2));
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 1]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 1]);
 	i.args_i(0).assert2_i(1);
 	i.args_i(1).assert2_i(1);
 	i.args_i(2).assert2_i(0xFFFFFFFF);
@@ -1943,8 +1941,8 @@ def test_memory_grow2(i: ExeTester) {
 	i.addMemory(0, Max.None);
 	i.sig(SigCache.i_i);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.MEMORY_GROW.code), 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.MEMORY_GROW.code), 0]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(0);
 	i.args_u(Target.limit_memory_pages + 1).assert2_i(0xFFFFFFFF);
@@ -1952,14 +1950,14 @@ def test_memory_grow2(i: ExeTester) {
 
 def test_sign_ext(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_EXTEND8_S.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I32_EXTEND8_S.code)]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(1);
 	i.args_i(127).assert2_i(127);
 	i.args_i(0x80).assert2_i(0xFFFFFF80);
 	i.args_i(0x100).assert2_i(0);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_EXTEND16_S.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I32_EXTEND16_S.code)]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(1).assert2_i(1);
 	i.args_i(127).assert2_i(127);
@@ -1968,14 +1966,14 @@ def test_sign_ext(i: ExeTester) {
 	i.args_i(0x10000).assert2_i(0);
 
 	i.sig(SigCache.l_l);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_EXTEND8_S.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I64_EXTEND8_S.code)]);
 	i.args_l(0).assert2_l(0);
 	i.args_l(1).assert2_l(1);
 	i.args_l(127).assert2_l(127);
 	i.args_l(0x87).assert2_l(0xFFFFFFFFFFFFFF87);
 	i.args_l(0x300).assert2_l(0);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_EXTEND16_S.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I64_EXTEND16_S.code)]);
 	i.args_l(0).assert2_l(0);
 	i.args_l(1).assert2_l(1);
 	i.args_l(0x7FFF).assert2_l(0x7FFF);
@@ -1983,7 +1981,7 @@ def test_sign_ext(i: ExeTester) {
 	i.args_l(0x8720).assert2_l(0xFFFFFFFFFFFF8720);
 	i.args_l(0x50000).assert2_l(0);
 
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_EXTEND32_S.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I64_EXTEND32_S.code)]);
 	i.args_l(0).assert2_l(0);
 	i.args_l(1).assert2_l(1);
 	i.args_l(0x7FFF).assert2_l(0x7FFF);
@@ -1995,41 +1993,41 @@ def test_sign_ext(i: ExeTester) {
 def test_reinterpret(i: ExeTester) {
 	for (bits in [0x11223344u, 0x55662233u]) {
 		i.sig(SigCache.f_i);
-		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I32_REINTERPRET_F32.code)]);
+		i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I32_REINTERPRET_F32.code)]);
 		i.args_f(bits).assert2_u(bits);
 
 		i.sig(SigCache.i_f);
-		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.F32_REINTERPRET_I32.code)]);
+		i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.F32_REINTERPRET_I32.code)]);
 		i.args_u(bits).assert2_f(bits);
 	}
 	for (bits in [0x1122334455667788u, 0x5566223344117799u]) {
 		i.sig(SigCache.d_l);
-		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.I64_REINTERPRET_F64.code)]);
+		i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.I64_REINTERPRET_F64.code)]);
 		i.args_d(bits).assert2_w(bits);
 
 		i.sig(SigCache.l_d);
-		i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.F64_REINTERPRET_I64.code)]);
+		i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.F64_REINTERPRET_I64.code)]);
 		i.args_w(bits).assert2_d(bits);
 	}
 }
 
 def test_invalid(i: ExeTester) {
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, 0xFF]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, 0xFF]);
 	i.args_u(33).assert2_trap(TrapReason.INVALID_OPCODE);
 
 	for (page in Opcodes.code_pages) {
 		if (page.prefix == 0xFD) continue; // TODO: SIMD space fully filled?
-		i.code([op8(Opcode.LOCAL_GET.code), 0, page.prefix, 0x7F]);
+		i.code([u8.!(Opcode.LOCAL_GET.code), 0, page.prefix, 0x7F]);
 		i.args_u(37).assert2_trap(TrapReason.INVALID_OPCODE);
 	}
 }
 
 def test_extleb(i: ExeTester) {
 	i.sig(SigCache.f_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.I32_TRUNC_SAT_F32_S.prefix,
-		op8(Opcode.I32_TRUNC_SAT_F32_S.code) | byte.!(0x80u), // manually extended LEB
+		u8.!(Opcode.I32_TRUNC_SAT_F32_S.code) | byte.!(0x80u), // manually extended LEB
 		0]);
 	i.args_f(Floats.f_1p31).assert2_i(i32.max);
 }
@@ -2045,48 +2043,48 @@ def test_ref_default(i: ExeTester) {
 	for (t in [ValueTypes.ANYREF, ValueTypes.I31REF, ValueTypes.FUNCREF, ValueTypes.EXTERNREF]) {
 		i.sig(newSig(SigCache.arr_v, [t]));
 		i.addLocal(t);
-		i.code([op8(Opcode.LOCAL_GET.code), 0]);
+		i.code([u8.!(Opcode.LOCAL_GET.code), 0]);
 		i.noargs().assert2_r(null);
 	}
 }
 
 def test_ref_null_extern(i: ExeTester) {
 	i.sig(SigCache.v_e);
-	i.code([op8(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code]);
+	i.code([u8.!(Opcode.REF_NULL.code), BpTypeCode.EXTERNREF.code]);
 	i.noargs().assert2_r(null);
 }
 
 def test_ref_null_func(i: ExeTester) {
 	i.sig(SigCache.v_g);
-	i.code([op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code]);
+	i.code([u8.!(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code]);
 	i.noargs().assert2_r(null);
 }
 
 def test_ref_is_null(i: ExeTester) {
 	// externs
 	i.sig(SigCache.e_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.REF_IS_NULL.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.REF_IS_NULL.code)]);
 	i.args_r(null).assert2_i(1);
 	i.args_r(null).assert2_i(1);
 	i.args_r(HostObject.new()).assert2_i(0);
 	// funcs
 	i.sig(SigCache.g_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.REF_IS_NULL.code)]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.REF_IS_NULL.code)]);
 	i.args_r(null).assert2_i(1);
 	i.args_r(Function.new(SigCache.i_i)).assert2_i(0);
 }
 
 def test_ref_func(i: ExeTester) {
 	i.sig(SigCache.v_g);
-	i.code([op8(Opcode.REF_FUNC.code), 0]);
+	i.code([u8.!(Opcode.REF_FUNC.code), 0]);
 	i.noargs().assert2_func(0);
 }
 
 def test_ref_as_non_null(i: ExeTester) {
 	i.sig(SigCache.r_r);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.REF_AS_NON_NULL.code)]);
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.REF_AS_NON_NULL.code)]);
 	i.args_r(null).assert2_trap(TrapReason.NULL_DEREF);
 	var f = Function.new(SigCache.i_i);
 	i.args_r(f).assert2_r(f);
@@ -2097,10 +2095,10 @@ def test_memory_init(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.addPassiveData([11, 22, 33, 44, 55]);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.MEMORY_INIT.prefix, u8.!(Opcode.MEMORY_INIT.code), 0, 0
 	]);
 	i.args_uuu(0, 0, 5).assert2_mem(0, [11, 22, 33, 44, 55]);
 	i.args_uuu(0, 1, 3).assert2_mem(0, [22, 33, 44, 0]);
@@ -2118,7 +2116,7 @@ def test_data_drop(i: ExeTester) {
 	i.sig(SigCache.v_v);
 	i.addMemory(1, Max.Set(1));
 	i.addData(0, [0]);
-	i.code([Opcode.DATA_DROP.prefix, op8(Opcode.DATA_DROP.code), 0]);
+	i.code([Opcode.DATA_DROP.prefix, u8.!(Opcode.DATA_DROP.code), 0]);
 	var t = i.run(X), instance = t.0;
 	if (instance.dropped_data[0] != true) i.t.fail("expected dropped data[0]");
 }
@@ -2128,7 +2126,7 @@ def test_memory_copy(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	var init: Array<byte> = [33, 44, 55];
 	i.addData(3, init);
-	i.code([Opcode.MEMORY_COPY.prefix, op8(Opcode.MEMORY_COPY.code), 0, 0]);
+	i.code([Opcode.MEMORY_COPY.prefix, u8.!(Opcode.MEMORY_COPY.code), 0, 0]);
 	i.args_uuu(0, 0, 0).assert2_mem(3, init);
 	i.args_uuu(0, 2, 5).assert2_mem(0, [0, 33, 44, 55, 0, 55, 0]);
 	i.args_uuu(7, 3, 3).assert2_mem(0, [0, 0, 0, 33, 44, 55, 0, 33, 44, 55]);
@@ -2146,7 +2144,7 @@ def test_memory_copy(i: ExeTester) {
 def test_memory_fill(i: ExeTester) {
 	i.sig(SigCache.iii_v);
 	i.addMemory(1, Max.Set(1));
-	i.code([Opcode.MEMORY_FILL.prefix, op8(Opcode.MEMORY_FILL.code), 0]);
+	i.code([Opcode.MEMORY_FILL.prefix, u8.!(Opcode.MEMORY_FILL.code), 0]);
 	i.args_uuu(0, 0, 0).assert2_mem(0, [0]);
 	i.args_uuu(3, 77, 2).assert2_mem(0, [0, 0, 0, 77, 77, 0]);
 	i.args_uuu(4, 99, 4).assert2_mem(0, [0, 0, 0, 0, 99, 99, 99, 99, 0]);
@@ -2167,10 +2165,10 @@ def test_table_init(i: ExeTester) {
 	i.addTable(6, 0, null);
 	i.addPassiveElems([f2.func_index, f3.func_index, f4.func_index, f5.func_index]);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.TABLE_INIT.prefix, op8(Opcode.TABLE_INIT.code), 0, 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_INIT.prefix, u8.!(Opcode.TABLE_INIT.code), 0, 0
 	]);
 	i.args_uuu(0, 0, 0).assert2_ftable(0, []);
 	i.args_uuu(0, 0, 1).assert2_ftable(0, [f2]);
@@ -2184,7 +2182,7 @@ def test_table_init(i: ExeTester) {
 def test_elem_drop(i: ExeTester) {
 	i.sig(SigCache.v_v);
 	i.addTable(1, 0, [0]);
-	i.code([Opcode.ELEM_DROP.prefix, op8(Opcode.ELEM_DROP.code), 0]);
+	i.code([Opcode.ELEM_DROP.prefix, u8.!(Opcode.ELEM_DROP.code), 0]);
 	var t = i.run(X), instance = t.0;
 	if (instance.dropped_elems[0] != true) i.t.fail("expected dropped elems[0]");
 }
@@ -2194,7 +2192,7 @@ def test_table_get(i: ExeTester) {
 	var f3 = i.newFunction(SigCache.v_v, NO_CODE);
 	i.addTable(3, 0, [0, f2.func_index, f3.func_index]);
 	i.sig0(SigCache.arr_i, [ValueTypes.FUNCREF]);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.TABLE_GET.code), 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.TABLE_GET.code), 0]);
 	i.args_u(0).assert2_func(0);
 	i.args_u(1).assert2_func(f2.func_index);
 	i.args_u(2).assert2_func(f3.func_index);
@@ -2206,7 +2204,7 @@ def test_table_set(i: ExeTester) {
 	var f3 = i.newFunction(SigCache.v_v, NO_CODE);
 	i.addTable(3, 0, [0, f2.func_index, f3.func_index]);
 	i.sig0([ValueType.I32, ValueTypes.FUNCREF], SigCache.arr_v);
-	i.code([op8(Opcode.LOCAL_GET.code), 0, op8(Opcode.LOCAL_GET.code), 1, op8(Opcode.TABLE_SET.code), 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0, u8.!(Opcode.LOCAL_GET.code), 1, u8.!(Opcode.TABLE_SET.code), 0]);
 
 	var gv1 = Value.Ref(WasmFunction.new(null, f3));
 	var t = i.run([Value.I32(1), gv1]), instance = t.0;
@@ -2223,7 +2221,7 @@ def test_table_copy(i: ExeTester) {
 	i.addTable(3, 0, [0, f2.func_index, f3.func_index]);
 
 	i.sig(SigCache.iii_v);
-	i.code([Opcode.TABLE_COPY.prefix, op8(Opcode.TABLE_COPY.code), 0, 1]);
+	i.code([Opcode.TABLE_COPY.prefix, u8.!(Opcode.TABLE_COPY.code), 0, 1]);
 
 	i.args_uuu(0, 0, 1).assert2_ftable(0, [i.func, null, null]);
 	i.args_uuu(1, 2, 1).assert2_ftable(0, [null, f3, null]);
@@ -2243,9 +2241,9 @@ def test_table_grow1(i: ExeTester) {
 	i.addTableOfSize(3, Max.Set(5));
 	i.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_i);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.TABLE_GROW.prefix, u8.!(Opcode.TABLE_GROW.code), 0
 	]);
 	var n = Values.FUNCREF_NULL;
 	i.argsN([n, Value.I32(1)]).assert2_i(3);
@@ -2254,10 +2252,10 @@ def test_table_grow1(i: ExeTester) {
 
 	i.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_v);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0,
-		op8(Opcode.DROP.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.TABLE_GROW.prefix, u8.!(Opcode.TABLE_GROW.code), 0,
+		u8.!(Opcode.DROP.code)
 	]);
 	var fv = Value.Ref(WasmFunction.new(null, i.func));
 	i.argsN([fv, Value.I32(1)]).assert2_ftable(0, [null, null, null, i.func]);
@@ -2268,9 +2266,9 @@ def test_table_grow2(i: ExeTester) {
 	i.addTableOfSize(3, Max.None);
 	i.sig0([ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_i);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.TABLE_GROW.prefix, op8(Opcode.TABLE_GROW.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.TABLE_GROW.prefix, u8.!(Opcode.TABLE_GROW.code), 0
 	]);
 	var n = Values.FUNCREF_NULL;
 	i.argsN([n, Value.I32(GlobalLimits.limit_table_size + 1)]).assert2_i(0xFFFFFFFF);
@@ -2279,7 +2277,7 @@ def test_table_grow2(i: ExeTester) {
 def test_table_size(i: ExeTester) {
 	i.addTable(3, 0, [0, 0, 0]);
 	i.sig(SigCache.v_i);
-	i.code([Opcode.TABLE_SIZE.prefix, op8(Opcode.TABLE_SIZE.code), 0]);
+	i.code([Opcode.TABLE_SIZE.prefix, u8.!(Opcode.TABLE_SIZE.code), 0]);
 	i.noargs().assert2_i(3);
 }
 
@@ -2291,10 +2289,10 @@ def test_table_fill(i: ExeTester) {
 	i.sig(newSig([ValueType.I32, ValueTypes.FUNCREF, ValueType.I32], SigCache.arr_v));
 	i.addTable(6, 0, []);
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.TABLE_FILL.prefix, op8(Opcode.TABLE_FILL.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.TABLE_FILL.prefix, u8.!(Opcode.TABLE_FILL.code), 0
 	]);
 	var f1 = Value.Ref(WasmFunction.new(null, i.func));
 	i.argsN(uvu(0, f1, 0)).assert2_ftable(0, [null]);
@@ -2330,9 +2328,9 @@ def test_struct_new(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0(SigCache.arr_i, [ValueTypes.RefStruct(false, st)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
 		Opcode.STRUCT_NEW.prefix,
-		op8(Opcode.STRUCT_NEW.code),
+		u8.!(Opcode.STRUCT_NEW.code),
 		heapIndexByte(st)
 	]);
 	for (i in [666u, 777u, 0x88776655u]) {
@@ -2351,7 +2349,7 @@ def test_struct_new_default(t: ExeTester) {
 	t.sig0(SigCache.arr_v, [ValueTypes.RefStruct(false, st)]);
 	t.codev([
 		Opcode.STRUCT_NEW_DEFAULT.prefix,
-		op8(Opcode.STRUCT_NEW_DEFAULT.code),
+		u8.!(Opcode.STRUCT_NEW_DEFAULT.code),
 		heapIndexByte(st)
 	]);
 	var rtt = (st);
@@ -2371,8 +2369,8 @@ def test_struct_get(t: ExeTester) {
 	var obj = HeapStruct.new(st, array_uuu(99, 98, 97));
 	for (f < st.field_types.length) {
 		t.codev([
-			op8(Opcode.LOCAL_GET.code), 0,
-			Opcode.STRUCT_GET.prefix, op8(Opcode.STRUCT_GET.code),
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			Opcode.STRUCT_GET.prefix, u8.!(Opcode.STRUCT_GET.code),
 			heapIndexByte(st), byte.view(f)
 		]);
 		for (i in [366u, 2777u, 0x18776655u]) {
@@ -2402,8 +2400,8 @@ def test_struct_get_su(t: ExeTester) {
 		var shift: u5 = if(f == 0, 24, 16);
 		for (opcode in [Opcode.STRUCT_GET_S, Opcode.STRUCT_GET_U]) {
 			t.codev([
-				op8(Opcode.LOCAL_GET.code), 0,
-				opcode.prefix, op8(opcode.code),
+				u8.!(Opcode.LOCAL_GET.code), 0,
+				opcode.prefix, u8.!(opcode.code),
 				heapIndexByte(st), byte.view(f)
 			]);
 			var expected = unpackI32(vals[f], st.field_types[f].pack, opcode == Opcode.STRUCT_GET_S);
@@ -2423,9 +2421,9 @@ def test_struct_set(t: ExeTester) {
 	var obj = HeapStruct.new(st, array_uuu(99, 98, 97));
 	for (f < st.field_types.length) {
 		t.codev([
-			op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.LOCAL_GET.code), 1,
-			Opcode.STRUCT_SET.prefix, op8(Opcode.STRUCT_SET.code),
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.LOCAL_GET.code), 1,
+			Opcode.STRUCT_SET.prefix, u8.!(Opcode.STRUCT_SET.code),
 			heapIndexByte(st), byte.view(f)
 		]);
 		for (i in [366u, 2777u, 0x18776655u]) {
@@ -2442,9 +2440,9 @@ def test_array_new(t: ExeTester) {
 	var at = t.newArray([I32_FIELD]);
 	t.sig0(SigCache.arr_i, [ValueTypes.RefArray(false, at)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ARRAY_NEW.prefix, op8(Opcode.ARRAY_NEW.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_NEW.prefix, u8.!(Opcode.ARRAY_NEW.code), heapIndexByte(at)
 	]);
 	for (i < 5u) {
 		var v = Value.I32(i);
@@ -2462,8 +2460,8 @@ def test_array_new_default(t: ExeTester) {
 	]);
 	t.sig0(SigCache.arr_i, [ValueTypes.RefArray(false, at)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ARRAY_NEW_DEFAULT.prefix, op8(Opcode.ARRAY_NEW_DEFAULT.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_NEW_DEFAULT.prefix, u8.!(Opcode.ARRAY_NEW_DEFAULT.code), heapIndexByte(at)
 	]);
 	var rtt = (at);
 	for (i < 5u) {
@@ -2481,9 +2479,9 @@ def test_array_get(t: ExeTester) {
 	]);
 	t.sig0([ValueTypes.RefArray(false, at), ValueType.I32], SigCache.arr_d);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		Opcode.ARRAY_GET.prefix, op8(Opcode.ARRAY_GET.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		Opcode.ARRAY_GET.prefix, u8.!(Opcode.ARRAY_GET.code), heapIndexByte(at)
 	]);
 	for (len < 5) {
 		var elems = Array<Value>.new(len);
@@ -2511,9 +2509,9 @@ def test_array_get_su(t: ExeTester) {
 		t.sig0([ValueTypes.RefArray(false, at), ValueType.I32], SigCache.arr_i);
 		for (opcode in [Opcode.ARRAY_GET_S, Opcode.ARRAY_GET_U]) {
 			t.codev([
-				op8(Opcode.LOCAL_GET.code), 0,
-				op8(Opcode.LOCAL_GET.code), 1,
-				opcode.prefix, op8(opcode.code), heapIndexByte(at)
+				u8.!(Opcode.LOCAL_GET.code), 0,
+				u8.!(Opcode.LOCAL_GET.code), 1,
+				opcode.prefix, u8.!(opcode.code), heapIndexByte(at)
 			]);
 			for (len < 5) {
 				var elems = Array<Value>.new(len);
@@ -2540,10 +2538,10 @@ def test_array_set(t: ExeTester) {
 	]);
 	t.sig0([ValueTypes.RefArray(false, at), ValueType.I32, ValueType.F64], SigCache.arr_v);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.ARRAY_SET.prefix, op8(Opcode.ARRAY_SET.code), heapIndexByte(at)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.ARRAY_SET.prefix, u8.!(Opcode.ARRAY_SET.code), heapIndexByte(at)
 	]);
 	var obj = HeapArray.new(at, [Value.F64(0x99999), Value.F64(55)]);
 	var ref = Value.Ref(obj);
@@ -2568,8 +2566,8 @@ def test_array_len(t: ExeTester) {
 	]);
 	t.sig0([ValueTypes.RefArray(false, at)], SigCache.arr_i);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ARRAY_LEN.prefix, op8(Opcode.ARRAY_LEN.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ARRAY_LEN.prefix, u8.!(Opcode.ARRAY_LEN.code)
 	]);
 	for (i < 5) {
 		var obj = Value.Ref(HeapArray.new(at, Array<Value>.new(i)));
@@ -2594,11 +2592,11 @@ def test_array_new_fixed(t: ExeTester) {
 	for (i < byte.view(5)) {
 		var v = Value.I64(9999999u + i);
 		for (j < i) {
-			code.put(op8(Opcode.LOCAL_GET.code)).put(j);
+			code.put(u8.!(Opcode.LOCAL_GET.code)).put(j);
 			params.put(ValueType.I64);
 			args.put(v);
 		}
-		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, op8(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), i]);
+		code.puta([Opcode.ARRAY_NEW_FIXED.prefix, u8.!(Opcode.ARRAY_NEW_FIXED.code), heapIndexByte(at), i]);
 		var expected = args.copy();
 
 		t.sig0(params.extract(), results);
@@ -2612,8 +2610,8 @@ def test_ref_i31(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0(SigCache.arr_i, [ValueTypes.I31REF]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_I31.prefix, op8(Opcode.REF_I31.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_I31.prefix, u8.!(Opcode.REF_I31.code)
 	]);
 	for (v in [0x8u, 0x99u, 0x12345678u, 0x87654321u]) {
 		t.args_u(v).assert2_val(Value.I31(u31.view(v)));
@@ -2624,8 +2622,8 @@ def test_i31_get_s(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0([ValueTypes.I31REF], SigCache.arr_i);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.I31_GET_S.prefix, op8(Opcode.I31_GET_S.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.I31_GET_S.prefix, u8.!(Opcode.I31_GET_S.code)
 	]);
 	for (v in [0x8u, 0x99u, 0x12345678u, 0x80000000u, 0xF7654321u]) {
 		var ext = (i32.view(v) << 1) >> 1;
@@ -2639,8 +2637,8 @@ def test_i31_get_u(t: ExeTester) {
 	t.extensions |= Extension.GC;
 	t.sig0([ValueTypes.I31REF], SigCache.arr_i);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.I31_GET_U.prefix, op8(Opcode.I31_GET_U.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.I31_GET_U.prefix, u8.!(Opcode.I31_GET_U.code)
 	]);
 	for (v in [0x8u, 0x99u, 0x12345678u, 0x80000000u, 0xF7654321u]) {
 		var ext = (u32.view(v) << 1) >> 1;
@@ -2665,8 +2663,8 @@ def test_ref_test(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], SigCache.arr_i);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_TEST.prefix, op8(Opcode.REF_TEST.code),
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_TEST.prefix, u8.!(Opcode.REF_TEST.code),
 		heapIndexByte(x.st1)
 	]);
 
@@ -2680,8 +2678,8 @@ def test_ref_test_null(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], SigCache.arr_i);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_TEST_NULL.prefix, op8(Opcode.REF_TEST_NULL.code),
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_TEST_NULL.prefix, u8.!(Opcode.REF_TEST_NULL.code),
 		heapIndexByte(x.st1)
 	]);
 
@@ -2695,8 +2693,8 @@ def test_ref_cast(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], [ValueTypes.RefStruct(false, x.st2)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_CAST.prefix, op8(Opcode.REF_CAST.code), heapIndexByte(x.st2)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_CAST.prefix, u8.!(Opcode.REF_CAST.code), heapIndexByte(x.st2)
 	]);
 
 	var fail = TrapReason.FAILED_CAST;
@@ -2711,8 +2709,8 @@ def test_ref_cast_null(t: ExeTester) {
 	var x = RttTestVals.new(t);
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], [ValueTypes.RefStruct(true, x.st2)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.REF_CAST_NULL.prefix, op8(Opcode.REF_CAST_NULL.code), heapIndexByte(x.st2)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.REF_CAST_NULL.prefix, u8.!(Opcode.REF_CAST_NULL.code), heapIndexByte(x.st2)
 	]);
 
 	var fail = TrapReason.FAILED_CAST;
@@ -2731,9 +2729,9 @@ def test_br_on_cast(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], [ValueTypes.RefStruct(false, x.st2)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), NULL1, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, u8.!(Opcode.BR_ON_CAST.code), NULL1, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(x.o2a).assert2_r(x.o2a);
@@ -2748,9 +2746,9 @@ def test_br_on_cast_null(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], [ValueTypes.RefStruct(true, x.st2)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST.code), NULL1 | NULL2, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, u8.!(Opcode.BR_ON_CAST.code), NULL1 | NULL2, 0, BpHeapTypeCode.ANY.code, heapIndexByte(x.st2),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(null).assert2_r(null);
@@ -2765,9 +2763,9 @@ def test_br_on_cast_fail(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(false, x.st1)], [ValueTypes.RefStruct(false, x.st1)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, u8.!(Opcode.BR_ON_CAST_FAIL.code), NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(null).assert2_trap(TrapReason.UNREACHABLE);
@@ -2782,9 +2780,9 @@ def test_br_on_cast_fail_null(t: ExeTester) {
 
 	t.sig0([ValueTypes.RefStruct(true, x.st1)], [ValueTypes.RefStruct(true, x.st1)]);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.BR_ON_CAST.prefix, op8(Opcode.BR_ON_CAST_FAIL.code), NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.BR_ON_CAST.prefix, u8.!(Opcode.BR_ON_CAST_FAIL.code), NULL1 | NULL2, 0, heapIndexByte(x.st1), heapIndexByte(x.st2),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	var fail = TrapReason.UNREACHABLE;
 	t.args_r(null).assert2_trap(fail);
@@ -2798,10 +2796,10 @@ def test_br_on_null(t: ExeTester) {
 
 	t.sig(SigCache.r_i);
 	t.codev([
-		op8(Opcode.I32_CONST.code), 11,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_ON_NULL.code), 0,
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.I32_CONST.code), 11,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_ON_NULL.code), 0,
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 
 	t.args_r(null).assert2_i(11);
@@ -2814,9 +2812,9 @@ def test_br_on_non_null(t: ExeTester) {
 
 	t.sig(SigCache.r_r);
 	t.codev([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.BR_ON_NON_NULL.code), 0,
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.BR_ON_NON_NULL.code), 0,
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 
 	t.args_r(null).assert2_trap(TrapReason.UNREACHABLE);
@@ -2830,9 +2828,9 @@ def test_ref_eq(t: ExeTester) {
 
 	t.sig(SigCache.rr_i);
 	t.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.REF_EQ.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.REF_EQ.code)
 	]);
 
 	var nil = Values.REF_NULL, obj1 = Value.Ref(HostObject.new()), obj2 = Value.Ref(HostObject.new());
@@ -2854,8 +2852,8 @@ def test_internalize(i: ExeTester) {
 	i.extensions |= Extension.GC;
 	i.sig(newSig([ValueTypes.EXTERNREF], [ValueTypes.ANYREF]));
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ANY_CONVERT_EXTERN.prefix, op8(Opcode.ANY_CONVERT_EXTERN.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ANY_CONVERT_EXTERN.prefix, u8.!(Opcode.ANY_CONVERT_EXTERN.code)
 	]);
 	i.args_r(null).assert2_r(null);
 	var hobj = HostObject.new();
@@ -2866,8 +2864,8 @@ def test_externalize(i: ExeTester) {
 	i.extensions |= Extension.GC;
 	i.sig(newSig([ValueTypes.ANYREF], [ValueTypes.EXTERNREF]));
 	i.code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		Opcode.ANY_CONVERT_EXTERN.prefix, op8(Opcode.ANY_CONVERT_EXTERN.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		Opcode.ANY_CONVERT_EXTERN.prefix, u8.!(Opcode.ANY_CONVERT_EXTERN.code)
 	]);
 	i.args_r(null).assert2_r(null);
 	var hostref = Value.Ref(HostObject.new());
@@ -2882,9 +2880,9 @@ def test_try_table0(i: ExeTester) {
 	i.extensions |= Extension.EXCEPTION_HANDLING;
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.TRY_TABLE.code), NONE, 0,
-		op8(Opcode.END.code),
-		op8(Opcode.LOCAL_GET.code), 0
+		u8.!(Opcode.TRY_TABLE.code), NONE, 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.LOCAL_GET.code), 0
 	]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(145555).assert2_i(145555);
@@ -2896,16 +2894,16 @@ def test_try_tableN(i: ExeTester) {
 	var code = Vector<byte>.new();
 	for (j = 1; j < 127; j = (j + 1) * 3) {
 		code.puta([
-			op8(Opcode.BLOCK.code), NONE,
-			op8(Opcode.TRY_TABLE.code), NONE, byte.view(j)
+			u8.!(Opcode.BLOCK.code), NONE,
+			u8.!(Opcode.TRY_TABLE.code), NONE, byte.view(j)
 		]);
 		for (k < j) {
 			code.put(BpCatchKind.CATCH_ALL.code).put(0);
 		}
 		code.puta([
-			op8(Opcode.END.code),
-			op8(Opcode.END.code),
-			op8(Opcode.LOCAL_GET.code), 0
+			u8.!(Opcode.END.code),
+			u8.!(Opcode.END.code),
+			u8.!(Opcode.LOCAL_GET.code), 0
 		]);
 		i.codev(code.extract());
 		i.args_i(0).assert2_i(0);
@@ -2917,9 +2915,9 @@ def test_try_tablei(i: ExeTester) {
 	i.extensions |= Extension.EXCEPTION_HANDLING;
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.TRY_TABLE.code), BpTypeCode.I32.code, 0,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.END.code)
+		u8.!(Opcode.TRY_TABLE.code), BpTypeCode.I32.code, 0,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.END.code)
 	]);
 	i.args_i(0).assert2_i(0);
 	i.args_i(3145566).assert2_i(3145566);
@@ -2929,16 +2927,16 @@ def test_try_table_if(i: ExeTester) {
 	i.extensions |= Extension.EXCEPTION_HANDLING;
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.BLOCK.code), NONE,
-		op8(Opcode.TRY_TABLE.code), NONE, 1, BpCatchKind.CATCH_ALL.code, 0,
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.IF.code), NONE,
-		op8(Opcode.I32_CONST.code), 11,
-		op8(Opcode.RETURN.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 22
+		u8.!(Opcode.BLOCK.code), NONE,
+		u8.!(Opcode.TRY_TABLE.code), NONE, 1, BpCatchKind.CATCH_ALL.code, 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.IF.code), NONE,
+		u8.!(Opcode.I32_CONST.code), 11,
+		u8.!(Opcode.RETURN.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 22
 	]);
 	i.args_i(0).assert2_i(22);
 	i.args_i(3145566).assert2_i(11);
@@ -2947,7 +2945,7 @@ def test_try_table_if(i: ExeTester) {
 def test_traplocs(i: ExeTester, offset: int, instrs: Array<byte>, reason: TrapReason) {
 	var code = Vector<byte>.new();
 	for (pc in [1, 2, 4, 13]) {
-		code.putn(op8(Opcode.NOP.code), pc - 1);
+		code.putn(u8.!(Opcode.NOP.code), pc - 1);
 		code.puta(instrs);
 		i.code(code.extract());
 		i.assert2_trap_at(reason, [pc + offset]); // arguments should be set by caller
@@ -2957,29 +2955,29 @@ def test_traplocs(i: ExeTester, offset: int, instrs: Array<byte>, reason: TrapRe
 def test_unreachable_traploc(i: ExeTester) {
 	var code = Vector<byte>.new();
 	for (pc in [1, 2, 3, 4, 5, 11, 17, 199, 701]) {
-		code.putn(op8(Opcode.NOP.code), pc - 1);
-		code.put(op8(Opcode.UNREACHABLE.code));
+		code.putn(u8.!(Opcode.NOP.code), pc - 1);
+		code.put(u8.!(Opcode.UNREACHABLE.code));
 		i.code(code.extract());
 		i.noargs().assert2_trap_at(TrapReason.UNREACHABLE, [pc]);
 	}
 }
 
 def test_call1_traploc(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_v, [op8(Opcode.UNREACHABLE.code)]).func_index);
-	i.code([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17]);
+	var f17 = byte.!(i.newFunction(SigCache.v_v, [u8.!(Opcode.UNREACHABLE.code)]).func_index);
+	i.code([u8.!(Opcode.I32_CONST.code), 17, u8.!(Opcode.CALL.code), f17]);
 	i.noargs().assert2_trap_at(TrapReason.UNREACHABLE, [3, 1]);
 }
 
 def test_call2_traploc(i: ExeTester) {
 	var buf = Vector<byte>.new();
 	for (j in [2, 3, 9]) {
-		buf.putn(op8(Opcode.NOP.code), j - 1);
-		buf.put(op8(Opcode.UNREACHABLE.code));
+		buf.putn(u8.!(Opcode.NOP.code), j - 1);
+		buf.put(u8.!(Opcode.UNREACHABLE.code));
 
 		var f17 = byte.!(i.newFunction(SigCache.v_v, buf.extract()).func_index);
 		for (k in [2, 6, 11]) {
-			buf.putn(op8(Opcode.NOP.code), k - 1);
-			buf.puta([op8(Opcode.I32_CONST.code), 17, op8(Opcode.CALL.code), f17]);
+			buf.putn(u8.!(Opcode.NOP.code), k - 1);
+			buf.puta([u8.!(Opcode.I32_CONST.code), 17, u8.!(Opcode.CALL.code), f17]);
 			i.code(buf.extract());
 			i.noargs().assert2_trap_at(TrapReason.UNREACHABLE, [2 + k, 0 + j]);
 		}
@@ -2989,8 +2987,8 @@ def test_call2_traploc(i: ExeTester) {
 def test_ref_as_non_null_traploc(i: ExeTester) {
 	i.sig(SigCache.r_r);
 	test_traplocs(i.args_r(null), 2, [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.REF_AS_NON_NULL.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.REF_AS_NON_NULL.code)
 	], TrapReason.NULL_DEREF);
 }
 
@@ -3029,21 +3027,21 @@ def test_load_oob0_traploc(i: ExeTester) {
 	i.sig(SigCache.i_i);
 
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD.code), 0, 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD.code), 0, 0
 	];
 	test_traplocs(i.args_u(0), 2, code, TrapReason.MEM_OUT_OF_BOUNDS);
 }
 
 def test_call_indirect_traploc(i: ExeTester) { // TODO: return_call_indirect, call_ref
 	i.sig(SigCache.ii_i);
-	var f1 = i.newFunction(SigCache.i_i, [op8(Opcode.I32_CONST.code), 11]);
+	var f1 = i.newFunction(SigCache.i_i, [u8.!(Opcode.I32_CONST.code), 11]);
 	var f3 = i.newFunction(SigCache.v_v, []);
 	i.addTable(7, 0, [f1.func_index, f3.func_index]);
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.CALL_INDIRECT.code), byte.!(f1.sig_index), 0
 	];
 	test_traplocs(i.args_uu(0, 1), 4, code, TrapReason.FUNC_SIG_MISMATCH);
 	test_traplocs(i.args_uu(0, 3), 4, code, TrapReason.FUNC_INVALID);
@@ -3058,8 +3056,8 @@ def test_i_trunc_f_traploc(i: ExeTester) {
 def test_call_ref_traploc(i: ExeTester) {
 	var sig_v_i = i.addSig(SigCache.v_i);
 	var code: Array<byte> = [
-		op8(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
-		op8(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
+		u8.!(Opcode.REF_NULL.code), BpTypeCode.FUNCREF.code,
+		u8.!(Opcode.CALL_REF.code), heapIndexByte(sig_v_i)
 	];
 	test_traplocs(i.noargs(), 2, code, TrapReason.NULL_DEREF);
 }
@@ -3069,10 +3067,10 @@ def test_memory_init_traploc(i: ExeTester) {
 	i.addMemory(1, Max.Set(1));
 	i.addPassiveData([11, 22, 33, 44, 55]);
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2,
-		Opcode.MEMORY_INIT.prefix, op8(Opcode.MEMORY_INIT.code), 0, 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2,
+		Opcode.MEMORY_INIT.prefix, u8.!(Opcode.MEMORY_INIT.code), 0, 0
 	];
 	test_traplocs(i.args_uuu(65533, 0, 4), 6, code, TrapReason.MEM_OUT_OF_BOUNDS);
 }
@@ -3082,8 +3080,8 @@ def test_table_get_traploc(i: ExeTester) {
 	i.sig0(SigCache.arr_i, [ValueTypes.FUNCREF]);
 
 	var code: Array<byte> = [
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.TABLE_GET.code), 0
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.TABLE_GET.code), 0
 	];
 	test_traplocs(i.args_u(3), 2, code, TrapReason.TABLE_OUT_OF_BOUNDS);
 }

--- a/test/unittest/ExeTest.v3
+++ b/test/unittest/ExeTest.v3
@@ -5,7 +5,7 @@ def X: Array<Value>;
 var NO_CODE: Array<byte> = [];
 def NONE = BpTypeCode.EmptyBlock.code;
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 // Registers a "unop" opcode test
 def reg1<X, Z>(opcode: Opcode,

--- a/test/unittest/ModuleBuilder.v3
+++ b/test/unittest/ModuleBuilder.v3
@@ -1,6 +1,8 @@
 // Copyright 2020 Ben L. Titzer. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 // A utility class to build an in-memory {Module} object.
 class ModuleBuilder {
 	var extensions: Extension.set;
@@ -85,14 +87,14 @@ class ModuleBuilder {
 	def wrap_opcode(opcode: Opcode) -> Array<byte> {
 		var code = BinBuilder.new();
 		for (i < opcode.sig.params.length) {
-			code.put(Opcode.LOCAL_GET.code);
+			code.put(op8(Opcode.LOCAL_GET.code));
 			code.put(byte.view(i));
 		}
 		if (opcode.prefix != 0) {
 			code.put(opcode.prefix);
 			code.put_u32leb(opcode.code);
 		} else {
-			code.put(opcode.code);
+			code.put(op8(opcode.code));
 		}
 		return code.extract();
 	}
@@ -111,7 +113,7 @@ class ModuleBuilder {
 			copy.put_ValueType(e.0);
 		}
 		copy.puta(raw);
-		copy.put(Opcode.END.code);
+		copy.put(op8(Opcode.END.code));
 		return copy.extract();
 	}
 	def newGlobal(valtype: ValueType, init: InitExpr) -> GlobalDecl {

--- a/test/unittest/ModuleBuilder.v3
+++ b/test/unittest/ModuleBuilder.v3
@@ -1,7 +1,7 @@
 // Copyright 2020 Ben L. Titzer. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 // A utility class to build an in-memory {Module} object.
 class ModuleBuilder {

--- a/test/unittest/ModuleBuilder.v3
+++ b/test/unittest/ModuleBuilder.v3
@@ -1,8 +1,6 @@
 // Copyright 2020 Ben L. Titzer. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
-def op8 = Opcodes.op8;
-
 // A utility class to build an in-memory {Module} object.
 class ModuleBuilder {
 	var extensions: Extension.set;
@@ -87,14 +85,14 @@ class ModuleBuilder {
 	def wrap_opcode(opcode: Opcode) -> Array<byte> {
 		var code = BinBuilder.new();
 		for (i < opcode.sig.params.length) {
-			code.put(op8(Opcode.LOCAL_GET.code));
+			code.put(u8.!(Opcode.LOCAL_GET.code));
 			code.put(byte.view(i));
 		}
 		if (opcode.prefix != 0) {
 			code.put(opcode.prefix);
 			code.put_u32leb(opcode.code);
 		} else {
-			code.put(op8(opcode.code));
+			code.put(u8.!(opcode.code));
 		}
 		return code.extract();
 	}
@@ -113,7 +111,7 @@ class ModuleBuilder {
 			copy.put_ValueType(e.0);
 		}
 		copy.puta(raw);
-		copy.put(op8(Opcode.END.code));
+		copy.put(u8.!(Opcode.END.code));
 		return copy.extract();
 	}
 	def newGlobal(valtype: ValueType, init: InitExpr) -> GlobalDecl {

--- a/test/unittest/OutlineTest.v3
+++ b/test/unittest/OutlineTest.v3
@@ -15,7 +15,7 @@ def Z = void(
 	()
 );
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 def DEFAULT_LIMITS = Limits.new().set(Extension.set.all);
 

--- a/test/unittest/OutlineTest.v3
+++ b/test/unittest/OutlineTest.v3
@@ -15,8 +15,6 @@ def Z = void(
 	()
 );
 
-def op8 = Opcodes.op8;
-
 def DEFAULT_LIMITS = Limits.new().set(Extension.set.all);
 
 class OutlineTester(t: Tester) {
@@ -52,7 +50,7 @@ def MEMORY1: Array<byte> = [
 	0, 1
 ];
 def GLOBAL: Array<byte> = [
-	BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)
+	BpTypeCode.I32.code, 0, u8.!(Opcode.I32_CONST.code), 0, u8.!(Opcode.END.code)
 ];
 
 
@@ -112,7 +110,7 @@ def test_funcs0(t: OutlineTester) {
 	b.beginSection(BpSection.Code);
 	b.put(1);
 	b.put(3);
-	b.puta([0, op8(Opcode.UNREACHABLE.code), op8(Opcode.END.code)]);
+	b.puta([0, u8.!(Opcode.UNREACHABLE.code), u8.!(Opcode.END.code)]);
 	b.endSection();
 	var outline = t.outline(b.extract());
 	t.assert_entries(outline.heaptypes, 14, [15], 18);
@@ -173,7 +171,7 @@ def test_exports0(t: OutlineTester) {
 	b.beginSection(BpSection.Code);
 	b.put(1);
 	b.put(3);
-	b.puta([0, op8(Opcode.UNREACHABLE.code), op8(Opcode.END.code)]);
+	b.puta([0, u8.!(Opcode.UNREACHABLE.code), u8.!(Opcode.END.code)]);
 	b.endSection();
 	var outline = t.outline(b.extract());
 	t.assert_entries(outline.exports, 32, [33, 38], 43);

--- a/test/unittest/OutlineTest.v3
+++ b/test/unittest/OutlineTest.v3
@@ -15,6 +15,8 @@ def Z = void(
 	()
 );
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 def DEFAULT_LIMITS = Limits.new().set(Extension.set.all);
 
 class OutlineTester(t: Tester) {
@@ -50,7 +52,7 @@ def MEMORY1: Array<byte> = [
 	0, 1
 ];
 def GLOBAL: Array<byte> = [
-	BpTypeCode.I32.code, 0, Opcode.I32_CONST.code, 0, Opcode.END.code
+	BpTypeCode.I32.code, 0, op8(Opcode.I32_CONST.code), 0, op8(Opcode.END.code)
 ];
 
 
@@ -110,7 +112,7 @@ def test_funcs0(t: OutlineTester) {
 	b.beginSection(BpSection.Code);
 	b.put(1);
 	b.put(3);
-	b.puta([0, Opcode.UNREACHABLE.code, Opcode.END.code]);
+	b.puta([0, op8(Opcode.UNREACHABLE.code), op8(Opcode.END.code)]);
 	b.endSection();
 	var outline = t.outline(b.extract());
 	t.assert_entries(outline.heaptypes, 14, [15], 18);
@@ -171,7 +173,7 @@ def test_exports0(t: OutlineTester) {
 	b.beginSection(BpSection.Code);
 	b.put(1);
 	b.put(3);
-	b.puta([0, Opcode.UNREACHABLE.code, Opcode.END.code]);
+	b.puta([0, op8(Opcode.UNREACHABLE.code), op8(Opcode.END.code)]);
 	b.endSection();
 	var outline = t.outline(b.extract());
 	t.assert_entries(outline.exports, 32, [33, 38], 43);

--- a/test/unittest/ProbeTest.v3
+++ b/test/unittest/ProbeTest.v3
@@ -29,6 +29,8 @@ def X_ = void(
 );
 def frame: TargetFrame;
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 class ProbeTester extends DebugTester {
 	new(t: Tester) super(t) {
 		Execute.tiering = ExecuteOptions.default;
@@ -48,21 +50,21 @@ class ProbeTester extends DebugTester {
 	def stdCode() {
 		sig(SigCache.v_i);
 		code([
-			Opcode.I32_CONST.code, 22,
-			Opcode.I32_CONST.code, 33,
-			Opcode.I32_SUB.code
+			op8(Opcode.I32_CONST.code), 22,
+			op8(Opcode.I32_CONST.code), 33,
+			op8(Opcode.I32_SUB.code)
 		]);
 	}
 	def loopCode() {
 		sig(SigCache.i_i);
-		codev([Opcode.LOOP.code, BpTypeCode.EmptyBlock.code,
-			Opcode.LOCAL_GET.code, 0,
-			Opcode.I32_CONST.code, 1,
-			Opcode.I32_SUB.code,
-			Opcode.LOCAL_TEE.code, 0,
-			Opcode.BR_IF.code, 0,
-			Opcode.END.code,
-			Opcode.LOCAL_GET.code, 0]);
+		codev([op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+			op8(Opcode.LOCAL_GET.code), 0,
+			op8(Opcode.I32_CONST.code), 1,
+			op8(Opcode.I32_SUB.code),
+			op8(Opcode.LOCAL_TEE.code), 0,
+			op8(Opcode.BR_IF.code), 0,
+			op8(Opcode.END.code),
+			op8(Opcode.LOCAL_GET.code), 0]);
 	}
 	def assert_count(expected: int, p: CountProbe) {
 		if (p.count != expected) return t.fail2("expected count = %d, got %d", expected, p.count);
@@ -263,11 +265,11 @@ def test_remove_2i(t: ProbeTester) {
 }
 
 def test_depth0(t: ProbeTester) {
-	var f2 = t.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 17]);
+	var f2 = t.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]);
 	Execute.tiering.onFuncValidationFinish(t.module, f2, null); // TODO: move into newFunction()
 	t.sig(SigCache.v_i);
 	t.codev([
-		Opcode.CALL.code, byte.!(f2.func_index)
+		op8(Opcode.CALL.code), byte.!(f2.func_index)
 	]);
 	var p = DepthProbe.new();
 	t.probe(f2.func_index, 1, p);
@@ -360,15 +362,15 @@ def test_no_skip_block(t: ProbeTester) {
 	// Tests that empty blocks are not skipped in global probe mode
 	t.sig(SigCache.v_i);
 	t.codev([
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 11
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 11
 	]);
 	var p = CountProbe.new();
 	var exe = t.exe();
@@ -383,15 +385,15 @@ def test_insert_g0(t: ProbeTester) {
 	// Tests that empty blocks are not skipped when dynamically inserting global probe
 	t.sig(SigCache.v_i);
 	t.codev([
-		Opcode.I32_CONST.code, 11,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.END.code
+		op8(Opcode.I32_CONST.code), 11,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.END.code)
 	]);
 	var c = CountProbe.new();
 	var exe = t.exe();
@@ -406,15 +408,15 @@ def test_insert_g0(t: ProbeTester) {
 def test_insert_g1(t: ProbeTester) {
 	t.sig(SigCache.v_i);
 	t.codev([
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.BLOCK.code, BpTypeCode.EmptyBlock.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.END.code,
-		Opcode.I32_CONST.code, 11
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.END.code),
+		op8(Opcode.I32_CONST.code), 11
 	]);
 	var c = CountProbe.new();
 	var exe = t.exe();

--- a/test/unittest/ProbeTest.v3
+++ b/test/unittest/ProbeTest.v3
@@ -29,8 +29,6 @@ def X_ = void(
 );
 def frame: TargetFrame;
 
-def op8 = Opcodes.op8;
-
 class ProbeTester extends DebugTester {
 	new(t: Tester) super(t) {
 		Execute.tiering = ExecuteOptions.default;
@@ -50,21 +48,21 @@ class ProbeTester extends DebugTester {
 	def stdCode() {
 		sig(SigCache.v_i);
 		code([
-			op8(Opcode.I32_CONST.code), 22,
-			op8(Opcode.I32_CONST.code), 33,
-			op8(Opcode.I32_SUB.code)
+			u8.!(Opcode.I32_CONST.code), 22,
+			u8.!(Opcode.I32_CONST.code), 33,
+			u8.!(Opcode.I32_SUB.code)
 		]);
 	}
 	def loopCode() {
 		sig(SigCache.i_i);
-		codev([op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
-			op8(Opcode.LOCAL_GET.code), 0,
-			op8(Opcode.I32_CONST.code), 1,
-			op8(Opcode.I32_SUB.code),
-			op8(Opcode.LOCAL_TEE.code), 0,
-			op8(Opcode.BR_IF.code), 0,
-			op8(Opcode.END.code),
-			op8(Opcode.LOCAL_GET.code), 0]);
+		codev([u8.!(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+			u8.!(Opcode.LOCAL_GET.code), 0,
+			u8.!(Opcode.I32_CONST.code), 1,
+			u8.!(Opcode.I32_SUB.code),
+			u8.!(Opcode.LOCAL_TEE.code), 0,
+			u8.!(Opcode.BR_IF.code), 0,
+			u8.!(Opcode.END.code),
+			u8.!(Opcode.LOCAL_GET.code), 0]);
 	}
 	def assert_count(expected: int, p: CountProbe) {
 		if (p.count != expected) return t.fail2("expected count = %d, got %d", expected, p.count);
@@ -265,11 +263,11 @@ def test_remove_2i(t: ProbeTester) {
 }
 
 def test_depth0(t: ProbeTester) {
-	var f2 = t.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]);
+	var f2 = t.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 17]);
 	Execute.tiering.onFuncValidationFinish(t.module, f2, null); // TODO: move into newFunction()
 	t.sig(SigCache.v_i);
 	t.codev([
-		op8(Opcode.CALL.code), byte.!(f2.func_index)
+		u8.!(Opcode.CALL.code), byte.!(f2.func_index)
 	]);
 	var p = DepthProbe.new();
 	t.probe(f2.func_index, 1, p);
@@ -362,15 +360,15 @@ def test_no_skip_block(t: ProbeTester) {
 	// Tests that empty blocks are not skipped in global probe mode
 	t.sig(SigCache.v_i);
 	t.codev([
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 11
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 11
 	]);
 	var p = CountProbe.new();
 	var exe = t.exe();
@@ -385,15 +383,15 @@ def test_insert_g0(t: ProbeTester) {
 	// Tests that empty blocks are not skipped when dynamically inserting global probe
 	t.sig(SigCache.v_i);
 	t.codev([
-		op8(Opcode.I32_CONST.code), 11,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.END.code)
+		u8.!(Opcode.I32_CONST.code), 11,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code)
 	]);
 	var c = CountProbe.new();
 	var exe = t.exe();
@@ -408,15 +406,15 @@ def test_insert_g0(t: ProbeTester) {
 def test_insert_g1(t: ProbeTester) {
 	t.sig(SigCache.v_i);
 	t.codev([
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.END.code),
-		op8(Opcode.I32_CONST.code), 11
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.BLOCK.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.I32_CONST.code), 11
 	]);
 	var c = CountProbe.new();
 	var exe = t.exe();

--- a/test/unittest/ProbeTest.v3
+++ b/test/unittest/ProbeTest.v3
@@ -29,7 +29,7 @@ def X_ = void(
 );
 def frame: TargetFrame;
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 class ProbeTester extends DebugTester {
 	new(t: Tester) super(t) {

--- a/test/unittest/SidetableTest.v3
+++ b/test/unittest/SidetableTest.v3
@@ -15,7 +15,7 @@ def X_ = void(
 	()
 );
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 class SidetableTester(t: Tester) extends ModuleBuilder {
 	var has_func_code = false;

--- a/test/unittest/SidetableTest.v3
+++ b/test/unittest/SidetableTest.v3
@@ -15,6 +15,8 @@ def X_ = void(
 	()
 );
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 class SidetableTester(t: Tester) extends ModuleBuilder {
 	var has_func_code = false;
 
@@ -89,13 +91,13 @@ class SidetableTester(t: Tester) extends ModuleBuilder {
 	}
 }
 
-def K = Opcode.I32_CONST.code;
-def BR = Opcode.BR.code;
-def END = Opcode.END.code;
-def BLOCK = Opcode.BLOCK.code;
-def LOOP = Opcode.LOOP.code;
-def IF = Opcode.IF.code;
-def ELSE = Opcode.ELSE.code;
+def K = op8(Opcode.I32_CONST.code);
+def BR = op8(Opcode.BR.code);
+def END = op8(Opcode.END.code);
+def BLOCK = op8(Opcode.BLOCK.code);
+def LOOP = op8(Opcode.LOOP.code);
+def IF = op8(Opcode.IF.code);
+def ELSE = op8(Opcode.ELSE.code);
 def N = BpTypeCode.EmptyBlock.code;
 def I = BpTypeCode.I32.code;
 
@@ -240,7 +242,7 @@ def test_relative(t: SidetableTester) {
 def test_br_table0(t: SidetableTester) {
 	t.sig(SigCache.v_v);
 	t.codev([K, 1,
-		Opcode.BR_TABLE.code, 2,
+		op8(Opcode.BR_TABLE.code), 2,
 		0, 0, 0]);
 	t.assert_entries([
 		(3, BRE(3, 0, 0, 0)),

--- a/test/unittest/SidetableTest.v3
+++ b/test/unittest/SidetableTest.v3
@@ -15,8 +15,6 @@ def X_ = void(
 	()
 );
 
-def op8 = Opcodes.op8;
-
 class SidetableTester(t: Tester) extends ModuleBuilder {
 	var has_func_code = false;
 
@@ -91,13 +89,13 @@ class SidetableTester(t: Tester) extends ModuleBuilder {
 	}
 }
 
-def K = op8(Opcode.I32_CONST.code);
-def BR = op8(Opcode.BR.code);
-def END = op8(Opcode.END.code);
-def BLOCK = op8(Opcode.BLOCK.code);
-def LOOP = op8(Opcode.LOOP.code);
-def IF = op8(Opcode.IF.code);
-def ELSE = op8(Opcode.ELSE.code);
+def K = u8.!(Opcode.I32_CONST.code);
+def BR = u8.!(Opcode.BR.code);
+def END = u8.!(Opcode.END.code);
+def BLOCK = u8.!(Opcode.BLOCK.code);
+def LOOP = u8.!(Opcode.LOOP.code);
+def IF = u8.!(Opcode.IF.code);
+def ELSE = u8.!(Opcode.ELSE.code);
 def N = BpTypeCode.EmptyBlock.code;
 def I = BpTypeCode.I32.code;
 
@@ -242,7 +240,7 @@ def test_relative(t: SidetableTester) {
 def test_br_table0(t: SidetableTester) {
 	t.sig(SigCache.v_v);
 	t.codev([K, 1,
-		op8(Opcode.BR_TABLE.code), 2,
+		u8.!(Opcode.BR_TABLE.code), 2,
 		0, 0, 0]);
 	t.assert_entries([
 		(3, BRE(3, 0, 0, 0)),

--- a/test/unittest/WasmStackTest.v3
+++ b/test/unittest/WasmStackTest.v3
@@ -18,6 +18,8 @@ def unused_ = TestTiers.addTests2([
 	("gc_stacks1", N, test_gc_stacks1)
 ]);
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 class WasmStackTester extends ExeTester {
 	new(t: Tester, tiering: ExecutionStrategy) super(t, tiering) { }
 
@@ -116,9 +118,9 @@ def test_resume_nop(t: WasmStackTester) {
 
 def test_resume_add(t: WasmStackTester) {
 	t.sig(SigCache.ii_i).code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_ADD.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_ADD.code)
 	]);
 	var f = t.makeFunc();
 
@@ -186,9 +188,9 @@ def test_resume_host_tc_host(t: WasmStackTester) {
 
 def test_resume_host_tc_wasm(t: WasmStackTester) {
 	t.sig(SigCache.ii_i).code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_SUB.code
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_SUB.code)
 	]);
 	var g = t.makeFunc();
 
@@ -214,9 +216,9 @@ def test_gc_stacks0(t: WasmStackTester) {
 		[ValueTypes.ANYREF, ValueTypes.EXTERNREF, ValueTypes.FUNCREF],
 		[ValueTypes.ANYREF, ValueTypes.EXTERNREF, ValueTypes.FUNCREF]);
 	t.sig(sig).code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2
 	]);
 
 	var s1 = Target.newWasmStack();
@@ -242,9 +244,9 @@ def test_gc_stacks1(t: WasmStackTester) {
 		[ValueTypes.ANYREF, ValueTypes.ANYREF, ValueTypes.FUNCREF],
 		[ValueTypes.ANYREF, ValueTypes.ANYREF, ValueTypes.FUNCREF]);
 	t.sig(sig).code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.LOCAL_GET.code, 2
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.LOCAL_GET.code), 2
 	]);
 
 	var s1 = Target.newWasmStack();

--- a/test/unittest/WasmStackTest.v3
+++ b/test/unittest/WasmStackTest.v3
@@ -18,8 +18,6 @@ def unused_ = TestTiers.addTests2([
 	("gc_stacks1", N, test_gc_stacks1)
 ]);
 
-def op8 = Opcodes.op8;
-
 class WasmStackTester extends ExeTester {
 	new(t: Tester, tiering: ExecutionStrategy) super(t, tiering) { }
 
@@ -118,9 +116,9 @@ def test_resume_nop(t: WasmStackTester) {
 
 def test_resume_add(t: WasmStackTester) {
 	t.sig(SigCache.ii_i).code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_ADD.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_ADD.code)
 	]);
 	var f = t.makeFunc();
 
@@ -188,9 +186,9 @@ def test_resume_host_tc_host(t: WasmStackTester) {
 
 def test_resume_host_tc_wasm(t: WasmStackTester) {
 	t.sig(SigCache.ii_i).code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_SUB.code)
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_SUB.code)
 	]);
 	var g = t.makeFunc();
 
@@ -216,9 +214,9 @@ def test_gc_stacks0(t: WasmStackTester) {
 		[ValueTypes.ANYREF, ValueTypes.EXTERNREF, ValueTypes.FUNCREF],
 		[ValueTypes.ANYREF, ValueTypes.EXTERNREF, ValueTypes.FUNCREF]);
 	t.sig(sig).code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2
 	]);
 
 	var s1 = Target.newWasmStack();
@@ -244,9 +242,9 @@ def test_gc_stacks1(t: WasmStackTester) {
 		[ValueTypes.ANYREF, ValueTypes.ANYREF, ValueTypes.FUNCREF],
 		[ValueTypes.ANYREF, ValueTypes.ANYREF, ValueTypes.FUNCREF]);
 	t.sig(sig).code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.LOCAL_GET.code), 2
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.LOCAL_GET.code), 2
 	]);
 
 	var s1 = Target.newWasmStack();

--- a/test/unittest/WasmStackTest.v3
+++ b/test/unittest/WasmStackTest.v3
@@ -18,7 +18,7 @@ def unused_ = TestTiers.addTests2([
 	("gc_stacks1", N, test_gc_stacks1)
 ]);
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 class WasmStackTester extends ExeTester {
 	new(t: Tester, tiering: ExecutionStrategy) super(t, tiering) { }

--- a/test/unittest/x86-64-linux/X86_64LinuxExeTest.v3
+++ b/test/unittest/x86-64-linux/X86_64LinuxExeTest.v3
@@ -28,54 +28,52 @@ component X86_64LinuxExeTest {
 def X: Array<Value>;
 def NONE = BpTypeCode.EmptyBlock.code;
 
-def op8 = Opcodes.op8;
-
 def test_empty(i: ExeTester) {
 	i.sig(SigCache.v_v).code([])
 		.noargs().assert2_none();
 }
 
 def test_unreachable(i: ExeTester) {
-	i.code([op8(Opcode.UNREACHABLE.code)])
+	i.code([u8.!(Opcode.UNREACHABLE.code)])
 		.noargs().assert2_trap(TrapReason.UNREACHABLE);
 }
 
 def test_nop(i: ExeTester) {
-	i.sig(SigCache.v_v).code([op8(Opcode.NOP.code)])
+	i.sig(SigCache.v_v).code([u8.!(Opcode.NOP.code)])
 		.noargs().assert2_none();
 }
 
 def test_i32_add(i: ExeTester) {
 	i.sig(SigCache.ii_i).code([
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.LOCAL_GET.code), 1,
-		op8(Opcode.I32_ADD.code)]);
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.LOCAL_GET.code), 1,
+		u8.!(Opcode.I32_ADD.code)]);
 	i.args_ii(0xFF89520F, 9999999).assert2_i(2222222);
 }
 
 def test_load_oob0(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.i_i);
-	i.code([op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_LOAD.code), 0, 0]);
+	i.code([u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
 }
 
 def test_call1005(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]).func_index);
+	var f17 = byte.!(i.newFunction(SigCache.v_i, [u8.!(Opcode.I32_CONST.code), 17]).func_index);
 	i.sig(SigCache.i_i);
 	i.codev([
-		op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
-		op8(Opcode.CALL.code), f17,
-		op8(Opcode.LOCAL_GET.code), 0,
-		op8(Opcode.I32_CONST.code), 1,
-		op8(Opcode.I32_SUB.code),
-		op8(Opcode.LOCAL_TEE.code), 0,
-		op8(Opcode.I32_EQZ.code),
-		op8(Opcode.BR_IF.code), 1,
-		op8(Opcode.BR.code), 0,
-		op8(Opcode.END.code),
-		op8(Opcode.UNREACHABLE.code)
+		u8.!(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+		u8.!(Opcode.CALL.code), f17,
+		u8.!(Opcode.LOCAL_GET.code), 0,
+		u8.!(Opcode.I32_CONST.code), 1,
+		u8.!(Opcode.I32_SUB.code),
+		u8.!(Opcode.LOCAL_TEE.code), 0,
+		u8.!(Opcode.I32_EQZ.code),
+		u8.!(Opcode.BR_IF.code), 1,
+		u8.!(Opcode.BR.code), 0,
+		u8.!(Opcode.END.code),
+		u8.!(Opcode.UNREACHABLE.code)
 	]);
 	i.args_i(5).assert2_i(17);
 	i.args_i(1000).assert2_i(17);

--- a/test/unittest/x86-64-linux/X86_64LinuxExeTest.v3
+++ b/test/unittest/x86-64-linux/X86_64LinuxExeTest.v3
@@ -28,52 +28,54 @@ component X86_64LinuxExeTest {
 def X: Array<Value>;
 def NONE = BpTypeCode.EmptyBlock.code;
 
+def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+
 def test_empty(i: ExeTester) {
 	i.sig(SigCache.v_v).code([])
 		.noargs().assert2_none();
 }
 
 def test_unreachable(i: ExeTester) {
-	i.code([Opcode.UNREACHABLE.code])
+	i.code([op8(Opcode.UNREACHABLE.code)])
 		.noargs().assert2_trap(TrapReason.UNREACHABLE);
 }
 
 def test_nop(i: ExeTester) {
-	i.sig(SigCache.v_v).code([Opcode.NOP.code])
+	i.sig(SigCache.v_v).code([op8(Opcode.NOP.code)])
 		.noargs().assert2_none();
 }
 
 def test_i32_add(i: ExeTester) {
 	i.sig(SigCache.ii_i).code([
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.LOCAL_GET.code, 1,
-		Opcode.I32_ADD.code]);
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.LOCAL_GET.code), 1,
+		op8(Opcode.I32_ADD.code)]);
 	i.args_ii(0xFF89520F, 9999999).assert2_i(2222222);
 }
 
 def test_load_oob0(i: ExeTester) {
 	i.addMemory(0, Max.Set(0));
 	i.sig(SigCache.i_i);
-	i.code([Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_LOAD.code, 0, 0]);
+	i.code([op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_LOAD.code), 0, 0]);
 	i.args_i(0).assert2_trap(TrapReason.MEM_OUT_OF_BOUNDS);
 }
 
 def test_call1005(i: ExeTester) {
-	var f17 = byte.!(i.newFunction(SigCache.v_i, [Opcode.I32_CONST.code, 17]).func_index);
+	var f17 = byte.!(i.newFunction(SigCache.v_i, [op8(Opcode.I32_CONST.code), 17]).func_index);
 	i.sig(SigCache.i_i);
 	i.codev([
-		Opcode.LOOP.code, BpTypeCode.EmptyBlock.code,
-		Opcode.CALL.code, f17,
-		Opcode.LOCAL_GET.code, 0,
-		Opcode.I32_CONST.code, 1,
-		Opcode.I32_SUB.code,
-		Opcode.LOCAL_TEE.code, 0,
-		Opcode.I32_EQZ.code,
-		Opcode.BR_IF.code, 1,
-		Opcode.BR.code, 0,
-		Opcode.END.code,
-		Opcode.UNREACHABLE.code
+		op8(Opcode.LOOP.code), BpTypeCode.EmptyBlock.code,
+		op8(Opcode.CALL.code), f17,
+		op8(Opcode.LOCAL_GET.code), 0,
+		op8(Opcode.I32_CONST.code), 1,
+		op8(Opcode.I32_SUB.code),
+		op8(Opcode.LOCAL_TEE.code), 0,
+		op8(Opcode.I32_EQZ.code),
+		op8(Opcode.BR_IF.code), 1,
+		op8(Opcode.BR.code), 0,
+		op8(Opcode.END.code),
+		op8(Opcode.UNREACHABLE.code)
 	]);
 	i.args_i(5).assert2_i(17);
 	i.args_i(1000).assert2_i(17);

--- a/test/unittest/x86-64-linux/X86_64LinuxExeTest.v3
+++ b/test/unittest/x86-64-linux/X86_64LinuxExeTest.v3
@@ -28,7 +28,7 @@ component X86_64LinuxExeTest {
 def X: Array<Value>;
 def NONE = BpTypeCode.EmptyBlock.code;
 
-def op8(code: u16) -> u8 { return Opcodes.op8(code); }
+def op8 = Opcodes.op8;
 
 def test_empty(i: ExeTester) {
 	i.sig(SigCache.v_v).code([])


### PR DESCRIPTION
  Does not yet include the run-time dispatch table building and use in the Fast interpreter, but builds and passes the tests I can run (I'm not set up for JVM tests at present).