### PR TITLE
[wali] Removing generic argument type on WaliCheck

### DIFF
--- a/src/modules/wali/x86-64-linux/WaliCheck.v3
+++ b/src/modules/wali/x86-64-linux/WaliCheck.v3
@@ -1,7 +1,6 @@
 def EBADFD = HostResult.Value1(Values.box_i(LinuxConst.EBADFD));
 
-type ArgType {
-	def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult);
+component WaliCheck {
 	def getFd(fdmap: FileDescriptorMap, arg: Value) -> int {
 		return fdmap.get(Values.unbox_i(arg));
 	}
@@ -18,101 +17,86 @@ type ArgType {
 		var ptr = Values.unbox_u(args[n]);
 		return memory.range_ol_32(ptr, len);
 	}
-	case FD_POINTER_LEN {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (0, Pointer.NULL, 0);
-			var sysfd = getFd(fdmap, args[0]);
-			var range = getRegion(memory, args, 1);
-			if (sysfd < 0) return (T.!(err_retval), EBADFD);
-			if (range.reason != TrapReason.NONE) return (T.!(err_retval), range.toHostResultThrow());
-			return (T.!((sysfd, Pointer.atContents(range.result), range.result.length)), HostResult.Value0);
-		}
+	def FD_POINTER_LEN_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((i32, Pointer, i32), HostResult) {
+		var err_retval = (0, Pointer.NULL, 0);
+		var sysfd = getFd(fdmap, args[0]);
+		var range = getRegion(memory, args, 1);
+		if (sysfd < 0) return (err_retval, EBADFD);
+		if (range.reason != TrapReason.NONE) return (err_retval, range.toHostResultThrow());
+		var retval = ((sysfd, Pointer.atContents(range.result), range.result.length));
+		return (retval, HostResult.Value0);
 	}
-	case FD_L_I {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (0, 0, 0);
-			var sysfd = getFd(fdmap, args[0]);
-			if (sysfd < 0) return (T.!(err_retval), EBADFD);
-			var arg1 = Values.unbox_l(args[1]);
-			var arg2 = Values.unbox_i(args[2]);
-			return (T.!((sysfd, arg1, arg2)), HostResult.Value0);
-		}
+	def FD_L_I_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((i32, i64, i32), HostResult) {
+		var err_retval = (0, 0, 0);
+		var sysfd = getFd(fdmap, args[0]);
+		if (sysfd < 0) return (err_retval, EBADFD);
+		var arg1 = Values.unbox_l(args[1]);
+		var arg2 = Values.unbox_i(args[2]);
+		var retval = ((sysfd, arg1, arg2));
+		return (retval, HostResult.Value0);
 	}
-	case FD_I {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (0, 0);
-			var sysfd = getFd(fdmap, args[0]);
-			if (sysfd < 0) return (T.!(err_retval), EBADFD);
-			var arg1 = Values.unbox_i(args[1]);
-			return (T.!((sysfd, arg1)), HostResult.Value0);
-		}
+	def FD_I_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((i32, i32), HostResult) {
+		var err_retval = (0, 0);
+		var sysfd = getFd(fdmap, args[0]);
+		if (sysfd < 0) return (err_retval, EBADFD);
+		var arg1 = Values.unbox_i(args[1]);
+		var retval = ((sysfd, arg1));
+		return (retval, HostResult.Value0);
 	}
-	case FD_I_I {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (0, 0, 0);
-			var sysfd = getFd(fdmap, args[0]);
-			if (sysfd < 0) return (T.!(err_retval), EBADFD);
-			var arg1 = Values.unbox_i(args[1]);
-			var arg2 = Values.unbox_i(args[2]);
-			return (T.!((sysfd, arg1, arg2)), HostResult.Value0);
-		}
+	def FD_I_I_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((i32, i32, i32), HostResult) {
+		var err_retval = (0, 0, 0);
+		var sysfd = getFd(fdmap, args[0]);
+		if (sysfd < 0) return (err_retval, EBADFD);
+		var arg1 = Values.unbox_i(args[1]);
+		var arg2 = Values.unbox_i(args[2]);
+		var retval = ((sysfd, arg1, arg2));
+		return (retval, HostResult.Value0);
 	}
-	case PATH_U {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (Pointer.NULL, 0);
-			var path = getPath(memory, args[0]);
-			var arg1 = Values.unbox_u(args[1]);
-			if (path.reason != TrapReason.NONE) return (T.!(err_retval), path.toHostResultThrow());
-			return (T.!((Pointer.atContents(path.result), arg1)), HostResult.Value0);
-		}
+	def PATH_U_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((Pointer, u32), HostResult) {
+		var err_retval = (Pointer.NULL, 0u);
+		var path = getPath(memory, args[0]);
+		var arg1 = Values.unbox_u(args[1]);
+		if (path.reason != TrapReason.NONE) return (err_retval, path.toHostResultThrow());
+		var retval = ((Pointer.atContents(path.result), arg1));
+		return (retval, HostResult.Value0);
 	}
-	case PATH_U_U {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (Pointer.NULL, 0, 0);
-			var path = getPath(memory, args[0]);
-			var arg1 = Values.unbox_u(args[1]);
-			var arg2 = Values.unbox_u(args[2]);
-			if (path.reason != TrapReason.NONE) return (T.!(err_retval), path.toHostResultThrow());
-			return (T.!((Pointer.atContents(path.result), arg1, arg2)), HostResult.Value0);
-		}
+	def PATH_U_U_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((Pointer, u32, u32), HostResult) {
+		var err_retval = (Pointer.NULL, 0u, 0u);
+		var path = getPath(memory, args[0]);
+		var arg1 = Values.unbox_u(args[1]);
+		var arg2 = Values.unbox_u(args[2]);
+		if (path.reason != TrapReason.NONE) return (err_retval, path.toHostResultThrow());
+		var retval = ((Pointer.atContents(path.result), arg1, arg2));
+		return (retval, HostResult.Value0);
 	}
-	case FD {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (0);
-			var fd = Values.unbox_i(args[0]);
-			var sysfd = fdmap.get(fd);
-			if (sysfd < 0) return (T.!(err_retval), EBADFD);
-			return (T.!((sysfd)), HostResult.Value0);
-		}
+	def FD_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (i32, HostResult) {
+		var err_retval = (0);
+		var fd = Values.unbox_i(args[0]);
+		var sysfd = fdmap.get(fd);
+		if (sysfd < 0) return (err_retval, EBADFD);
+		return (sysfd, HostResult.Value0);
 	}
-	case PATH_STAT {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			var err_retval = (Pointer.NULL, Pointer.NULL);
-			var path = getPath(memory, args[0]);
-			if (path.reason != TrapReason.NONE) return (T.!(err_retval), path.toHostResultThrow());
-			var range = getRegionOf(memory, args, 1, u32.!(wali_stat.size));
-			if (range.reason != TrapReason.NONE) return (T.!(err_retval), range.toHostResultThrow());
-			// var incoming = Ref<wali_stat>.of(range.val);
-			// TODO: layout adjustment for minor stat buffer changes
-			return (T.!((Pointer.atContents(path.result), Pointer.atContents(range.result))), HostResult.Value0);
-		}
+	def PATH_STAT_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((Pointer, Pointer), HostResult) {
+		var err_retval = (Pointer.NULL, Pointer.NULL);
+		var path = getPath(memory, args[0]);
+		if (path.reason != TrapReason.NONE) return (err_retval, path.toHostResultThrow());
+		var range = getRegionOf(memory, args, 1, u32.!(wali_stat.size));
+		if (range.reason != TrapReason.NONE) return (err_retval, range.toHostResultThrow());
+		// var incoming = Ref<wali_stat>.of(range.val);
+		// TODO: layout adjustment for minor stat buffer changes
+		var retval = (Pointer.atContents(path.result), Pointer.atContents(range.result));
+		return (retval, HostResult.Value0);
 	}
-	case Void {
-		def getArgs<T>(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> (T, HostResult) {
-			return (T.!(()), HostResult.Value0);
-		}
+	def Void_UNWRAP(fdmap: FileDescriptorMap, memory: Memory, args: Range<Value>) -> ((), HostResult) {
+		return ((), HostResult.Value0);
 	}
-}
-
-
-component WaliCheck {
 	def Syscall<T>(fdmap: FileDescriptorMap,
 			memory: Memory,
-			args_type: ArgType,
 			args: Range<Value>,
+			getArgs: (FileDescriptorMap, Memory, Range<Value>) -> (T, HostResult),
 			syscall_num: int,
 			syscall: (int, T, FileDescriptorMap, Memory) -> HostResult) -> HostResult {
-	   var res: (T, HostResult) = args_type.getArgs(fdmap, memory, args);
+	   var res: (T, HostResult) = getArgs(fdmap, memory, args);
 	   var args = res.0;
 	   var host_result = res.1;
 	   if (host_result != HostResult.Value0) return host_result;

--- a/src/modules/wali/x86-64-linux/X86_64LinuxWaliModule.v3
+++ b/src/modules/wali/x86-64-linux/X86_64LinuxWaliModule.v3
@@ -86,8 +86,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD_POINTER_LEN,
 			args,
+			WaliCheck.FD_POINTER_LEN_UNWRAP,
 			LinuxConst.SYS_read,
 			WaliImpl.passthrough<(i32, Pointer, i32)>
 		);
@@ -96,8 +96,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD_POINTER_LEN,
 			args,
+			WaliCheck.FD_POINTER_LEN_UNWRAP,
 			LinuxConst.SYS_write,
 			WaliImpl.passthrough<(i32, Pointer, i32)>
 		);
@@ -106,8 +106,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.PATH_U_U,
 			args,
+			WaliCheck.PATH_U_U_UNWRAP,
 			LinuxConst.SYS_open,
 			WaliImpl.open
 		);
@@ -116,8 +116,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD_L_I,
 			args,
+			WaliCheck.FD_L_I_UNWRAP,
 			LinuxConst.SYS_lseek,
 			WaliImpl.passthrough<(i32, i64, i32)>
 		);
