### PR TITLE
[stack-switching] Removed passing canonicalization tests from `regress.failures.x86-64-linux`

### DIFF
--- a/test/regress.failures.x86-64-linux
+++ b/test/regress.failures.x86-64-linux
@@ -1,6 +1,1 @@
-test/regress/ext:stack-switching/switch6.bin.wast
-test/regress/ext:stack-switching/switch11.bin.wast
-test/regress/ext:stack-switching/switch11_a.bin.wast
-test/regress/ext:stack-switching/switch11_b.bin.wast
-
 test/regress/legacy-exceptions/try_delegate2.bin.wast


### PR DESCRIPTION
This PR removes canonicalization tests from `regress.failures.x86-64-linux` as they pass now.