### PR TITLE
Running stack's `rsp` points to return address instead of interpreter frame

### DIFF
--- a/src/engine/compiler/MacroAssembler.v3
+++ b/src/engine/compiler/MacroAssembler.v3
@@ -194,6 +194,9 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 	def emit_v3_X86_64Stack_rsp_r_r(dst: Reg, ptr: Reg);
 	def emit_v3_set_X86_64Stack_vsp_r_r(stk: Reg, vsp: Reg);
 	def emit_v3_set_X86_64Stack_rsp_r_r(stk: Reg, rsp: Reg);
+	
+	def emit_push_X86_64Stack_rsp_r_r(stk: Reg);
+	def emit_pop_X86_64Stack_rsp_r_r(stk: Reg);
 
 
 

--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -388,12 +388,16 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_get_curstack(regs.runtime_arg0);
 		// store %sp
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		// reload WasmFunction
 		masm.emit_mov_r_m(ValueKind.REF, regs.runtime_arg1, frame.wasm_func_slot);
 		// load PC
 		masm.emit_mov_r_i(regs.runtime_arg2, pc);
 		// call runtime
 		masm.emit_call_runtime_Probe_instr();
+		// restore {stack.rsp}
+		masm.emit_get_curstack(regs.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.scratch);
 		emit_reload_regs();
 		if (!spillMode.free_regs) state.emitRestoreAll(resolver);
 	}
@@ -675,6 +679,7 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, tag_index);
 		masm.emit_call_runtime_op(Opcode.THROW);
@@ -688,6 +693,7 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		popFixedReg(regs.runtime_arg1);
 		masm.emit_call_runtime_op(Opcode.THROW_REF);
 		setUnreachable();
@@ -1277,12 +1283,16 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		state.emitSaveAll(resolver, runtimeSpillMode);
 		emit_compute_vsp(regs.vsp, state.sp);
 		masm.emit_store_curstack_vsp(regs.vsp);
+		// XXX: if a RT function cannot trap, maybe skip setting {rsp}?
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, nullable);
 		masm.emit_mov_r_i(regs.runtime_arg3, ht_val);
 		masm.emit_call_runtime_cast();
+		masm.emit_get_curstack(regs.runtime_arg0);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_reload_regs();
 		if (!runtimeSpillMode.free_regs) state.emitRestoreAll(resolver);
 		return result;
@@ -1420,9 +1430,12 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, arg1);
 		masm.emit_call_runtime_op(op);
+		masm.emit_get_curstack(regs.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.scratch);
 		dropN(args);
 		for (t in results) state.push(typeToKindFlags(t) | TAG_STORED | IS_STORED, NO_REG, 0);
 		emit_reload_regs();
@@ -1434,10 +1447,13 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, arg1);
 		masm.emit_mov_r_i(regs.runtime_arg3, arg2);
 		masm.emit_call_runtime_op(op);
+		masm.emit_get_curstack(regs.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.scratch);
 		dropN(args);
 		for (t in results) state.push(typeToKindFlags(t) | TAG_STORED | IS_STORED, NO_REG, 0);
 		emit_reload_regs();

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -519,6 +519,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		// move function into correct register
 		masm.emit_mov_r_r(ValueKind.REF, xenv.runtime_arg1, r_func);
 		// call runtime
+		// TODO: verify host calls' {rsp} convention
 		masm.emit_call_runtime_callHost(xenv.func_arg);
 
 		// mov %stack, [cur_stack]    ; reload stack object from curStack
