### PR TITLE
[stack-switching] Fixed %vfp reloading

### DIFF
--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -230,8 +230,8 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 				var tv = SpcVal(sv.kindFlags(IN_REG), sv.reg, sv.const);
 				resolver.addMove((slot, tv), (slot, fv));
 			}
-			resolver.emitMoves();
 			emit_reload_regs();
+			resolver.emitMoves();
 
 			masm.emit_br(info.dest_label);
 		}


### PR DESCRIPTION
This PR fixed a misplaced register load.
Currently it executes correctly by accident because `suspend` sets the `%vfp` before transferring to the handler stack.