### PR TITLE
[WIP] `ValueKind.REF_U64` and optional wide `externref`

### DIFF
--- a/src/engine/Trace.v3
+++ b/src/engine/Trace.v3
@@ -23,6 +23,7 @@ component Trace {
 	var validation = false;
 	var linking = false;
 	var whamm = false;
+	var guard = false;
 
 	def OUT = TraceBuilder.new();
 	def STDOUT = System.write(1, _);

--- a/src/engine/TraceOptions.v3
+++ b/src/engine/TraceOptions.v3
@@ -17,7 +17,8 @@ enum TraceOption(ch: byte, help: string) {
 	stack('y', "stacks"),
 	exception('x', "exceptions"),
 	linking('l', "linking"),
-	whamm('w', "whamm monitoring")
+	whamm('w', "whamm monitoring"),
+	guard('g', "externref guard bytes (must be used with wideExternRef)")
 }
 
 // Parses and updates trace options based on arguments.
@@ -99,6 +100,7 @@ component TraceOptions {
 			exception => Trace.exception = true;
 			linking => Trace.linking = true;
 			whamm => Trace.whamm = true;
+			guard => Trace.guard = true;
 		}
 	}
 	def printHelp(out: TraceBuilder) {

--- a/src/engine/Tuning.v3
+++ b/src/engine/Tuning.v3
@@ -23,7 +23,6 @@ component FeatureDisable {
 	def emptyStacktraces = false;	// true => all stacktraces are empty
 	def legacyExceptions = false;	// for legacy phase 3 lexically-scoped exceptions
 	def frameVariables = false;	// allows probes to store variables in caller frame
-	def smallExtRef = true;	// true => externref uses {ValueKind.REF_U64} storage
 }
 
 // Tuning settings for the fast interpreter that have no effect on correctness.
@@ -62,4 +61,9 @@ component SpcTuning {
 	def runtimeCallFreesRegs = true;	// runtime calls frees registers in abstract state
 	var intrinsifyMemoryProbes = true;
 	var inlineGlobalAccess = true;		// enable inline access of (primitive) globals
+}
+
+// Flags that enable testing features to test the engine's correctness.
+component TestFeature {
+	def wideExternRef = true;	// externref uses REF_U64 storage
 }

--- a/src/engine/Tuning.v3
+++ b/src/engine/Tuning.v3
@@ -23,6 +23,7 @@ component FeatureDisable {
 	def emptyStacktraces = false;	// true => all stacktraces are empty
 	def legacyExceptions = false;	// for legacy phase 3 lexically-scoped exceptions
 	def frameVariables = false;	// allows probes to store variables in caller frame
+	def smallExtRef = true;	// true => externref uses {ValueKind.REF_U64} storage
 }
 
 // Tuning settings for the fast interpreter that have no effect on correctness.

--- a/src/engine/Value.v3
+++ b/src/engine/Value.v3
@@ -20,6 +20,7 @@ enum ValueKind(code: byte) {
 	F64(BpTypeCode.F64.code),
 	V128(BpTypeCode.V128.code),
 	REF(BpTypeCode.REF.code),
+	REF_U64(BpTypeCode.EXTERNREF.code),
 }
 
 // Superclass of all objects referred to by Value.Ref, including external refs.

--- a/src/engine/Value.v3
+++ b/src/engine/Value.v3
@@ -53,6 +53,7 @@ component Values {
 	def F64_minus_infinity	= Value.F64(0xfff0_0000_0000_0000);
 	def FUNCREF_NULL = Value.Ref(null);
 	def REF_NULL = FUNCREF_NULL;
+	def REF_U64_NULL = REF_NULL;
 	def NONE = Array<Value>.new(0);
 	def NO_SUPERS = Array<HeapTypeDecl>.new(0);
 

--- a/src/engine/compiler/MacroAssembler.v3
+++ b/src/engine/compiler/MacroAssembler.v3
@@ -108,6 +108,7 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 			F32 => emit_mov_s_f(slot, u32.view(val));
 			F64 => emit_mov_s_d(slot, u64.view(long.view(val))); // TODO: zero extend?
 			V128 => emit_mov_s_q(slot, u64.view(long.view(val)), if(val < 0, u64.max, 0)); // TODO: zero extend?
+			REF_U64 => emit_mov_s_q(slot, u64.view(long.view(val)), 0);
 		}
 	}
 	def emit_mov_s_i(slot: u32, val: int) { // utility method
@@ -220,7 +221,7 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 			I32, F32 => return 4;
 			I64, F64 => return 8;
 			REF => return 8; // override in subclasses if any 32-bit port
-			V128 => return 16;
+			V128, REF_U64 => return 16;
 		}
 	}
 	def logScaleOf(kind: ValueKind) -> u6 {
@@ -228,7 +229,7 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 			I32, F32 => return 2;
 			I64, F64 => return 3;
 			REF => return 3; // override in subclasses if any 32-bit port
-			V128 => return 4;
+			V128, REF_U64 => return 4;
 		}
 	}
 