@@ -126,8 +126,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD,
 			args,
+			WaliCheck.FD_UNWRAP,
 			LinuxConst.SYS_close,
 			WaliImpl.close
 		);
@@ -136,8 +136,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD,
 			args,
+			WaliCheck.FD_UNWRAP,
 			LinuxConst.SYS_dup,
 			WaliImpl.dup
 		);
@@ -146,8 +146,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD_I,
 			args,
+			WaliCheck.FD_I_UNWRAP,
 			LinuxConst.SYS_dup2,
 			WaliImpl.dup2<(i32, i32)>
 		);
@@ -156,8 +156,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.FD_I_I,
 			args,
+			WaliCheck.FD_I_I_UNWRAP,
 			LinuxConst.SYS_dup3,
 			// Reusing dup2 wrapper
 			WaliImpl.dup2<(i32, i32, i32)>
@@ -167,8 +167,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.PATH_STAT,
 			args,
+			WaliCheck.PATH_STAT_UNWRAP,
 			LinuxConst.SYS_stat,
 			WaliImpl.passthrough<(Pointer, Pointer)>
 		);
@@ -177,8 +177,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.Void,
 			args,
+			WaliCheck.Void_UNWRAP,
 			LinuxConst.SYS_exit,
 			WaliImpl.passthrough<()>
 		);
@@ -190,8 +190,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.Void,
 			args,
+			WaliCheck.Void_UNWRAP,
 			LinuxConst.SYS_fork,
 			WaliImpl.passthrough<()>
 		);
@@ -200,8 +200,8 @@ class WaliInstance {
 		return WaliCheck.Syscall(
 			fdmap,
 			memory,
-			ArgType.PATH_U,
 			args,
+			WaliCheck.PATH_U_UNWRAP,
 			LinuxConst.SYS_access,
 			WaliImpl.passthrough<(Pointer, u32)>
 		);


### PR DESCRIPTION
Removed `ArgType` enum to reduce activations.