### PR TITLE
[refactor] Improved stack walking logic

### DIFF
--- a/src/engine/WasmStack.v3
+++ b/src/engine/WasmStack.v3
@@ -26,7 +26,7 @@ class ExecStack {
 	def pushN(vs: Range<Value>);
 	
 	def trap(r: TrapReason) -> Throwable;
-	def throw(t: Throwable) -> Throwable;
+	def throw(t: Throwable) -> ThrowResult;
 
 	def trap_or<T>(r: (T, TrapReason), push: T -> ()) -> Throwable {
 		if (r.1 != TrapReason.NONE) return trap(r.1);
@@ -159,4 +159,10 @@ type FrameLoc { // TODO: #unboxed
 	case None;
 	case Wasm(func: WasmFunction, pc: int, frame: TargetFrame);
 	case Host(func: HostFunction, frame: HostFrame);
+}
+
+// Result of a throw.
+type ThrowResult {
+	case Handled(at: WasmStack);
+	case Unhandled(thrown: Throwable);
 }

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -15,11 +15,7 @@ class V3Interpreter extends WasmStack {
 	private var params_arity = -1;
 	private var return_arity = -1;
 
-	// XXX: remove this
-	// This flag is used for incrementing past a {resume} or {switch} opcode after
-	// being resumed. Suspending/switching shouldn't increment {frame.pc} until
-	// {resume} as {resume_throw} uses the old {pc} for error handling.
-	private var was_suspended = false; // TODO: change to {suspend_pc}
+	private var suspend_pc: int = -1;
 
 	// WasmStack interface
 	// ===================================================================================
@@ -31,6 +27,7 @@ class V3Interpreter extends WasmStack {
 		pushFrame(func, 0);
 		params_arity = func.sig.params.length;
 		return_arity = func.sig.results.length;
+		suspend_pc = -1;
 		thrown = null;
 		parent = null;
 		state_ = if(params_arity == 0, StackState.RESUMABLE, StackState.SUSPENDED);
@@ -47,24 +44,6 @@ class V3Interpreter extends WasmStack {
 		checkState("resume()", StackState.RESUMABLE);
 		thrown = null;
 		goto_stack = null;
-
-		if (was_suspended) {
-			if (Trace.stack) {
-				Trace.OUT.puts("skipping past suspend/switch opcode in suspended stack:").ln();
-				Trace.OUT.put1("  old=%d, ", frame.pc);
-			}
-			was_suspended = false;
-			// advance past suspend instruction
-			var code = frame.func.decl.cur_bytecode;
-			codeptr.reset(code, frame.pc, code.length);
-			var opcode = codeptr.read_opcode_and_skip(frame.func.decl);
-			frame.pc = codeptr.pos;
-			if (Trace.stack) Trace.OUT.put1("new=%d", frame.pc).ln();
-			match (opcode) {
-				SUSPEND, SWITCH => ;
-				_ => fail(Strings.format1("expected suspend/switch instruction, got %s", opcode.name));
-			}
-		}
 
 		// Set the initial state to running and loop until return, throw, or suspend.
 		state_ = StackState.RUNNING;
@@ -127,8 +106,7 @@ class V3Interpreter extends WasmStack {
 		return_arity = -1;
 		params_arity = -1;
 		codeptr.reset(null, 0, 0);
-
-		was_suspended = false;
+		suspend_pc = -1;
 	}
 
 	// Internal implementation: nominally private
@@ -243,7 +221,7 @@ class V3Interpreter extends WasmStack {
 			} else {
 				opcode = codeptr.read_opcode();
 			}
-			execOp(pc, opcode);
+			execOp(pc, opcode); // TODO: make this return a value or smth
 		}
 	}
 	def runHostCall() {
@@ -1246,12 +1224,13 @@ class V3Interpreter extends WasmStack {
 				if (Trace.stack) Trace.OUT.put2("resume_throw %q %q", tag.render, cont.render).ln();
 
 				// search for handler in continuation
+				var top = V3Interpreter.!(cont.top);
+				top.frame.pc = top.suspend_pc;
 				match (cont.top.throw(ex)) {
 					Handled(stack) => {
 						if (Trace.stack) Trace.OUT.put1("tag %q handled in continuation, resuming", tag.render).ln();
 						var handler = V3Interpreter.!(stack);
 						handler.state_ = StackState.RESUMABLE;
-						handler.was_suspended = false;
 						cont.top = handler;
 						resumeContinuation(cont);
 						return; // skip setting frame.pc = codeptr.pos
@@ -1276,8 +1255,7 @@ class V3Interpreter extends WasmStack {
 				handler.pushN(popN(tag.sig.params));
 				handler.push(Value.Ref(cont));
 				goto_stack = handler;
-				was_suspended = true;
-				return; // skip setting frame.pc = codeptr.pos
+				suspend_pc = frame.pc;
 			}
 			SWITCH => {
 				// `target_cont`: the continuation to switch to
@@ -1312,8 +1290,7 @@ class V3Interpreter extends WasmStack {
 				target_cont.top.bind(vals);
 				target_cont.top.bind([Value.Ref(cont)]);
 				goto_stack = V3Interpreter.!(target_cont.top);
-				was_suspended = true;
-				return; // skip setting frame.pc = codeptr.pos
+				suspend_pc = frame.pc;
 			}
 			INVALID => trap(TrapReason.INVALID_OPCODE);
 			_ => {

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -32,7 +32,7 @@ class V3Interpreter extends WasmStack {
 		params_arity = func.sig.params.length;
 		return_arity = func.sig.results.length;
 		thrown = null;
-		was_suspended = false;
+		parent = null;
 		state_ = if(params_arity == 0, StackState.RESUMABLE, StackState.SUSPENDED);
 	}
 	def bind(args: Range<Value>) -> this {
@@ -127,6 +127,8 @@ class V3Interpreter extends WasmStack {
 		return_arity = -1;
 		params_arity = -1;
 		codeptr.reset(null, 0, 0);
+
+		was_suspended = false;
 	}
 
 	// Internal implementation: nominally private
@@ -1704,7 +1706,6 @@ class V3Interpreter extends WasmStack {
 				if (Trace.exception) Trace.OUT.puts("  push_exnref").ln();
 				values.push(Value.Ref(ex));
 			}
-			frame = f;
 			return true;
 		}
 		return false;

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -5,7 +5,7 @@ class V3Interpreter extends WasmStack {
 	private var instrTracer: InstrTracer;
 	private def values = ArrayStack<Value>.new();	// storage of all WasmValues
 	private var state_: StackState;
-	private var goto_stack: V3Interpreter; // set when state_ == {CALL_CHILD|SUSPENDED}
+	private var goto_stack: V3Interpreter; // set when state_ == {CALL_CHILD|SUSPENDED|THROWING}
 	private var cache: V3Frame;			// cache of all V3Frame objects (bottom of stack)
 	private var frame: V3Frame;
 	private var host_frame: HostFrame;
@@ -46,6 +46,7 @@ class V3Interpreter extends WasmStack {
 	def resume() -> Result {
 		checkState("resume()", StackState.RESUMABLE);
 		thrown = null;
+		goto_stack = null;
 
 		if (was_suspended) {
 			if (Trace.stack) {
@@ -76,7 +77,11 @@ class V3Interpreter extends WasmStack {
 
 		// Return the appropriate result.
 		match (state_) {
-			THROWING => return clearAndThrow();
+			THROWING => {
+				// If {goto_stack} is set, then a handler is found.
+				var t = clearAndThrow();
+				return if(goto_stack == null, t, Result.Switch(goto_stack));
+			}
 			RETURNING => return clearAndReturn();
 			SUSPENDED, CALL_CHILD => return Result.Switch(goto_stack);
 			_ => {
@@ -1219,7 +1224,6 @@ class V3Interpreter extends WasmStack {
 				if (cont.used) return void(trap(TrapReason.USED_CONTINUATION));
 				cont.used = true;
 
-				if (Trace.stack) Trace.OUT.put1("resume %q", cont.render).ln();
 				cont.top.bind(popN(cont_type.sig.params));
 				resumeContinuation(cont);
 				return; // skip setting frame.pc = codeptr.pos
@@ -1239,28 +1243,21 @@ class V3Interpreter extends WasmStack {
 				var ex: Throwable = Exception.new(tag, popN(tag.sig.params), null);
 				if (Trace.stack) Trace.OUT.put2("resume_throw %q %q", tag.render, cont.render).ln();
 
-				// search for handler in continuation first
-				var handler_in_cont: V3Interpreter = null;
-				for (curr = V3Interpreter.!(cont.top); curr != null; curr = V3Interpreter.!(curr.parent)) {
-					match (curr.throw(ex)) {
-						Handled => {
-							handler_in_cont = curr;
-							handler_in_cont.was_suspended = false;
-							break;
-						}
-						Unhandled(thrown) => ex = thrown;
+				// search for handler in continuation
+				match (cont.top.throw(ex)) {
+					Handled(stack) => {
+						if (Trace.stack) Trace.OUT.put1("tag %q handled in continuation, resuming", tag.render).ln();
+						var handler = V3Interpreter.!(stack);
+						handler.state_ = StackState.RESUMABLE;
+						handler.was_suspended = false;
+						cont.top = handler;
+						resumeContinuation(cont);
+						return; // skip setting frame.pc = codeptr.pos
 					}
-				}
-
-				if (handler_in_cont == null) {
-					if (Trace.stack) Trace.OUT.put1("tag %q not handled in continuation, throwing", tag.render).ln();
-					throw(ex);
-				} else {
-					if (Trace.stack) Trace.OUT.put1("tag %q handled in continuation, resuming", tag.render).ln();
-					handler_in_cont.state_ = StackState.RESUMABLE;
-					cont.top = handler_in_cont;
-					resumeContinuation(cont);
-					return; // skip setting frame.pc = codeptr.pos
+					Unhandled => {
+						if (Trace.stack) Trace.OUT.put1("tag %q not handled in continuation, throwing", tag.render).ln();
+						throw(ex);
+					}
 				}
 			}
 			SUSPEND => {
@@ -1663,38 +1660,63 @@ class V3Interpreter extends WasmStack {
 		goto_stack = V3Interpreter.!(cont.top);
 	}
 	def throw(t: Throwable) -> ThrowResult {
+		if (Trace.stack) Trace.OUT.put1("throw on stack: %q", t.render).ln();
 		if (Exception.?(t)) {
 			var ex = Exception.!(t);
-			for (f = frame; f != null && f.func != null; f = f.prev) {
-				var handler = f.func.decl.findExHandler(f.func.instance, ex.tag, f.pc);
-				if (handler.handler_pc >= 0) {
-					frame = f;
-					var code = f.func.decl.cur_bytecode;
-					f.pc = handler.handler_pc;
-					f.stp = handler.sidetable_pos;
-					codeptr.reset(code, f.pc, code.length);
-					// TODO: clean up frame math here
-					values.top = f.fp + handler.val_stack_top + f.func.decl.num_slots();
-					for (v in ex.vals) values.push(v);
-					if (handler.ex_slot >= 0) {
-						if (Trace.exception) Trace.OUT.put2("  set_ex_slot fp=%d, ex_slot=%d", f.fp, handler.ex_slot).ln();
-						values.elems[f.fp + f.func.decl.num_locals + handler.ex_slot] = Value.Ref(ex);
+			for (stack = this; stack != null; stack = V3Interpreter.!(stack.parent)) {
+				for (f = stack.frame; f != null && f.func != null; f = f.prev) {
+					if (stack.tryHandleEx(ex, f)) {
+						if (stack == this) { // don't transfer
+							return ThrowResult.Handled(this);
+						} else { // go to handler stack
+							state_ = StackState.THROWING;
+							goto_stack = stack;
+							goto_stack.state_ = StackState.RESUMABLE;
+							return ThrowResult.Handled(stack);
+						}
 					}
-					if (handler.push_exnref) {
-						if (Trace.exception) Trace.OUT.puts("  push_exnref").ln();
-						values.push(Value.Ref(ex));
-					}
-					frame = f;
-					return ThrowResult.Handled(this);
 				}
+				stack.trapWith(ex);
 			}
+			return ThrowResult.Unhandled(thrown);
 		}
+
+		trapWith(t);
+		return ThrowResult.Unhandled(thrown);
+	}
+	// Returns whether the given exception can be handled by the given frame.
+	private def tryHandleEx(ex: Exception, f: V3Frame) -> bool {
+		var handler = f.func.decl.findExHandler(f.func.instance, ex.tag, f.pc);
+		if (handler.handler_pc >= 0) {
+			frame = f;
+			var code = f.func.decl.cur_bytecode;
+			f.pc = handler.handler_pc;
+			f.stp = handler.sidetable_pos;
+			codeptr.reset(code, f.pc, code.length);
+			// TODO: clean up frame math here
+			values.top = f.fp + handler.val_stack_top + f.func.decl.num_slots();
+			for (v in ex.vals) values.push(v);
+			if (handler.ex_slot >= 0) {
+				if (Trace.exception) Trace.OUT.put2("  set_ex_slot fp=%d, ex_slot=%d", f.fp, handler.ex_slot).ln();
+				values.elems[f.fp + f.func.decl.num_locals + handler.ex_slot] = Value.Ref(ex);
+			}
+			if (handler.push_exnref) {
+				if (Trace.exception) Trace.OUT.puts("  push_exnref").ln();
+				values.push(Value.Ref(ex));
+			}
+			frame = f;
+			return true;
+		}
+		return false;
+	}
+	// Marks this stack as throwing with {t}.
+	private def trapWith(t: Throwable) {
 		var segment = popAllFrames(true);
 		if (segment != null) t = t.prependFrames(segment.frames).prependHostFunction(segment.host);
 		state_ = StackState.THROWING;
 		thrown = t; // unhandled exception
-		return ThrowResult.Unhandled(thrown);
 	}
+
 	def trap(reason: TrapReason) -> Throwable {
 		var stacktrace = popAllFrames(true);
 		thrown = Trap.new(reason, null, stacktrace);

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -1242,11 +1242,13 @@ class V3Interpreter extends WasmStack {
 				// search for handler in continuation first
 				var handler_in_cont: V3Interpreter = null;
 				for (curr = V3Interpreter.!(cont.top); curr != null; curr = V3Interpreter.!(curr.parent)) {
-					ex = curr.throw(ex);
-					if (ex == null) { // handled
-						handler_in_cont = curr;
-						handler_in_cont.was_suspended = false;
-						break;
+					match (curr.throw(ex)) {
+						Handled => {
+							handler_in_cont = curr;
+							handler_in_cont.was_suspended = false;
+							break;
+						}
+						Unhandled(thrown) => ex = thrown;
 					}
 				}
 
@@ -1651,16 +1653,16 @@ class V3Interpreter extends WasmStack {
 		if (Trace.stack) Trace.OUT.puts("  found switch handler").ln();
 		return handler;
 	}
-	def onChildThrow(t: Throwable) -> Throwable {
+	def onChildThrow(t: Throwable) {
 		state_ = StackState.RESUMABLE;
-		return throw(t);
+		throw(t);
 	}
 	def resumeContinuation(cont: Continuation) {
 		state_ = StackState.CALL_CHILD;
 		cont.bottom.parent = this;
 		goto_stack = V3Interpreter.!(cont.top);
 	}
-	def throw(t: Throwable) -> Throwable {
+	def throw(t: Throwable) -> ThrowResult {
 		if (Exception.?(t)) {
 			var ex = Exception.!(t);
 			for (f = frame; f != null && f.func != null; f = f.prev) {
@@ -1683,14 +1685,15 @@ class V3Interpreter extends WasmStack {
 						values.push(Value.Ref(ex));
 					}
 					frame = f;
-					return null;
+					return ThrowResult.Handled(this);
 				}
 			}
 		}
 		var segment = popAllFrames(true);
 		if (segment != null) t = t.prependFrames(segment.frames).prependHostFunction(segment.host);
 		state_ = StackState.THROWING;
-		return thrown = t; // unhandled exception
+		thrown = t; // unhandled exception
+		return ThrowResult.Unhandled(thrown);
 	}
 	def trap(reason: TrapReason) -> Throwable {
 		var stacktrace = popAllFrames(true);

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -19,7 +19,7 @@ class V3Interpreter extends WasmStack {
 	// This flag is used for incrementing past a {resume} or {switch} opcode after
 	// being resumed. Suspending/switching shouldn't increment {frame.pc} until
 	// {resume} as {resume_throw} uses the old {pc} for error handling.
-	private var was_suspended = false;
+	private var was_suspended = false; // TODO: change to {suspend_pc}
 
 	// WasmStack interface
 	// ===================================================================================

--- a/src/engine/v3/V3Target.v3
+++ b/src/engine/v3/V3Target.v3
@@ -55,21 +55,7 @@ class V3InterpreterOnlyStrategy extends ExecutionStrategy {
 			//   terminates.
 			// - Switches the current stack based on the stack switch request
 			//   in the execution `Result`.
-
-			// Runs the stack until a result is produced.
-			var r: Result;
-			var state = stack.state();
-			if (Trace.stack) Trace.OUT.put1("resume[state=%s]", state.name).ln();
-			match (state) {
-				RESUMABLE => r = stack.resume();
-				THROWING => r = stack.clearAndThrow();
-				_ => {
-					var msg = Strings.format1("unexpected state %s", state.name);
-					return Result.Throw(Trap.new(TrapReason.INVALID_RESUME, msg, null));
-				}
-			}
-
-			match (r) {
+			match (stack.resume()) {
 				// The stack terminated. If there is no parent stack in the
 				// execution stack chain, return the values as the result.
 				// Otherwise add the values to the stack.

--- a/src/engine/v3/V3Target.v3
+++ b/src/engine/v3/V3Target.v3
@@ -83,13 +83,8 @@ class V3InterpreterOnlyStrategy extends ExecutionStrategy {
 					stack.onChildTerminate(vals);
 				}
 				Throw(thrown) => {
-					if (Trace.stack) Trace.OUT.put1("throw %q", thrown.render).ln();
-					if (stack.parent == null) {
-						if (cached_stack == null) cached_stack = stack;
-						return Result.Throw(thrown);
-					}
-					stack = popStackInChain(stack);
-					stack.onChildThrow(thrown);
+					if (cached_stack == null) cached_stack = stack;
+					return Result.Throw(thrown);
 				}
 				Switch(new_stack) => stack = V3Interpreter.!(new_stack);
 			}

--- a/src/engine/x86-64/V3Offsets.v3
+++ b/src/engine/x86-64/V3Offsets.v3
@@ -71,7 +71,6 @@ class V3Offsets {
 	def X86_64Stack_func		= int.view(Pointer.atField(vs.func) - Pointer.atObject(vs));
 	def X86_64Stack_parent_rsp_ptr	= int.view(Pointer.atField(vs.parent_rsp_ptr) - Pointer.atObject(vs));
 	def X86_64Stack_parent		= int.view(Pointer.atField(vs.parent) - Pointer.atObject(vs));
-	def X86_64Stack_throw_on_resume	= int.view(Pointer.atField(vs.throw_on_resume) - Pointer.atObject(vs));
 	def X86_64FrameAccessor_metaRef	= int.view(Pointer.atField(acc.metaRef) - Pointer.atObject(acc));
 	def X86_64Stack_state		= int.view(Pointer.atField(vs.state_) - Pointer.atObject(vs));
 	def X86_64Stack_return_results	= int.view(Pointer.atField(vs.return_results) - Pointer.atObject(vs));

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2431,7 +2431,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 			var cont = xenv.tmp1;
 			genPopInto(G(cont));
-			masm.emit_validate_and_consume_cont(xenv.tmp1);
+			masm.emit_validate_and_consume_cont(cont);
 
 			// move parameter values from %curStack to %cont.top
 			var r_nvals = cont_id; // reuse due to non-overlapping live ranges
@@ -2454,7 +2454,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 
 			asm.call_rel_far(stub_resume);
 			/* === CHILD STACK RUNNING === */
-			genOnResumeFinish();
+			genOnResumeFinish(false);
 			endHandler();
 			asm.bind(stub_resume); {
 				// load new stack pointers
@@ -2466,34 +2466,52 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 				masm.emit_jump_r(xenv.scratch);
 			}
 		}
-		// bindHandler(Opcode.RESUME_THROW); {
-		// 	var resumeStub = X86_64Label.new();
-		// 	var cont_id = r_tmp0, ip_store = r_tmp1, tag_index = r_tmp4;
-		// 	computeCurIpForTrap(-1);
-		// 	computePcFromCurIp();
-		// 	// read info and rewind %ip (need %ip at start of opcode during call)
-		// 	asm.movq_r_r(ip_store, r_ip);
-		// 	genReadUleb32(cont_id); // read signature index
-		// 	genReadUleb32(tag_index); // read tag index
-		// 	asm.movq_r_r(r_ip, ip_store);
-		// 	saveCallerIVars();
-		// 	var r_cont = r_tmp1;
-		// 	genResume(cont_id, r_cont, r_tmp3);
-		// 	var r_tag = r_tmp3;
-		// 	asm.movq_r_m(r_scratch, r_instance.plus(offsets.Instance_tags));
-		// 	asm.movq_r_m(r_tag, r_scratch.plusR(tag_index, offsets.REF_SIZE, offsets.Array_contents));
-		// 	masm.emit_get_curstack(xenv.tmp4);
-		// 	saveCallerIVars();
-		// 	callRuntime(refRuntimeCall(X86_64RT.runtime_process_resume_throw), [r_tmp4, r_instance, r_cont, r_tag], false);
-		// 	asm.movq_r_r(r_cont, r_runtime_ret0);
-		// 	restoreCallerIVars();
-		// 	asm.call_rel_far(resumeStub);
-		// 	/* === CHILD STACK RUNNING === */
-		// 	genOnResumeFinish(true);
-		// 	endHandler();
+		bindHandler(Opcode.RESUME_THROW); {
+			var stub_resume = X86_64Label.new();
+			var tag_id = xenv.tmp0;
+			computeCurIpForTrap(-1);
+			computePcFromCurIp();
+			saveCallerIVars();
+			genSkipLeb(); // skip signature index
+			genReadUleb32(G(tag_id)); // read tag index
 
-		// 	asm.bind(resumeStub); { genResumeStub(r_cont, r_tmp0, r_tmp3, true); }
-		// }
+			var cont = xenv.tmp1;
+			genPopInto(G(cont));
+			masm.emit_validate_and_consume_cont(cont);
+
+			var curStack = xenv.tmp4;
+			masm.emit_get_curstack(curStack);
+			callRuntime(
+				refRuntimeCall(X86_64RT.runtime_handle_resume_throw),
+				[G(curStack), r_instance, G(cont), G(tag_id)], true
+			);
+			restoreCallerIVars();
+			/* === only reachable when continuation handles the error === */
+			genPopInto(G(cont)); // XXX: make RT function return {Continuation} directly
+
+			// chain {cont to {curStack}, then set {m_curStack} to {cont.top}.
+			masm.emit_get_curstack(curStack);
+			masm.emit_v3_set_X86_64Stack_vsp_r_r(curStack, xenv.vsp);
+			masm.emit_v3_set_X86_64Stack_rsp_r_r(curStack, xenv.sp);
+			// reserve space for call addr
+			asm.sub_m_i(G(curStack).plus(offsets.X86_64Stack_rsp), Pointer.SIZE);
+			masm.emit_chain_cont_to_parent(curStack, cont);
+			masm.emit_switch_curStack_to_cont(cont);
+
+			asm.call_rel_far(stub_resume);
+			/* === CHILD STACK RUNNING === */
+			genOnResumeFinish(true);
+			endHandler();
+			asm.bind(stub_resume); {
+				// load new stack pointers
+				masm.emit_get_curstack(curStack);
+				masm.emit_v3_X86_64Stack_vsp_r_r(xenv.vsp, curStack);
+				masm.emit_v3_X86_64Stack_rsp_r_r(xenv.sp, curStack);
+				// pop address from new stack and go to it
+				masm.emit_pop_r(ValueKind.REF, xenv.scratch);
+				masm.emit_jump_r(xenv.scratch);
+			}
+		}
 		bindHandler(Opcode.SUSPEND); {
 			var tag_index = r_tmp0;
 			var suspendStub = X86_64Label.new();
@@ -2504,9 +2522,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			masm.emit_get_curstack(xenv.tmp1);
 			callRuntime(refRuntimeCall(X86_64RT.runtime_handle_suspend), [r_tmp1, r_instance, tag_index], true);
 			asm.call_rel_far(suspendStub);
-
 			/* === PARENT STACK RUNNING === */
-
 			// skip pass {suspend} instruction after begin resumed
 			restoreCallerIVars();
 			genSkipLeb();
@@ -4064,7 +4080,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		asm.movq_r_m(reg, vsph[0].value);
 	}
 	// generates cleanup code for after a child stack returns
-	private def genOnResumeFinish() {
+	private def genOnResumeFinish(skip_tag: bool) {
 		// check for error (in %rax)
 		var done = X86_64Label.new();
 		asm.q.cmp_r_i(r_ret_throw, 0);
@@ -4085,6 +4101,7 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 		// skip the handler table
 		var handler_length = r_tmp1;
 		genSkipLeb(); // skip cont signature
+		if (skip_tag) genSkipLeb(); // skip tag index
 		genReadUleb32(handler_length); // read handler length
 
 		// skip handler table

--- a/src/engine/x86-64/X86_64Interpreter.v3
+++ b/src/engine/x86-64/X86_64Interpreter.v3
@@ -2499,15 +2499,17 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			var suspendStub = X86_64Label.new();
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
+			saveCallerIVars();
 			genReadUleb32(tag_index); // read tag index
 			masm.emit_get_curstack(xenv.tmp1);
-			saveCallerIVars();
 			callRuntime(refRuntimeCall(X86_64RT.runtime_handle_suspend), [r_tmp1, r_instance, tag_index], true);
 			asm.call_rel_far(suspendStub);
 
 			/* === PARENT STACK RUNNING === */
 
+			// skip pass {suspend} instruction after begin resumed
 			restoreCallerIVars();
+			genSkipLeb();
 			restoreDispatchTableReg();
 			endHandler();
 
@@ -2525,16 +2527,19 @@ class X86_64InterpreterGen(ic: X86_64InterpreterCode, w: DataWriter) {
 			var switchStub = X86_64Label.new();
 			computeCurIpForTrap(-1);
 			computePcFromCurIp();
+			saveCallerIVars();
 			genReadUleb32(target_cont_id); // read cont index
 			genReadUleb32(tag_id); // read tag index
 			masm.emit_get_curstack(xenv.tmp3);
-			saveCallerIVars();
 			callRuntime(refRuntimeCall(X86_64RT.runtime_handle_switch), [r_tmp3, r_instance, target_cont_id, tag_id], true);
 			asm.call_rel_far(switchStub);
 
 			/* === OTHER STACK RUNNING === */
 
+			// skip pass {switch} instruction after begin resumed
 			restoreCallerIVars();
+			genSkipLeb();
+			genSkipLeb();
 			restoreDispatchTableReg();
 			endHandler();
 

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -18,7 +18,8 @@ component X86_64Runtime {
 			var result = hf.invoke(args);
 			match (result) {
 				Throw(thrown) => {
-					stack.throw(thrown).prependHostFunction(hf);
+					// TODO: case for ThrowResult.Handled
+					ThrowResult.Unhandled.!(stack.throw(thrown)).thrown.prependHostFunction(hf);
 					return (thrown, null);
 				}
 				Value0 => {
@@ -52,13 +53,13 @@ component X86_64Runtime {
 	def runtime_PROBE_loop(stack: X86_64Stack, func: WasmFunction, pc: int) -> Throwable {
 		var frame = TargetFrame(stack.rsp + Pointer.SIZE);
 		var ret = Instrumentation.fireGlobalProbes(DynamicLoc(func, pc, frame));
-		if (ret != null) return stack.throw(ret);
+		if (ret != null) return ThrowResult.Unhandled.!(stack.throw(ret)).thrown;
 		return ret;
 	}
 	def runtime_PROBE_instr(stack: X86_64Stack, func: WasmFunction, pc: int) -> Throwable {
 		var frame = TargetFrame(stack.rsp + Pointer.SIZE);
 		var ret = Instrumentation.fireLocalProbes(DynamicLoc(func, pc, frame));
-		if (ret != null) return stack.throw(ret);
+		if (ret != null) return ThrowResult.Unhandled.!(stack.throw(ret)).thrown;
 		return ret;
 	}
 	def runtime_GET_LOCAL_PROBE(func: WasmFunction, pc: int) -> Probe {
@@ -91,10 +92,10 @@ component X86_64Runtime {
 		var tag = instance.tags[tag_index];
 		var args = stack.popN(tag.sig.params);
 		var ex = Exception.new(tag, args, null);
-		return stack.throw(ex);
+		return ThrowResult.Unhandled.!(stack.throw(ex)).thrown;
 	}
 	def runtime_THROW_REF(stack: X86_64Stack, thrown: Throwable) -> Throwable {
-		return stack.throw(thrown);
+		return ThrowResult.Unhandled.!(stack.throw(thrown)).thrown;
 	}
 	def runtime_CONT_NEW(stack: X86_64Stack, instance: Instance, cont_index: u31) -> Throwable {
 		return Runtime.CONT_NEW(stack, instance, cont_index, make_new_x86_stack);
@@ -106,7 +107,6 @@ component X86_64Runtime {
 		var top = X86_64Stack.!(cont.top);
 		top.rsp += Pointer.SIZE;
 		top.throw(ex);
-		top.throw_on_resume = ex;
 		top.state_ = StackState.RUNNING;
 		return Pointer.atObject(cont);
 	}

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -92,23 +92,19 @@ component X86_64Runtime {
 		var tag = instance.tags[tag_index];
 		var args = stack.popN(tag.sig.params);
 		var ex = Exception.new(tag, args, null);
-		return ThrowResult.Unhandled.!(stack.throw(ex)).thrown;
+		match (stack.throw(ex)) {
+			Handled => return null;
+			Unhandled(t) => return t;
+		}
 	}
 	def runtime_THROW_REF(stack: X86_64Stack, thrown: Throwable) -> Throwable {
-		return ThrowResult.Unhandled.!(stack.throw(thrown)).thrown;
+		match (stack.throw(thrown)) {
+			Handled => return null;
+			Unhandled(t) => return t;
+		}
 	}
 	def runtime_CONT_NEW(stack: X86_64Stack, instance: Instance, cont_index: u31) -> Throwable {
 		return Runtime.CONT_NEW(stack, instance, cont_index, make_new_x86_stack);
-	}
-	def runtime_process_resume_throw(stack: X86_64Stack, instance: Instance, cont: Continuation, tag: Tag) -> Pointer {
-		var ps = tag.sig.params;
-		var vals = stack.popN(ps);
-		var ex = Exception.new(tag, vals, null);
-		var top = X86_64Stack.!(cont.top);
-		top.rsp += Pointer.SIZE;
-		top.throw(ex);
-		top.state_ = StackState.RUNNING;
-		return Pointer.atObject(cont);
 	}
 	// Unwinds the stack chain and sets {curStack} to the stack that can handle
 	// the suspension (or throw an error on the top-most stack if no such handler

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -106,12 +106,32 @@ component X86_64Runtime {
 	def runtime_CONT_NEW(stack: X86_64Stack, instance: Instance, cont_index: u31) -> Throwable {
 		return Runtime.CONT_NEW(stack, instance, cont_index, make_new_x86_stack);
 	}
+	// If the given continuation handles the thrown error, a modified {Continuation} is pushed
+	// onto the value stack. Otherwise, trap on the current stack.
+	// XXX: eliminate returning {Throwable}?
+	def runtime_handle_resume_throw(stack: X86_64Stack, instance: Instance, cont: Continuation, tag_index: u31) -> Throwable {
+		var tag = instance.tags[tag_index];
+		var ex: Throwable = Exception.new(tag, stack.popN(tag.sig.params), null);
+		if (Trace.stack) Trace.OUT
+			.put2("resume_throw %q %q ", tag.render, cont.render)
+			.put1("on stack[rsp=0x%x]", stack.rsp - Pointer.NULL).ln();
+
+		// search for handler in continuation
+		match (cont.top.throw(ex)) {
+			Handled(handler) => {
+				X86_64Stack.!(handler).state_ = StackState.RESUMABLE;
+				cont.top = handler;
+				stack.push(Value.Ref(cont));
+				return null;
+			}
+			Unhandled(t) => return runtime_THROW_REF(stack, t);
+		}
+	}
 	// Unwinds the stack chain and sets {curStack} to the stack that can handle
 	// the suspension (or throw an error on the top-most stack if no such handler
 	// is found). Then, the tag parameters and the continuation is pushed onto
 	// the handler stack.
 	def runtime_handle_suspend(stack: X86_64Stack, instance: Instance, tag_id: u31) -> Throwable {
-		var stack = X86_64Stack.!(stack);
 		var tag = instance.tags[tag_id];
 		var vals = stack.popN(tag.sig.params);
 		var cont = Runtime.unwindStackChain(stack, instance, tag_id, WasmStack.tryHandleSuspension);
@@ -134,7 +154,6 @@ component X86_64Runtime {
 	// throw an error on the top-most stack if no such handler is found). Then,
 	// the tag parameters and the continuation is pushed onto the target stack.
 	def runtime_handle_switch(stack: X86_64Stack, instance: Instance, target_cont_idx: int, tag_id: u31) -> Throwable {
-		var stack = X86_64Stack.!(stack);
 		var tag = instance.tags[tag_id];
 
 		// unraveling all relevant signatures

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -90,17 +90,24 @@ class X86_64Stack extends WasmStack {
 		var prev_sp = this.rsp;
 		if (Exception.?(thrown)) {
 			var ex = Exception.!(thrown);
-			var new_sp = walk(findExHandler, ex, prev_sp);
-			unwind(prev_sp, new_sp);
-			return ThrowResult.Unhandled(ex); // TODO: implement proper return results
+			var result = walk(findExHandler, ex, prev_sp, true);
+			var pos = result.1;
+			var new_sp = pos.frame.sp + -RETADDR_SIZE;
+			if (Trace.stack) {
+				if (result.0) Trace.OUT.put1("walk found handler at frame[sp=0x%x]", pos.frame.sp - Pointer.NULL).ln();
+				else Trace.OUT.puts("walk found no handler");
+			}
+			if (new_sp != prev_sp) unwind(prev_sp, new_sp);
+			return if(result.0, ThrowResult.Handled(pos.stack), ThrowResult.Unhandled(ex));
 		}
 
 		var gatherTrace = !FeatureDisable.stacktraces;
 		var trace = if (gatherTrace, Vector<(WasmFunction, int)>.new());
-		var return_parent_sp = walk(if(gatherTrace, addFrameToTrace), trace, prev_sp);
+		var result = walk(if(gatherTrace, addFrameToTrace), trace, prev_sp, true);
+		var new_sp = result.1.frame.sp + -RETADDR_SIZE;
 		// Unwind this stack to the return parent stub and overwrite the caller's return IP.
 		this.vsp = mapping.range.start; // clear value stack
-		unwind(prev_sp, return_parent_sp);
+		if (new_sp != prev_sp) unwind(prev_sp, new_sp);
 
 		// Append the (reversed) stacktrace to the throwable.
 		if (trace != null) thrown.prependFrames(ArrayUtil.copyReverse(trace));
@@ -108,11 +115,17 @@ class X86_64Stack extends WasmStack {
 	}
 	// Walk the stack, applying {f} to every target frame (i.e. no stubs). If {f} returns {false},
 	// stop the stackwalk. Otherwise stop at the return-parent stub. In any case, return the last
-	// valid stack pointer.
+	// valid stack pointer, and a boolean indicating if the walk stopped early (due to {f} returning {false}).
 	// (XXX: takes a function {f} with an additional parameter, and the parameter, to avoid a closure).
-	private def walk<P>(f: (Pointer, RiUserCode, TargetFrame, P) -> bool, param: P, start_sp: Pointer) -> Pointer {
+	private def walk<P>(f: (Pointer, RiUserCode, StackFramePos, P) -> bool, param: P, start_sp: Pointer, continue_to_parent: bool) -> (bool, StackFramePos) {
+		var stack = this;
 		var sp = start_sp;
-		while (sp < mapping.range.end) {
+		if (Trace.stack && Debug.stack) {
+			Trace.OUT.put1("walk started on stack[rsp=0x%x] (", this.rsp - Pointer.NULL);
+			Trace.OUT.put1("start_sp=0x%x, ", start_sp - Pointer.NULL);
+			Trace.OUT.put1("continue_to_parent=%s)", if(continue_to_parent, "true", "false")).ln();
+		}
+		while (sp < stack.mapping.range.end) {
 			var retip = sp.load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
 			var accessor: FrameAccessor;
@@ -121,18 +134,31 @@ class X86_64Stack extends WasmStack {
 				// TODO: unify {sp} convention
  				if (code != null) code.describeFrame(retip, sp + RETADDR_SIZE, Trace.OUT.putr_void);
 				else Trace.OUT.ln();
+				Trace.OUT.flush();
 			}
+			var pos = StackFramePos(stack, TargetFrame(sp + RETADDR_SIZE));
 			match (code) {
 				null => break;
-				x: X86_64InterpreterCode => if (f != null && !f(retip, code, TargetFrame(sp + RETADDR_SIZE), param)) return sp;
-				x: X86_64SpcModuleCode => if (f != null && !f(retip, code, TargetFrame(sp + RETADDR_SIZE), param)) return sp;
-				x: X86_64SpcTrapsStub => if (f != null && !f(retip, code, TargetFrame(sp + RETADDR_SIZE), param)) return sp;
-				x: X86_64ReturnParentStub => return sp;
+				x: X86_64InterpreterCode => if (f != null && !f(retip, code, pos, param)) return (true, pos);
+				x: X86_64SpcModuleCode => if (f != null && !f(retip, code, pos, param)) return (true, pos);
+				x: X86_64SpcTrapsStub => if (f != null && !f(retip, code, pos, param)) return (true, pos);
+				x: X86_64ReturnParentStub => {
+					if (stack.parent == null || !continue_to_parent) {
+						if (Trace.stack && Debug.stack) Trace.OUT.puts("walk finished").ln();
+						return (false, pos);
+					} else {
+						if (Trace.stack && Debug.stack) Trace.OUT.put1("walk to parent[rsp=0x%x]", stack.rsp - Pointer.NULL).ln();
+						stack = X86_64Stack.!(stack.parent);
+						sp = stack.rsp;
+						continue;
+					}
+				}
 			}
 			var t = code.nextFrame(retip, sp);
 			sp = t.1;
 		}
-		return Pointer.NULL;
+		// XXX: only reachable through an invalid stack structure, maybe trap here?
+		return (false, StackFramePos(null, TargetFrame(Pointer.NULL)));
 	}
 	def traceFrames(when: string, sp: Pointer) {
 		Trace.OUT.puts(when);
@@ -190,7 +216,9 @@ class X86_64Stack extends WasmStack {
 		if (Trace.stack) Trace.OUT.puts("  found switch handler").ln();
 		return handler;
 	}
-	private def findExHandler(ip: Pointer, code: RiUserCode, frame: TargetFrame, ex: Exception) -> bool {
+	private def findExHandler(ip: Pointer, code: RiUserCode, pos: StackFramePos, ex: Exception) -> bool {
+		var stack = pos.stack;
+		var frame = pos.frame;
 		var accessor = frame.getFrameAccessor(); // XXX: don't materialize accessor
 		var func = accessor.func();
 		var handler = func.decl.findExHandler(func.instance, ex.tag, accessor.pc());
@@ -201,26 +229,26 @@ class X86_64Stack extends WasmStack {
 			var vfp: Pointer = accessor.vfp();
 			var slot_num = (handler.val_stack_top + func.decl.num_slots());
 			var vsp = vfp + (slot_num * valuerep.slot_size);
-			this.vsp = vsp;
+			stack.vsp = vsp;
 			if (Trace.exception) Trace.OUT.put3("  push %d vfp=0x%x, vsp=0x%x", ex.vals.length, vfp - Pointer.NULL, vsp - Pointer.NULL).ln();
-			for (v in ex.vals) this.push(v);
+			for (v in ex.vals) stack.push(v);
 			if (handler.ex_slot >= 0) {
 				if (Trace.exception) Trace.OUT.put2("  set_ex_slot vfp=0x%x, ex_slot=%d", vfp - Pointer.NULL, handler.ex_slot).ln();
 				var ptr = vfp + (func.decl.num_locals + handler.ex_slot) * valuerep.slot_size;
-				this.storeValue(ptr, Value.Ref(ex));
+				stack.storeValue(ptr, Value.Ref(ex));
 			}
 			if (handler.push_exnref) {
 				if (Trace.exception) Trace.OUT.puts("  push_exnref").ln();
-				this.push(Value.Ref(ex));
+				stack.push(Value.Ref(ex));
 			}
-			accessor.set_vsp(this.vsp);
+			accessor.set_vsp(stack.vsp);
 			return false; // terminate stackwalk
 		}
 		if (Trace.exception) Trace.OUT.puts("  walk found no handler").ln();
 		return true;
 	}
-	private def addFrameToTrace(ip: Pointer, code: RiUserCode, frame: TargetFrame, trace: Vector<(WasmFunction, int)>) -> bool {
-		var accessor = frame.getFrameAccessor(); // XXX: don't materialize accessor
+	private def addFrameToTrace(ip: Pointer, code: RiUserCode, pos: StackFramePos, trace: Vector<(WasmFunction, int)>) -> bool {
+		var accessor = pos.frame.getFrameAccessor(); // XXX: don't materialize accessor
 		trace.put(accessor.func(), accessor.pc());
 		return true;
 	}
@@ -234,10 +262,11 @@ class X86_64Stack extends WasmStack {
 		if (Trace.stack) traceFrames("stack.overflow (before)", sp);
 		// Unwind the stack, skipping the top frame (which might have triggered the overflow)
 		// XXX: change the %sp convention from the caller instead of doing {+ -RETADDR_SIZE}
-		var return_parent_sp = walk<void>(null, (), sp + -RETADDR_SIZE);
+		var result = walk<void>(null, (), sp + -RETADDR_SIZE, true);
+		var new_sp = result.1.frame.sp + -RETADDR_SIZE;
 		// Unwind without updating any return addresses.
 		this.vsp = mapping.range.start; // clear value stack
-		unwind(Pointer.NULL, return_parent_sp);
+		if (new_sp != this.rsp) unwind(Pointer.NULL, new_sp);
 		// Instead, return from the signal to the stack overflow stub, which will unwind with a Trap.STACK_OVERFLOW throwable.
 		if (Trace.stack) traceFrames("stack.overflow (after)", this.rsp + RETADDR_SIZE);
 		return STACK_OVERFLOW_STUB.getEntry() + NOP_ENTRY;
@@ -396,10 +425,10 @@ class X86_64Stack extends WasmStack {
 			}
 		}
 		// Walk Wasm execution frames to scan their roots.
-		walk<void>(scanFrame, (), rsp);
+		walk<void>(scanFrame, (), rsp, false);
 	}
-	private def scanFrame(ip: Pointer, code: RiUserCode, frame: TargetFrame, v: void) -> bool {
-		code.scanFrame(ip, frame.sp);
+	private def scanFrame(ip: Pointer, code: RiUserCode, pos: StackFramePos, v: void) -> bool {
+		code.scanFrame(ip, pos.frame.sp);
 		return true;
 	}
 	def readValue(base: Pointer, offset: int) -> Value {
@@ -1084,3 +1113,5 @@ component X86_64StackManager {
 		return result;
 	}
 }
+
+type StackFramePos(stack: X86_64Stack, frame: TargetFrame) #unboxed;

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -95,7 +95,7 @@ class X86_64Stack extends WasmStack {
 			var new_sp = pos.frame.sp + -RETADDR_SIZE;
 			if (Trace.stack) {
 				if (result.0) Trace.OUT.put1("walk found handler at frame[sp=0x%x]", pos.frame.sp - Pointer.NULL).ln();
-				else Trace.OUT.puts("walk found no handler");
+				else Trace.OUT.puts("walk found no handler").ln();
 			}
 			if (new_sp != prev_sp) unwind(prev_sp, new_sp);
 			return if(result.0, ThrowResult.Handled(pos.stack), ThrowResult.Unhandled(ex));

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -17,9 +17,6 @@ class X86_64Stack extends WasmStack {
 	// other, assert that the value stored at the pointer is {null} on the child
 	// stack and manually set it).
 	var parent_rsp_ptr: Pointer;
-	
-	// For {resume_throw}.
-	var throw_on_resume: Throwable;
 
 	var params_arity = -1;
 	var return_results: Array<ValueType>;
@@ -84,10 +81,10 @@ class X86_64Stack extends WasmStack {
 	// "Throw" a trap on this stack.
 	def trap(reason: TrapReason) -> Throwable {
 		var thrown = throw(Trap.new(reason, null, null));
-		return thrown;
+		return ThrowResult.Unhandled.!(thrown).thrown;
 	}
 	// Throw a throwable on this stack, unwinding to the handler, if there is one.
-	def throw(thrown: Throwable) -> Throwable {
+	def throw(thrown: Throwable) -> ThrowResult {
 		if (Trace.stack) traceFrames(Strings.format1("stack.throw(%q)", thrown.render), rsp + RETADDR_SIZE);
 		// Perform a stackwalk, starting from the RSP stored in this object, gathering frames.
 		var prev_sp = this.rsp;
@@ -95,7 +92,7 @@ class X86_64Stack extends WasmStack {
 			var ex = Exception.!(thrown);
 			var new_sp = walk(findExHandler, ex, prev_sp);
 			unwind(prev_sp, new_sp);
-			return ex;
+			return ThrowResult.Unhandled(ex); // TODO: implement proper return results
 		}
 
 		var gatherTrace = !FeatureDisable.stacktraces;
@@ -107,7 +104,7 @@ class X86_64Stack extends WasmStack {
 
 		// Append the (reversed) stacktrace to the throwable.
 		if (trace != null) thrown.prependFrames(ArrayUtil.copyReverse(trace));
-		return thrown;
+		return ThrowResult.Unhandled(thrown);
 	}
 	// Walk the stack, applying {f} to every target frame (i.e. no stubs). If {f} returns {false},
 	// stop the stackwalk. Otherwise stop at the return-parent stub. In any case, return the last
@@ -254,7 +251,6 @@ class X86_64Stack extends WasmStack {
 		return_results = null;
 		parent =  null;
 		parent_rsp_ptr = Pointer.NULL;
-		throw_on_resume = null;
 		func = null;
 	}
 	// def pushReenterStub() {

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -10,7 +10,7 @@ class X86_64Stack extends WasmStack {
 	def mapping = Mmap.reserve(size, Mmap.PROT_READ | Mmap.PROT_WRITE);
 	var vsp: Pointer;
 	var rsp: Pointer;
-	var func: Function;
+	var func: Function; // TODO: move into "enter-func-stub"
 	
 	// For tail-calling purposes (from V3): ALWAYS, ALWAYS use this instead of
 	// [%parent.rsp]. In case of linking two stacks (due to one resuming the


### PR DESCRIPTION
This PR enables stack walking to continue onto parent stacks for the stack-switching extension, eliminating the need for `%ret_throw` when handling exceptions.