@@ -255,6 +256,7 @@ class MacroAssembler(valuerep: Tagging, regConfig: RegConfig) {
 			F32 => emit_mov_r_f32(reg, u32.view(val));
 			F64 => emit_mov_r_d64(reg, u64.view(val));
 			V128 => emit_mov_r_q(reg, u64.view(long.view(val)), if(val < 0, u64.max, 0)); // TODO: zero extend?
+			REF_U64 => emit_mov_r_q(reg, u64.view(long.view(val)), 0); // TODO: zero extend?
 		}
 	}
 	def emit_mov_r_i(reg: Reg, val: int);

--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -2451,6 +2451,7 @@ type SpcVal(flags: byte, reg: Reg, const: int) #unboxed {
 			F64 => buf.puts("d");
 			V128 => buf.puts("v");
 			REF => buf.puts("r");
+			REF_U64 => buf.puts("w");
 		}
 		buf.put2("%s%s",
 			if(tagStored(), "T", ""),
@@ -2472,6 +2473,7 @@ type SpcVal(flags: byte, reg: Reg, const: int) #unboxed {
 			F64 => buf.puts("d");
 			V128 => buf.puts("v");
 			REF => buf.puts("r");
+			REF_U64 => buf.puts("w");
 		}
 		if (!buf.hasColor(Color.BOLD) && tagStored()) buf.puts("T");
 		if (!buf.hasColor(Color.UNDERLINE) && isStored()) buf.puts("S");

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -166,6 +166,7 @@ class V3Interpreter extends WasmStack {
 			F64 => val = Values.F64_0;
 			V128 => val = Values.V128_0;
 			REF => val = Values.REF_NULL;
+			REF_U64 => val = Values.REF_U64_NULL;
 		}
 		values.pushn(val, int.!(count));
 	}

--- a/src/engine/v3/V3Target.v3
+++ b/src/engine/v3/V3Target.v3
@@ -10,6 +10,9 @@ component Target {
 	def newWasmStack = V3Interpreter.new;
 	var unused_ = ExecuteOptions.registerDefaultMode("v3-int", V3InterpreterOnlyStrategy.new(), "slow interpreter only");
 
+	// TestFeature.wideExternRef
+	var getHostObjectGuardBytes: HostObject -> u64 = fun obj => 0;
+
 	def forceGC() { } // nop
 	def ticksNs() -> u64 { return u32.view(System.ticksNs()); }
 	def rdtsc() -> u64 { return u32.view(System.ticksNs()); }

--- a/src/engine/x86-64/X86_64MacroAssembler.v3
+++ b/src/engine/x86-64/X86_64MacroAssembler.v3
@@ -75,7 +75,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 	def getScratchReg(kind: ValueKind) -> Reg {
 		match (kind) {
 			I32, I64, REF => return regConfig.scratch;
-			F32, F64, V128 => return X86_64MasmRegs.XMM15; // TODO: make configurable
+			F32, F64, V128, REF_U64 => return X86_64MasmRegs.XMM15; // TODO: make configurable
 		}
 	}
 	def getV3ParamReg(kind: ValueKind, index: int) -> Reg {
@@ -105,7 +105,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 			F32 => asm.movss_s_m(X(dst), X86_64Addr.new(a, i, 4, getOffsets().Array_contents));
 			I64, REF => asm.movq_r_m(G(dst), X86_64Addr.new(a, i, 8, getOffsets().Array_contents));
 			F64 => asm.movsd_s_m(X(dst), X86_64Addr.new(a, i, 8, getOffsets().Array_contents));
-			V128 => asm.movdqu_s_m(X(dst), X86_64Addr.new(a, i, 16, getOffsets().Array_contents)); // TODO: can't scale by 16
+			V128, REF_U64 => asm.movdqu_s_m(X(dst), X86_64Addr.new(a, i, 16, getOffsets().Array_contents)); // TODO: can't scale by 16
 		}
 	}
 	def emit_v3_Array_bounds_check_rr(array: Reg, index: Reg, oob_label: MasmLabel) {
@@ -178,7 +178,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 			REF, I64 => asm.movq_r_m(G(dst), X86_64Addr.new(G(base), t.0, 1, t.1));
 			F32 => asm.movss_s_m(X(dst), X86_64Addr.new(G(base), t.0, 1, t.1));
 			F64 => asm.movsd_s_m(X(dst), X86_64Addr.new(G(base), t.0, 1, t.1));
-			V128 => asm.movdqu_s_m(X(dst), X86_64Addr.new(G(base), t.0, 1, t.1));
+			V128, REF_U64 => asm.movdqu_s_m(X(dst), X86_64Addr.new(G(base), t.0, 1, t.1));
 		}
 	}
 	def emit_v128_load_lane_r_m<T>(dst: Reg, src: X86_64Addr, asm_mov_r_m: (X86_64Gpr, X86_64Addr) -> T) {
@@ -211,7 +211,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 			REF, I64 => asm.movq_m_r(X86_64Addr.new(b, t.0, 1, t.1), G(val));
 			F32 => asm.movss_m_s(X86_64Addr.new(b, t.0, 1, t.1), X(val));
 			F64 => asm.movsd_m_s(X86_64Addr.new(b, t.0, 1, t.1), X(val));
-			V128 => asm.movdqu_m_s(X86_64Addr.new(b, t.0, 1, t.1), X(val));
+			V128, REF_U64 => asm.movdqu_m_s(X86_64Addr.new(b, t.0, 1, t.1), X(val));
 		}
 	}
 
