### PR TITLE
Applied changes to `X86_64Stack.rsp` convention to frame objects

### DIFF
--- a/src/engine/compiler/MacroAssembler.v3
+++ b/src/engine/compiler/MacroAssembler.v3
@@ -194,6 +194,9 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 	def emit_v3_X86_64Stack_rsp_r_r(dst: Reg, ptr: Reg);
 	def emit_v3_set_X86_64Stack_vsp_r_r(stk: Reg, vsp: Reg);
 	def emit_v3_set_X86_64Stack_rsp_r_r(stk: Reg, rsp: Reg);
+	
+	def emit_push_X86_64Stack_rsp_r_r(stk: Reg);
+	def emit_pop_X86_64Stack_rsp_r_r(stk: Reg);
 
 
 

--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -388,12 +388,16 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_get_curstack(regs.runtime_arg0);
 		// store %sp
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		// reload WasmFunction
 		masm.emit_mov_r_m(ValueKind.REF, regs.runtime_arg1, frame.wasm_func_slot);
 		// load PC
 		masm.emit_mov_r_i(regs.runtime_arg2, pc);
 		// call runtime
 		masm.emit_call_runtime_Probe_instr();
+		// restore {stack.rsp}
+		masm.emit_get_curstack(regs.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.scratch);
 		emit_reload_regs();
 		if (!spillMode.free_regs) state.emitRestoreAll(resolver);
 	}
@@ -675,6 +679,7 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, tag_index);
 		masm.emit_call_runtime_op(Opcode.THROW);
@@ -688,6 +693,7 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		popFixedReg(regs.runtime_arg1);
 		masm.emit_call_runtime_op(Opcode.THROW_REF);
 		setUnreachable();
@@ -1277,12 +1283,16 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		state.emitSaveAll(resolver, runtimeSpillMode);
 		emit_compute_vsp(regs.vsp, state.sp);
 		masm.emit_store_curstack_vsp(regs.vsp);
+		// XXX: if a RT function cannot trap, maybe skip setting {rsp}?
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, nullable);
 		masm.emit_mov_r_i(regs.runtime_arg3, ht_val);
 		masm.emit_call_runtime_cast();
+		masm.emit_get_curstack(regs.runtime_arg0);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_reload_regs();
 		if (!runtimeSpillMode.free_regs) state.emitRestoreAll(resolver);
 		return result;
@@ -1420,9 +1430,12 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, arg1);
 		masm.emit_call_runtime_op(op);
+		masm.emit_get_curstack(regs.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.scratch);
 		dropN(args);
 		for (t in results) state.push(typeToKindFlags(t) | TAG_STORED | IS_STORED, NO_REG, 0);
 		emit_reload_regs();
@@ -1434,10 +1447,13 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		masm.emit_store_curstack_vsp(regs.vsp);
 		masm.emit_get_curstack(regs.runtime_arg0);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 		emit_load_instance(regs.runtime_arg1);
 		masm.emit_mov_r_i(regs.runtime_arg2, arg1);
 		masm.emit_mov_r_i(regs.runtime_arg3, arg2);
 		masm.emit_call_runtime_op(op);
