### PR TITLE
Only perform calls in match rules if other params result in a match

### DIFF
--- a/src/util/Whamm.v3
+++ b/src/util/Whamm.v3
@@ -250,7 +250,8 @@ component WhammVarBinder {
 	def bindParams(cv: CodeValidator, func: Function, wi: Instance,
 			params: Array<WhammParam>, op: Opcode, nested: bool, err: ErrorGen) -> Array<WhammArg> {
 		var args = Array<WhammArg>.new(params.length);
-		var callsToEval = Vector<ToCall>.new();		// calls to lazily perform (only if we have a match)
+		// calls to lazily perform (only if we have a match)
+		var callsToEval = Vector<(int, (Instance, Opcode, CodeValidator, ErrorGen) -> WhammArg)>.new();
 	  	def expParams = func.sig.params;  			// expected params of WasmFunction
 
 	  	if (expParams.length != args.length) {
@@ -305,7 +306,7 @@ component WhammVarBinder {
 						return null;
 					}
 					// Call this function only if we have a match!
-					callsToEval.put(ToCall.new(i, target, params, expParams[i]));
+					callsToEval.put((i, bindCallResult(target, params, _, _, expParams[i], _, _)));
 					isCall = true;
 				}
 			}
@@ -318,11 +319,11 @@ component WhammVarBinder {
 			// Perform the calls to the saved off functions
 			def call = callsToEval[i];
 
-			def arg = bindCallResult(call.target, call.params, wi, op, call.expType, cv, err);
+			def arg = call.1(wi, op, cv, err);
 			if (arg == WhammArg.Null) {
 				return null;
 			}
-			args[call.arg] = arg;
+			args[call.0] = arg;
 		}
 		return args;
 	}
@@ -553,9 +554,3 @@ type CallResult {
 	case Fail; // should be set in errorgen, so no extra context needed
 	case OK(t: ValueType, v: Value);
 }
-
-class ToCall(arg: int,
-	target: Token,
-	params: Array<WhammParam>,
-	expType: ValueType
-) {}

--- a/src/util/Whamm.v3
+++ b/src/util/Whamm.v3
@@ -250,7 +250,8 @@ component WhammVarBinder {
 	def bindParams(cv: CodeValidator, func: Function, wi: Instance,
 			params: Array<WhammParam>, op: Opcode, nested: bool, err: ErrorGen) -> Array<WhammArg> {
 		var args = Array<WhammArg>.new(params.length);
-	  	def expParams = func.sig.params;  // expected params of WasmFunction
+		var callsToEval = Vector<ToCall>.new();		// calls to lazily perform (only if we have a match)
+	  	def expParams = func.sig.params;  			// expected params of WasmFunction
 
 	  	if (expParams.length != args.length) {
 			err.at(cv.parser.decoder).WhammProbeError("whamm probe", "arity mismatch between wasm function params and whamm exported name");
@@ -259,6 +260,7 @@ component WhammVarBinder {
 
 		for (i < args.length) {
 			var arg: WhammArg;
+			var isCall: bool;
 			match (params[i]) {
 				DynamicLoc     => ; // TODO
 				FrameAccessor  => {
@@ -302,13 +304,25 @@ component WhammVarBinder {
 						err.at(cv.parser.decoder).WhammProbeError("whamm probe", "nested function calls");
 						return null;
 					}
-					arg = bindCallResult(target, params, wi, op, expParams[i], cv, err);
+					// Call this function only if we have a match!
+					callsToEval.put(ToCall.new(i, target, params, expParams[i]));
+					isCall = true;
 				}
 			}
-			if (arg == WhammArg.Null) {
+			if (!isCall && arg == WhammArg.Null) {
 				return null;
 			}
 			args[i] = arg;
+		}
+		for (i = 0; i < callsToEval.length; i++) {
+			// Perform the calls to the saved off functions
+			def call = callsToEval[i];
+
+			def arg = bindCallResult(call.target, call.params, wi, op, call.expType, cv, err);
+			if (arg == WhammArg.Null) {
+				return null;
+			}
+			args[call.arg] = arg;
 		}
 		return args;
 	}
@@ -539,3 +553,9 @@ type CallResult {
 	case Fail; // should be set in errorgen, so no extra context needed
 	case OK(t: ValueType, v: Value);
 }
+
+class ToCall(arg: int,
+	target: Token,
+	params: Array<WhammParam>,
+	expType: ValueType
+) {}


### PR DESCRIPTION
There is a bug if we have the following:

```
(func "wasm:opcode:i32.const  ($15(fid, pc), local0)" (param i32 i32) ...)
```

This probe has a type bound on `local0`. We only have a match if the `local0` is, in fact, an `i32`. If it's not an `i32`, we don't have a match and the probe won't be inserted. This logic is done correctly, the probe isn't inserted...but the static allocation function is still called during parameter parsing. This means that we allocate memory for a probe that we'll never use since it's not inserted.

This PR fixes this issue through lazily performing these calls if other parameter preparation results in a match.