@@ -248,7 +248,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 			I64, REF => asm.movq_r_m(G(reg), addr);
 			F32 => asm.movss_s_m(X(reg), addr);
 			F64 => asm.movsd_s_m(X(reg), addr);
-			V128 => asm.movdqu_s_m(X(reg), addr);
+			V128, REF_U64 => asm.movdqu_s_m(X(reg), addr);
 		}
 	}
 	def emit_mov_r_i(reg: Reg, val: int) {
@@ -301,7 +301,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 			I64, REF => asm.movq_m_r(addr, G(reg));
 			F32 => asm.movss_m_s(addr, X(reg));
 			F64 => asm.movsd_m_s(addr, X(reg));
-			V128 => asm.movdqu_m_s(addr, X(reg));
+			V128, REF_U64 => asm.movdqu_m_s(addr, X(reg));
 		}
 	}
 	def emit_mov_m_i(ma: MasmAddr, val: int) {
@@ -336,7 +336,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 				asm.movq_r_m(scratch, A(src));
 				asm.movq_m_r(A(dst), scratch);
 			}
-			V128 => {
+			V128, REF_U64 => {
 				var scratch = R.XMM15; // TODO
 				asm.movdqu_s_m(scratch, A(src));
 				asm.movdqu_m_s(A(dst), scratch);
@@ -546,6 +546,7 @@ class X86_64MacroAssembler extends MacroAssembler {
 			I64, REF => asm.q.popq_r(G(reg));
 			F64 => { asm.q.popq_r(scratch);  asm.movq_s_r(X(reg), scratch); }
 			V128 => System.error("X86_64MacroAssembler", "cannot pop v128 type"); // TODO
+			REF_U64 => System.error("X86_64MacroAssembler", "cannot pop ref_u64 type"); // TODO
 		}
 	}
 	def emit_ret() {

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -484,6 +484,7 @@ class X86_64Stack extends WasmStack {
 	def storeValue(ptr: Pointer, v: Value) {
 		var tag_ptr = ptr;
 		var val_ptr = ptr + valuerep.tag_size;
+		// [rv]: add ref_u64 by extending Ref case and changing {readValue} to match
 		match (v) {
 			Ref(obj) => {
 				if (valuerep.tagged) tag_ptr.store<u8>(BpTypeCode.REF_NULL.code);

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -484,11 +484,16 @@ class X86_64Stack extends WasmStack {
 	def storeValue(ptr: Pointer, v: Value) {
 		var tag_ptr = ptr;
 		var val_ptr = ptr + valuerep.tag_size;
-		// [rv]: add ref_u64 by extending Ref case and changing {readValue} to match
 		match (v) {
 			Ref(obj) => {
-				if (valuerep.tagged) tag_ptr.store<u8>(BpTypeCode.REF_NULL.code);
-				val_ptr.store(obj);
+				if (TestFeature.wideExternRef && HostObject.?(obj)) {
+					if (valuerep.tagged) tag_ptr.store<u8>(BpTypeCode.EXTERNREF.code);
+					(val_ptr + 0).store(obj);
+					(val_ptr + 8).store(Target.getHostObjectGuardBytes(HostObject.!(obj)));
+				} else {
+					if (valuerep.tagged) tag_ptr.store<u8>(BpTypeCode.REF_NULL.code);
+					val_ptr.store(obj);
+				}
 			}
 			I31(val) => {
 				if (valuerep.tagged) tag_ptr.store<u8>(BpTypeCode.I31REF.code);
@@ -543,7 +548,14 @@ class X86_64Stack extends WasmStack {
 		if (bits == 0) return Values.REF_NULL;
 		if ((bits & 1) == 1) return Value.I31(u31.view(bits >> 1));
 		var obj = vp.load<Object>();
-		return Value.Ref(obj);
+		if (TestFeature.wideExternRef && HostObject.?(obj)) {
+			var guard = (vp + 8).load<u64>();
+			var expected = Target.getHostObjectGuardBytes(HostObject.!(obj));
+			if (expected != guard) {
+				fatal(Strings.format2("externref got invalid guard %d, expected %d", guard, expected));
+			}
+			return Value.Ref(obj);
+		} else return Value.Ref(obj);
 	}
 	def popResult(rt: Array<ValueType>) -> Result {
 		var r = Array<Value>.new(rt.length);

--- a/src/engine/x86-64/X86_64Target.v3
+++ b/src/engine/x86-64/X86_64Target.v3
@@ -19,8 +19,7 @@ component Target {
 	def tagging = Tagging.new(!FeatureDisable.valueTags, !FeatureDisable.simd);
 
 	// TestFeature.wideExternRef
-	// Traps if guard check fails.
-	var guardCheckHostObject: (HostObject, u64) -> void = fun (a, b) => ();
+	var getHostObjectGuardBytes: HostObject -> u64 = fun obj => 0;
 
 	new() {
 		if (!SpcTuning.disable) {

--- a/src/engine/x86-64/X86_64Target.v3
+++ b/src/engine/x86-64/X86_64Target.v3
@@ -18,6 +18,10 @@ component Target {
 	def recycleWasmStack = X86_64StackManager.recycleStack;
 	def tagging = Tagging.new(!FeatureDisable.valueTags, !FeatureDisable.simd);
 
+	// TestFeature.wideExternRef
+	// Traps if guard check fails.
+	var guardCheckHostObject: (HostObject, u64) -> void = fun (a, b) => ();
+
 	new() {
 		if (!SpcTuning.disable) {
 			ExecuteOptions.registerMode("spc", X86_64SpcAotStrategy.new(false), "pre-compile modules with SPC, no fallback");

--- a/test/spectest.main.v3
+++ b/test/spectest.main.v3
@@ -21,6 +21,8 @@ component spectest {
 		err.abs(u64.!(0));
 		OptionsRegistry.filterArgs(args, err);
 		engine.extensions = EngineOptions.extensions;
+		// [rv]: change this
+		Target.getHostObjectGuardBytes = fun obj => 42;
 		for (i < args.length) {
 			var a = args[i];
 			if (a == null) continue;


### PR DESCRIPTION
This PR introduces the wide reference `REF_U64` value kind in the `x86-64-linux` execution tiers, and adds a `Tuning` option to represent `externref` with the wide reference type, as a tuple of `(<host_object>, <guard_bytes>)`.
Changes:
- `spectest.main.v3` assigns a `u64` guard bytes to each `externref` created in the spectest
- The guard of an `externref` is checked when it is popped from a value stack (This is not done for value transfers in x86 Assembly code to reduce invasiveness, but the coverage might be too little as of now? Currently it is only done for `X86_64Runtime` pops, `popResult` and suspension; function calls, returns and continuation resumptions/returns will not trigger a guard check)
- New trace option for tracing the guard bytes of each instantiated `externref` values during spectest