+		masm.emit_get_curstack(regs.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(regs.scratch);
 		dropN(args);
 		for (t in results) state.push(typeToKindFlags(t) | TAG_STORED | IS_STORED, NO_REG, 0);
 		emit_reload_regs();

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -519,6 +519,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		// move function into correct register
 		masm.emit_mov_r_r(ValueKind.REF, xenv.runtime_arg1, r_func);
 		// call runtime
+		// TODO: verify host calls' {rsp} convention
 		masm.emit_call_runtime_callHost(xenv.func_arg);
 
 		// mov %stack, [cur_stack]    ; reload stack object from curStack
@@ -3515,6 +3516,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		masm.emit_get_curstack(xenv.scratch);
 		masm.emit_v3_set_X86_64Stack_vsp_r_r(xenv.scratch, xenv.vsp);
 		masm.emit_v3_set_X86_64Stack_rsp_r_r(xenv.scratch, xenv.sp);
+		masm.emit_push_X86_64Stack_rsp_r_r(xenv.scratch);
 		// Generate parallel moves from args into param gprs; assume each src register used only once
 		var dst = Array<X86_64Gpr>.new(GPRs.length);
 		for (i < args.length) {
@@ -3530,6 +3532,9 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		// restore VSP from valueStack.sp
 		masm.emit_get_curstack(xenv.vsp);
 		masm.emit_v3_X86_64Stack_vsp_r_r(xenv.vsp, xenv.vsp);
+		// restore old %sp
+		masm.emit_get_curstack(xenv.scratch);
+		masm.emit_pop_X86_64Stack_rsp_r_r(xenv.scratch);
 	}
 	def orderMoves(dst: Array<X86_64Gpr>, stk: Array<i8>, i: int) {
 		// XXX: use move ordering logic from macro assembler?

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -130,6 +130,12 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def emit_v3_set_X86_64Stack_rsp_r_r(stk: Reg, rsp: Reg) {
 		emit_mov_m_r(ValueKind.REF, MasmAddr(stk, offsets.X86_64Stack_rsp), rsp);
 	}
+	def emit_push_X86_64Stack_rsp_r_r(stk: Reg) {
+		asm.q.sub_m_i(G(stk).plus(offsets.X86_64Stack_rsp), Pointer.SIZE);
+	}
+	def emit_pop_X86_64Stack_rsp_r_r(stk: Reg) {
+		asm.q.add_m_i(G(stk).plus(offsets.X86_64Stack_rsp), Pointer.SIZE);
+	}
 
 	def emit_loadbsx_r_r_r_i(kind: ValueKind, dst: Reg, base: Reg, index: Reg, offset: u32) {
 		var t = handle_large_offset(index, offset);

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -50,13 +50,13 @@ component X86_64Runtime {
 		return (null, null);
 	}
 	def runtime_PROBE_loop(stack: X86_64Stack, func: WasmFunction, pc: int) -> Throwable {
-		var frame = TargetFrame(stack.rsp);
+		var frame = TargetFrame(stack.rsp + Pointer.SIZE);
 		var ret = Instrumentation.fireGlobalProbes(DynamicLoc(func, pc, frame));
 		if (ret != null) return stack.throw(ret);
 		return ret;
 	}
 	def runtime_PROBE_instr(stack: X86_64Stack, func: WasmFunction, pc: int) -> Throwable {
-		var frame = TargetFrame(stack.rsp);
+		var frame = TargetFrame(stack.rsp + Pointer.SIZE);
 		var ret = Instrumentation.fireLocalProbes(DynamicLoc(func, pc, frame));
 		if (ret != null) return stack.throw(ret);
 		return ret;
@@ -130,8 +130,6 @@ component X86_64Runtime {
 		curStack.state_ = StackState.RUNNING;
 		curStack.pushN(vals);
 		curStack.push(Value.Ref(cont));
-		curStack.rsp += Pointer.SIZE; // pop ret addr
-		stack.rsp += -Pointer.SIZE; // reserve space for suspend stub addr
 		cont.bottom.parent = null;
 		return null;
 	}
@@ -175,9 +173,10 @@ component X86_64Runtime {
 		curStack.state_ = StackState.RUNNING;
 		curStack.pushN(vals);
 		curStack.push(Value.Ref(this_cont));
-
-		// reserve space for suspend stub addr
-		stack.rsp += -Pointer.SIZE;
+		// push extra dummy RET_ADDR to counteract RT call-site's %sp increment
+		// after a RT call returns
+		// XXX: revisit this design and clean up
+		curStack.rsp += -Pointer.SIZE;
 		return null;
 	}
 	def runtime_doCast(stack: X86_64Stack, instance: Instance, nullable: byte, ht_val: int) -> bool {

--- a/src/engine/x86-64/X86_64SinglePassCompiler.v3
+++ b/src/engine/x86-64/X86_64SinglePassCompiler.v3
@@ -1218,7 +1218,7 @@ class X86_64SpcModuleCode extends X86_64SpcCode {
 // Represents (shared) code that calls the runtime to generate a trap.
 // This is jumped to conditionally by SPC code or via the signal handler for the
 // {X86_64SpcModuleCode}.
-def TRAP_HANDLER_SIZE = 42;
+def TRAP_HANDLER_SIZE = 48;
 class X86_64SpcTrapsStub extends X86_64SpcCode {
 
 	new() super("spc-trap-stubs", Pointer.NULL, Pointer.NULL) { }
@@ -1362,6 +1362,7 @@ def genTrapsStub(ic: X86_64InterpreterCode, w: DataWriter) {
 			var m_wasm_func = X86_64Regs.RSP.plus(X86_64InterpreterFrame.wasm_func.offset);
 			masm.emit_get_curstack(regs.runtime_arg0);	// stack
 			masm.emit_v3_set_X86_64Stack_rsp_r_r(regs.runtime_arg0, regs.sp);
+			masm.emit_push_X86_64Stack_rsp_r_r(regs.runtime_arg0);
 			asm.movq_r_m(Target.V3_PARAM_GPRS[2], m_wasm_func);	// wasm_func
 			asm.movq_r_i(Target.V3_PARAM_GPRS[3], -1);		// pc
 			asm.movd_r_i(Target.V3_PARAM_GPRS[4], reason.tag);	// reason

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -509,26 +509,27 @@ component X86_64Stacks {
 	var RESUME_STUB_POINTER: Pointer;
 
 	def getFrameAccessor(sp: Pointer) -> X86_64FrameAccessor {
-		var retip = (sp + -RETADDR_SIZE).load<Pointer>();
+		var retip = sp.load<Pointer>();
 		var code = RiRuntime.findUserCode(retip);
+		var fp = sp + RETADDR_SIZE;
 		match (code) {
 			x: X86_64InterpreterCode => {
-				var prev = (sp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+				var prev = (fp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 				if (prev != null) return prev;
 				// Interpreter frames store the {WasmFunction} _and_ {FuncDecl}.
-				var decl = (sp + X86_64InterpreterFrame.func_decl.offset).load<FuncDecl>();
+				var decl = (fp + X86_64InterpreterFrame.func_decl.offset).load<FuncDecl>();
 				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sp, decl);
-				(sp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
+				(fp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
 				return n;
 			}
 			x: X86_64SpcCode => {
-				var prev = (sp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+				var prev = (fp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 				if (prev != null) return prev;
 				// SPC frames only store the {WasmFunction}.
-				var wf = (sp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
+				var wf = (fp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
 				// TODO: assert wf.decl == x.decl()
 				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sp, wf.decl);
-				(sp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
+				(fp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
 				return n;
 			}
 		}
@@ -859,16 +860,17 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	var writer: X86_64FrameWriter; // non-null if any writes have been made
 	var cached_depth = -1;
 	var cached_pc: int;
+	def fp = sp + RETADDR_SIZE;
 
 	// Returns {true} if this frame has been unwound, either due to returning, a trap, or exception.
 	def isUnwound() -> bool {
 		if (FeatureDisable.frameAccess) return false; // TODO: proper is-frame-unwound check
-		return this != (sp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+		return this != (fp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 	}
 	// Returns the Wasm function in this frame.
 	def func() -> WasmFunction {
 		checkNotUnwound();
-		return (sp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
+		return (fp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
 	}
 	// Returns the current program counter.
 	def pc() -> int {
@@ -877,8 +879,8 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var code = RiRuntime.findUserCode(ip);
 		match (code) {
 			x: X86_64SpcModuleCode => cached_pc = x.lookupPc(ip, true);
-			x: X86_64InterpreterCode => cached_pc = X86_64Interpreter.computePCFromFrame(sp);
-			x: X86_64SpcTrapsStub => cached_pc = (sp + X86_64InterpreterFrame.curpc.offset).load<int>();
+			x: X86_64InterpreterCode => cached_pc = X86_64Interpreter.computePCFromFrame(fp);
+			x: X86_64SpcTrapsStub => cached_pc = (fp + X86_64InterpreterFrame.curpc.offset).load<int>();
 			_ => cached_pc = -1;
 		}
 		return cached_pc;
@@ -898,8 +900,8 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var depth = 0;
 		var next_sp = sp;
 		while (true) {
-			next_sp = next_sp + X86_64InterpreterFrame.size + RETADDR_SIZE;
-			var retip = (next_sp + -RETADDR_SIZE).load<Pointer>();
+			next_sp = next_sp + RETADDR_SIZE + X86_64InterpreterFrame.size;
+			var retip = next_sp.load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
 			match (code) {
 				x: X86_64InterpreterCode => ;
@@ -923,7 +925,7 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var code = RiRuntime.findUserCode(ip);
 		match (code) {
 			x: X86_64InterpreterCode => {
-				var stp = (sp + X86_64InterpreterFrame.stp.offset).load<Pointer>();
+				var stp = (fp + X86_64InterpreterFrame.stp.offset).load<Pointer>();
 				var stp0 = Pointer.atContents(func().decl.sidetable.entries);
 				return int.!((stp - stp0) / 4);
 			}
@@ -944,28 +946,28 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	def getLocal(i: int) -> Value {
 		checkNotUnwound();
 		checkLocalBounds(i);
-		var vfp = (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		return stack.readValue(vfp, i);
 	}
 	// Get the value of frame variable {i}.
 	def getFrameVar(i: int) -> Value {
 		checkNotUnwound();
 		checkFrameVarBounds(i);
-		var vfp = (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		return stack.readValue(vfp, i + decl.num_locals);
 	}
 	// Get the number of operand stack elements.
 	def numOperands() -> int {
 		checkNotUnwound();
-		var vfp = (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
-		var vsp = (sp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
+		var vfp = (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vsp = (fp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
 		var diff = int.!((vsp - vfp) / Target.tagging.slot_size);
 		return diff - decl.num_locals;
 	}
 	// Get operand at depth {i}, with 0 being the top of the stack, -1 being one lower, etc.
 	def getOperand(i: int) -> Value {
 		checkNotUnwound();
-		var vsp = (sp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
+		var vsp = (fp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
 		return stack.readValue(vsp, i - 1);
 	}
 	// Get the frame writer.
@@ -975,15 +977,15 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 
 	// Read the return address from the frame.
 	def readRetAddr() -> Pointer {
-		return (sp + X86_64InterpreterFrame.size).load<Pointer>();
+		return (fp + X86_64InterpreterFrame.size).load<Pointer>();
 	}
 	// Read the instruction pointer from the frame.
 	private def readIp() -> Pointer {
-		return (sp + -RETADDR_SIZE).load<Pointer>();
+		return (fp + -RETADDR_SIZE).load<Pointer>();
 	}
 	// Compute the caller frame's stack pointer.
 	def callerSp() -> Pointer {
-		return sp + X86_64InterpreterFrame.size + RETADDR_SIZE;
+		return sp + RETADDR_SIZE + X86_64InterpreterFrame.size;
 	}
 	def isSpc() -> bool {
 		var ip = readIp();
@@ -1013,24 +1015,24 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	private def deoptToInterpreter0(func: FuncDecl, pc: int, stp: int) {
 		var ic = X86_64PreGenStubs.getInterpreterCode();
 		setNewProgramLocation(func, pc, stp);
-		(sp + -RETADDR_SIZE).store<Pointer>(ic.start + ic.header.deoptReentryOffset);
+		sp.store<Pointer>(ic.start + ic.header.deoptReentryOffset);
 	}
 	private def setNewProgramLocation(func: FuncDecl, pc: int, stp: int) {
 		var code = func.cur_bytecode;
-		(sp + X86_64InterpreterFrame.func_decl.offset)	.store<FuncDecl>(func);
-		(sp + X86_64InterpreterFrame.curpc.offset)	.store<int>(pc);
-		(sp + X86_64InterpreterFrame.code.offset)	.store<Array<byte>>(code);
-		(sp + X86_64InterpreterFrame.ip.offset)		.store<Pointer>(Pointer.atElement(code, pc));
-		(sp + X86_64InterpreterFrame.eip.offset)	.store<Pointer>(Pointer.atContents(code) + code.length);
+		(fp + X86_64InterpreterFrame.func_decl.offset)	.store<FuncDecl>(func);
+		(fp + X86_64InterpreterFrame.curpc.offset)	.store<int>(pc);
+		(fp + X86_64InterpreterFrame.code.offset)	.store<Array<byte>>(code);
+		(fp + X86_64InterpreterFrame.ip.offset)		.store<Pointer>(Pointer.atElement(code, pc));
+		(fp + X86_64InterpreterFrame.eip.offset)	.store<Pointer>(Pointer.atContents(code) + code.length);
 		var st_entries = func.sidetable.entries;
 		var st_ptr = if(stp == st_entries.length, Pointer.atContents(st_entries), Pointer.atElement(func.sidetable.entries, stp));
-		(sp + X86_64InterpreterFrame.stp.offset)	.store<Pointer>(st_ptr);
+		(fp + X86_64InterpreterFrame.stp.offset)	.store<Pointer>(st_ptr);
 	}
 	private def vfp() -> Pointer {
-		return (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		return (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 	}
 	private def set_vsp(p: Pointer) {
-		(sp + X86_64InterpreterFrame.vsp.offset).store<Pointer>(p);
+		(fp + X86_64InterpreterFrame.vsp.offset).store<Pointer>(p);
 	}
 }
 private class X86_64FrameWriter extends FrameWriter {
@@ -1042,7 +1044,7 @@ private class X86_64FrameWriter extends FrameWriter {
 	def setLocal(i: int, v: Value) {
 		accessor.checkNotUnwound();
 		accessor.checkLocalBounds(i);
-		var vfp = (accessor.sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (accessor.fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		accessor.stack.overwriteValue(vfp, i, v);
 		if (accessor.isSpc()) accessor.deoptToInterpreter();
 	}
@@ -1050,7 +1052,7 @@ private class X86_64FrameWriter extends FrameWriter {
 	def setFrameVar(i: int, v: Value) {
 		accessor.checkNotUnwound();
 		accessor.checkFrameVarBounds(i);
-		var vfp = (accessor.sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (accessor.fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		accessor.stack.overwriteValue(vfp, i + accessor.decl.num_locals, v);
 		if (accessor.isSpc()) accessor.deoptToInterpreter();
 	}

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -511,25 +511,25 @@ component X86_64Stacks {
 	def getFrameAccessor(sp: Pointer) -> X86_64FrameAccessor {
 		var retip = sp.load<Pointer>();
 		var code = RiRuntime.findUserCode(retip);
-		var fp = sp + RETADDR_SIZE;
+		var frame_pos = sp + RETADDR_SIZE;
 		match (code) {
 			x: X86_64InterpreterCode => {
-				var prev = (fp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+				var prev = (frame_pos + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 				if (prev != null) return prev;
 				// Interpreter frames store the {WasmFunction} _and_ {FuncDecl}.
-				var decl = (fp + X86_64InterpreterFrame.func_decl.offset).load<FuncDecl>();
+				var decl = (frame_pos + X86_64InterpreterFrame.func_decl.offset).load<FuncDecl>();
 				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sp, decl);
-				(fp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
+				(frame_pos + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
 				return n;
 			}
 			x: X86_64SpcCode => {
-				var prev = (fp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+				var prev = (frame_pos + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 				if (prev != null) return prev;
 				// SPC frames only store the {WasmFunction}.
-				var wf = (fp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
+				var wf = (frame_pos + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
 				// TODO: assert wf.decl == x.decl()
 				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sp, wf.decl);
-				(fp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
+				(frame_pos + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
 				return n;
 			}
 		}
@@ -860,17 +860,17 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	var writer: X86_64FrameWriter; // non-null if any writes have been made
 	var cached_depth = -1;
 	var cached_pc: int;
-	def fp = sp + RETADDR_SIZE;
+	def frame_pos = sp + RETADDR_SIZE;
 
 	// Returns {true} if this frame has been unwound, either due to returning, a trap, or exception.
 	def isUnwound() -> bool {
 		if (FeatureDisable.frameAccess) return false; // TODO: proper is-frame-unwound check
-		return this != (fp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+		return this != (frame_pos + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 	}
 	// Returns the Wasm function in this frame.
 	def func() -> WasmFunction {
 		checkNotUnwound();
-		return (fp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
+		return (frame_pos + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
 	}
 	// Returns the current program counter.
 	def pc() -> int {
@@ -879,8 +879,8 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var code = RiRuntime.findUserCode(ip);
 		match (code) {
 			x: X86_64SpcModuleCode => cached_pc = x.lookupPc(ip, true);
-			x: X86_64InterpreterCode => cached_pc = X86_64Interpreter.computePCFromFrame(fp);
-			x: X86_64SpcTrapsStub => cached_pc = (fp + X86_64InterpreterFrame.curpc.offset).load<int>();
+			x: X86_64InterpreterCode => cached_pc = X86_64Interpreter.computePCFromFrame(frame_pos);
+			x: X86_64SpcTrapsStub => cached_pc = (frame_pos + X86_64InterpreterFrame.curpc.offset).load<int>();
 			_ => cached_pc = -1;
 		}
 		return cached_pc;
@@ -925,7 +925,7 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var code = RiRuntime.findUserCode(ip);
 		match (code) {
 			x: X86_64InterpreterCode => {
-				var stp = (fp + X86_64InterpreterFrame.stp.offset).load<Pointer>();
+				var stp = (frame_pos + X86_64InterpreterFrame.stp.offset).load<Pointer>();
 				var stp0 = Pointer.atContents(func().decl.sidetable.entries);
 				return int.!((stp - stp0) / 4);
 			}
@@ -946,28 +946,28 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	def getLocal(i: int) -> Value {
 		checkNotUnwound();
 		checkLocalBounds(i);
-		var vfp = (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (frame_pos + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		return stack.readValue(vfp, i);
 	}
 	// Get the value of frame variable {i}.
 	def getFrameVar(i: int) -> Value {
 		checkNotUnwound();
 		checkFrameVarBounds(i);
-		var vfp = (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (frame_pos + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		return stack.readValue(vfp, i + decl.num_locals);
 	}
 	// Get the number of operand stack elements.
 	def numOperands() -> int {
 		checkNotUnwound();
-		var vfp = (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
-		var vsp = (fp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
+		var vfp = (frame_pos + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vsp = (frame_pos + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
 		var diff = int.!((vsp - vfp) / Target.tagging.slot_size);
 		return diff - decl.num_locals;
 	}
 	// Get operand at depth {i}, with 0 being the top of the stack, -1 being one lower, etc.
 	def getOperand(i: int) -> Value {
 		checkNotUnwound();
-		var vsp = (fp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
+		var vsp = (frame_pos + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
 		return stack.readValue(vsp, i - 1);
 	}
 	// Get the frame writer.
@@ -977,11 +977,11 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 
 	// Read the return address from the frame.
 	def readRetAddr() -> Pointer {
-		return (fp + X86_64InterpreterFrame.size).load<Pointer>();
+		return (frame_pos + X86_64InterpreterFrame.size).load<Pointer>();
 	}
 	// Read the instruction pointer from the frame.
 	private def readIp() -> Pointer {
-		return (fp + -RETADDR_SIZE).load<Pointer>();
+		return (frame_pos + -RETADDR_SIZE).load<Pointer>();
 	}
 	// Compute the caller frame's stack pointer.
 	def callerSp() -> Pointer {
@@ -1019,20 +1019,20 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	}
 	private def setNewProgramLocation(func: FuncDecl, pc: int, stp: int) {
 		var code = func.cur_bytecode;
-		(fp + X86_64InterpreterFrame.func_decl.offset)	.store<FuncDecl>(func);
-		(fp + X86_64InterpreterFrame.curpc.offset)	.store<int>(pc);
-		(fp + X86_64InterpreterFrame.code.offset)	.store<Array<byte>>(code);
-		(fp + X86_64InterpreterFrame.ip.offset)		.store<Pointer>(Pointer.atElement(code, pc));
-		(fp + X86_64InterpreterFrame.eip.offset)	.store<Pointer>(Pointer.atContents(code) + code.length);
+		(frame_pos + X86_64InterpreterFrame.func_decl.offset)	.store<FuncDecl>(func);
+		(frame_pos + X86_64InterpreterFrame.curpc.offset)	.store<int>(pc);
+		(frame_pos + X86_64InterpreterFrame.code.offset)	.store<Array<byte>>(code);
+		(frame_pos + X86_64InterpreterFrame.ip.offset)		.store<Pointer>(Pointer.atElement(code, pc));
+		(frame_pos + X86_64InterpreterFrame.eip.offset)	.store<Pointer>(Pointer.atContents(code) + code.length);
 		var st_entries = func.sidetable.entries;
 		var st_ptr = if(stp == st_entries.length, Pointer.atContents(st_entries), Pointer.atElement(func.sidetable.entries, stp));
-		(fp + X86_64InterpreterFrame.stp.offset)	.store<Pointer>(st_ptr);
+		(frame_pos + X86_64InterpreterFrame.stp.offset)	.store<Pointer>(st_ptr);
 	}
 	private def vfp() -> Pointer {
-		return (fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		return (frame_pos + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 	}
 	private def set_vsp(p: Pointer) {
-		(fp + X86_64InterpreterFrame.vsp.offset).store<Pointer>(p);
+		(frame_pos + X86_64InterpreterFrame.vsp.offset).store<Pointer>(p);
 	}
 }
 private class X86_64FrameWriter extends FrameWriter {
@@ -1044,7 +1044,7 @@ private class X86_64FrameWriter extends FrameWriter {
 	def setLocal(i: int, v: Value) {
 		accessor.checkNotUnwound();
 		accessor.checkLocalBounds(i);
-		var vfp = (accessor.fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (accessor.frame_pos + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		accessor.stack.overwriteValue(vfp, i, v);
 		if (accessor.isSpc()) accessor.deoptToInterpreter();
 	}
@@ -1052,7 +1052,7 @@ private class X86_64FrameWriter extends FrameWriter {
 	def setFrameVar(i: int, v: Value) {
 		accessor.checkNotUnwound();
 		accessor.checkFrameVarBounds(i);
-		var vfp = (accessor.fp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (accessor.frame_pos + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		accessor.stack.overwriteValue(vfp, i + accessor.decl.num_locals, v);
 		if (accessor.isSpc()) accessor.deoptToInterpreter();
 	}

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -94,7 +94,7 @@ class X86_64Stack extends WasmStack {
 		if (Exception.?(thrown)) {
 			var ex = Exception.!(thrown);
 			var new_sp = walk(findExHandler, ex, prev_sp);
-			unwind(prev_sp + -RETADDR_SIZE, new_sp);
+			unwind(prev_sp, new_sp);
 			return ex;
 		}
 
@@ -103,7 +103,7 @@ class X86_64Stack extends WasmStack {
 		var return_parent_sp = walk(if(gatherTrace, addFrameToTrace), trace, prev_sp);
 		// Unwind this stack to the return parent stub and overwrite the caller's return IP.
 		this.vsp = mapping.range.start; // clear value stack
-		unwind(prev_sp + -RETADDR_SIZE, return_parent_sp);
+		unwind(prev_sp, return_parent_sp);
 
 		// Append the (reversed) stacktrace to the throwable.
 		if (trace != null) thrown.prependFrames(ArrayUtil.copyReverse(trace));
@@ -116,7 +116,7 @@ class X86_64Stack extends WasmStack {
 	private def walk<P>(f: (TargetFrame, P) -> bool, param: P, start_sp: Pointer) -> Pointer {
 		var sp = start_sp;
 		while (sp < mapping.range.end) {
-			var retip = (sp + -RETADDR_SIZE).load<Pointer>();
+			var retip = sp.load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
 			var accessor: FrameAccessor;
 			if (Trace.stack && Debug.stack) {
@@ -126,9 +126,9 @@ class X86_64Stack extends WasmStack {
 			}
 			match (code) {
 				null => break;
-				x: X86_64InterpreterCode => if (f != null && !f(TargetFrame(sp), param)) return sp;
-				x: X86_64SpcModuleCode => if (f != null && !f(TargetFrame(sp), param)) return sp;
-				x: X86_64SpcTrapsStub => if (f != null && !f(TargetFrame(sp), param)) return sp;
+				x: X86_64InterpreterCode => if (f != null && !f(TargetFrame(sp + RETADDR_SIZE), param)) return sp;
+				x: X86_64SpcModuleCode => if (f != null && !f(TargetFrame(sp + RETADDR_SIZE), param)) return sp;
+				x: X86_64SpcTrapsStub => if (f != null && !f(TargetFrame(sp + RETADDR_SIZE), param)) return sp;
 				x: X86_64ReturnParentStub => return sp;
 			}
 			var t = code.nextFrame(retip, sp);
@@ -225,14 +225,15 @@ class X86_64Stack extends WasmStack {
 	}
 	private def unwind(p_retaddr: Pointer, new_sp: Pointer) {
 		if (new_sp != this.rsp) {
-			this.rsp = (new_sp + -RETADDR_SIZE);
+			this.rsp = new_sp;
 			if (p_retaddr != Pointer.NULL) p_retaddr.store<Pointer>(STACK_UNWIND_STUB.getEntry() + NOP_ENTRY);
 		}
 	}
 	def handleOverflow(ip: Pointer, sp: Pointer) -> Pointer {
 		if (Trace.stack) traceFrames("stack.overflow (before)", sp);
 		// Unwind the stack, skipping the top frame (which might have triggered the overflow)
-		var return_parent_sp = walk<void>(null, (), sp);
+		// XXX: change the %sp convention from the caller instead of doing {+ -RETADDR_SIZE}
+		var return_parent_sp = walk<void>(null, (), sp + -RETADDR_SIZE);
 		// Unwind without updating any return addresses.
 		this.vsp = mapping.range.start; // clear value stack
 		unwind(Pointer.NULL, return_parent_sp);

--- a/src/engine/x86-64/X86_64Target.v3
+++ b/src/engine/x86-64/X86_64Target.v3
@@ -127,7 +127,7 @@ type TargetCode(spc_entry: Pointer) #unboxed { }
 type TargetModule(spc_code: X86_64SpcModuleCode) #unboxed { }
 type TargetFrame(sp: Pointer) #unboxed {
 	def getFrameAccessor() -> X86_64FrameAccessor {
-		return X86_64Stacks.getFrameAccessor(sp);
+		return X86_64Stacks.getFrameAccessor(sp + -Pointer.SIZE);
 	}
 }
 type SpcResultForStub(wf: WasmFunction, entrypoint: Pointer, thrown: Throwable) #unboxed { }


### PR DESCRIPTION
#374 changed the placement of `X86_64Stack.rsp` during runtime calls. This PR applies this change to x86 frame accessors so that their `sp` points to the return addresses as well.