@@ -3515,6 +3516,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		masm.emit_get_curstack(xenv.scratch);
 		masm.emit_v3_set_X86_64Stack_vsp_r_r(xenv.scratch, xenv.vsp);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(xenv.scratch, xenv.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(xenv.scratch);
 		// Generate parallel moves from args into param gprs; assume each src register used only once
 		var dst = Array<X86_64Gpr>.new(GPRs.length);
 		for (i < args.length) {
@@ -3530,6 +3532,9 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		// restore VSP from valueStack.sp
 		masm.emit_get_curstack(xenv.vsp);
 		masm.emit_v3_X86_64Stack_vsp_r_r(xenv.vsp, xenv.vsp);
+		// restore old %sp
+		masm.emit_get_curstack(xenv.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(xenv.scratch);
 	}
 	def orderMoves(dst: Array<X86_64Gpr>, stk: Array<i8>, i: int) {
 		// XXX: use move ordering logic from macro assembler?

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -130,6 +130,12 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def emit_v3_set_X86_64Stack_rsp_r_r(stk: Reg, rsp: Reg) {
 		emit_mov_m_r(ValueKind.REF, MasmAddr(stk, offsets.X86_64Stack_rsp), rsp);
 	}
+	def emit_push_X86_64Stack_rsp_r_r(stk: Reg) {
+		asm.q.sub_m_i(G(stk).plus(offsets.X86_64Stack_rsp), Pointer.SIZE);
+	}
+	def emit_pop_X86_64Stack_rsp_r_r(stk: Reg) {
+		asm.q.add_m_i(G(stk).plus(offsets.X86_64Stack_rsp), Pointer.SIZE);
+	}
 
 	def emit_loadbsx_r_r_r_i(kind: ValueKind, dst: Reg, base: Reg, index: Reg, offset: u32) {
 		var t = handle_large_offset(index, offset);

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -50,13 +50,13 @@ component X86_64Runtime {
 		return (null, null);
 	}
 	def runtime_PROBE_loop(stack: X86_64Stack, func: WasmFunction, pc: int) -> Throwable {
-		var frame = TargetFrame(stack.rsp);
+		var frame = TargetFrame(stack.rsp + Pointer.SIZE);
 		var ret = Instrumentation.fireGlobalProbes(DynamicLoc(func, pc, frame));
 		if (ret != null) return stack.throw(ret);
 		return ret;
 	}
 	def runtime_PROBE_instr(stack: X86_64Stack, func: WasmFunction, pc: int) -> Throwable {
-		var frame = TargetFrame(stack.rsp);
+		var frame = TargetFrame(stack.rsp + Pointer.SIZE);
 		var ret = Instrumentation.fireLocalProbes(DynamicLoc(func, pc, frame));
 		if (ret != null) return stack.throw(ret);
 		return ret;
@@ -130,8 +130,6 @@ component X86_64Runtime {
 		curStack.state_ = StackState.RUNNING;
 		curStack.pushN(vals);
 		curStack.push(Value.Ref(cont));
-		curStack.rsp += Pointer.SIZE; // pop ret addr
-		stack.rsp += -Pointer.SIZE; // reserve space for suspend stub addr
 		cont.bottom.parent = null;
 		return null;
 	}
@@ -175,9 +173,10 @@ component X86_64Runtime {
 		curStack.state_ = StackState.RUNNING;
 		curStack.pushN(vals);
 		curStack.push(Value.Ref(this_cont));
-
-		// reserve space for suspend stub addr
-		stack.rsp += -Pointer.SIZE;
+		// push extra dummy RET_ADDR to counteract RT call-site's %sp increment
+		// after a RT call returns
+		// XXX: revisit this design and clean up
+		curStack.rsp += -Pointer.SIZE;
 		return null;
 	}
 	def runtime_doCast(stack: X86_64Stack, instance: Instance, nullable: byte, ht_val: int) -> bool {

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -1218,7 +1218,7 @@ class X86_64SpcModuleCode extends X86_64SpcCode {
 // Represents (shared) code that calls the runtime to generate a trap.
 // This is jumped to conditionally by SPC code or via the signal handler for the
 // {X86_64SpcModuleCode}.
-def TRAP_HANDLER_SIZE = 42;
+def TRAP_HANDLER_SIZE = 48;
 class X86_64SpcTrapsStub extends X86_64SpcCode {
 
 	new() super("spc-trap-stubs", Pointer.NULL, Pointer.NULL) { }
@@ -1362,6 +1362,7 @@ def genTrapsStub(ic: X86_64InterpreterCode, w: DataWriter) {
 			var m_wasm_func = X86_64Regs.RSP.plus(X86_64InterpreterFrame.wasm_func.offset);
 			masm.emit_get_curstack(regs.runtime_arg0);	// stack
 			masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+			masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 			asm.movq_r_m(Target.V3_PARAM_GPRS[2], m_wasm_func);	// wasm_func
 			asm.movq_r_i(Target.V3_PARAM_GPRS[3], -1);		// pc
 			asm.movd_r_i(Target.V3_PARAM_GPRS[4], reason.tag);	// reason

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -94,7 +94,7 @@ class X86_64Stack extends WasmStack {
 		if (Exception.?(thrown)) {
 			var ex = Exception.!(thrown);
 			var new_sp = walk(findExHandler, ex, prev_sp);
-			unwind(prev_sp + -RETADDR_SIZE, new_sp);
+			unwind(prev_sp, new_sp);
 			return ex;
 		}
 
@@ -103,7 +103,7 @@ class X86_64Stack extends WasmStack {
 		var return_parent_sp = walk(if(gatherTrace, addFrameToTrace), trace, prev_sp);
 		// Unwind this stack to the return parent stub and overwrite the caller's return IP.
 		this.vsp = mapping.range.start; // clear value stack
-		unwind(prev_sp + -RETADDR_SIZE, return_parent_sp);
+		unwind(prev_sp, return_parent_sp);
 
 		// Append the (reversed) stacktrace to the throwable.
 		if (trace != null) thrown.prependFrames(ArrayUtil.copyReverse(trace));
@@ -116,7 +116,7 @@ class X86_64Stack extends WasmStack {
 	private def walk<P>(f: (TargetFrame, P) -> bool, param: P, start_sp: Pointer) -> Pointer {
 		var sp = start_sp;
 		while (sp < mapping.range.end) {
-			var retip = (sp + -RETADDR_SIZE).load<Pointer>();
+			var retip = sp.load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
 			var accessor: FrameAccessor;
 			if (Trace.stack && Debug.stack) {
@@ -126,9 +126,9 @@ class X86_64Stack extends WasmStack {
 			}
 			match (code) {
 				null => break;
-				x: X86_64InterpreterCode => if (f != null && !f(TargetFrame(sp), param)) return sp;
-				x: X86_64SpcModuleCode => if (f != null && !f(TargetFrame(sp), param)) return sp;
-				x: X86_64SpcTrapsStub => if (f != null && !f(TargetFrame(sp), param)) return sp;
+				x: X86_64InterpreterCode => if (f != null && !f(TargetFrame(sp + RETADDR_SIZE), param)) return sp;
+				x: X86_64SpcModuleCode => if (f != null && !f(TargetFrame(sp + RETADDR_SIZE), param)) return sp;
+				x: X86_64SpcTrapsStub => if (f != null && !f(TargetFrame(sp + RETADDR_SIZE), param)) return sp;
 				x: X86_64ReturnParentStub => return sp;
 			}
 			var t = code.nextFrame(retip, sp);
@@ -225,14 +225,15 @@ class X86_64Stack extends WasmStack {
 	}
 	private def unwind(p_retaddr: Pointer, new_sp: Pointer) {
 		if (new_sp != this.rsp) {
-			this.rsp = (new_sp + -RETADDR_SIZE);
+			this.rsp = new_sp;
 			if (p_retaddr != Pointer.NULL) p_retaddr.store<Pointer>(STACK_UNWIND_STUB.getEntry() + NOP_ENTRY);
 		}
 	}
 	def handleOverflow(ip: Pointer, sp: Pointer) -> Pointer {
 		if (Trace.stack) traceFrames("stack.overflow (before)", sp);
 		// Unwind the stack, skipping the top frame (which might have triggered the overflow)
-		var return_parent_sp = walk<void>(null, (), sp);
+		// XXX: change the %sp convention from the caller instead of doing {+ -RETADDR_SIZE}
+		var return_parent_sp = walk<void>(null, (), sp + -RETADDR_SIZE);
 		// Unwind without updating any return addresses.
 		this.vsp = mapping.range.start; // clear value stack
 		unwind(Pointer.NULL, return_parent_sp);


### PR DESCRIPTION
This refactor changes the runtime stack's `rsp` to point to the interpreter code's return address, making its `rsp` placement consistent with suspended stacks.