### PR TITLE
[monitors] Added monitor hooks to `SpecTestInterpreter`

### DIFF
--- a/src/SpectestMode.v3
+++ b/src/SpectestMode.v3
@@ -23,11 +23,11 @@ component SpectestMode {
 		OUT.ln();
 
 		var result = 0;
-		for (f in files) result |= runTest(engine, f);
+		for (f in files) result |= runTest(engine, monitors, f);
 		return result;
 	}
 
-	def runTest(engine: Engine, filename: string) -> int {
+	def runTest(engine: Engine, monitors: Range<Monitor>, filename: string) -> int {
 		OUT.puts("##+");
 		OUT.puts(filename);
 		OUT.ln();
@@ -49,6 +49,20 @@ component SpectestMode {
 		}
 		if (p.ok) {
 			var ip = SpecTestInterpreter.new(engine, filename);
+			if (monitors.length > 0) {
+				ip.onMonitorsStart = Execute.tiering.onMonitorsStart;
+				ip.onParse = fun (mod, err) {
+					for (monitor in monitors) {
+						monitor.onParse(mod, err);
+						if (err.error()) return;
+					}
+				};
+				ip.onMonitorsFinish = Execute.tiering.onMonitorsFinish;
+				ip.onInstantiate = fun ins { for (monitor in monitors) monitor.onInstantiate(ins); };
+				ip.onStart = fun f { for (monitor in monitors) monitor.onStart(f); };
+				ip.onTest = fun (f, args) { for (monitor in monitors) monitor.onTest(f, args); };
+				ip.onFinish = fun (ins, r) { for (monitor in monitors) monitor.onFinish(ins, r); };
+			}
 			ip.skip_actions = SKIP_ACTIONS.val;
 			ip.ignore_failure = expected[filename];
 			if (ip.run(p.commands)) {

--- a/src/monitors/Monitor.v3
+++ b/src/monitors/Monitor.v3
@@ -35,6 +35,9 @@ class Monitor {
 	// Called by the engine before the main method, if any, is called.
 	def onMain(f: Function, args: Array<Value>) {
 	}
+	// Called by the engine before a spectest invokes a function.
+	def onTest(f: Function, args: Array<Value>) {
+	}
 	// Called by the engine after the instance has finished executing, e.g. to print
 	// a report.
 	def onFinish(i: Instance, r: Result) {

--- a/test/wasm-spec/SpecTestInterpreter.v3
+++ b/test/wasm-spec/SpecTestInterpreter.v3
@@ -13,6 +13,14 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 	var skip_actions = false;
 	var ignore_failure = false;
 
+	// Spectest monitor callbacks (Monitor.v3 is not compiled as a dep of this file).
+	var onMonitorsStart: void -> void;
+	var onMonitorsFinish: (Module, ErrorGen) -> void;
+	var onInstantiate: Instance -> void;
+	var onStart: Function -> void;
+	var onTest: (Function, Array<Value>) -> void;
+	var onFinish: (Instance, Result) -> void;
+
 	new() {
 		// Register the exported module for specification tests
 		var sti = StInstance.new(null);
@@ -36,6 +44,8 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 	}
 
 	def run(commands: Vector<SpecTestCommand>) -> bool {
+		if (onMonitorsStart != null) onMonitorsStart();
+
 		for (i < commands.length) {
 			if (!ok) break;
 			var cmd = commands[i];
@@ -151,6 +161,7 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 		}
 	}
 	def doModule(stm: StModule) -> StModuleResult {
+		var err = ErrorGen.new("test");
 		var module: Module;
 		var bindname: string;
 		match (stm) {
@@ -158,7 +169,6 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 				bindname = varname;
 				var extensions = engine.extensions;
 				var limits = Limits.new().set(extensions);
-				var err = ErrorGen.new("test");
 				var mp = BinParser.new(extensions, limits, err, "test");
 				mp.tiering = Execute.tiering;
 				module = mp.push(bytes, 0, bytes.length).finish();
@@ -182,6 +192,8 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 				}
 			}
 		}
+		if (onMonitorsFinish != null) onMonitorsFinish(module, err);
+
 		var i = doInstantiate(module);
 		if (bindname != null) {
 			match (i) {
@@ -212,6 +224,7 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 	def error1<T>(msg: string, p: T) -> Result.Throw {
 		return Result.Throw(Trap.new(TrapReason.ERROR, Strings.format1(msg, p), null));
 	}
+	// [rv]: monitor.onStart and monitor.onFinish
 	def doInvoke(varname: string, funcname: string, args: Array<Value>) -> Result {
 		if (Trace.spectest) {
 			OUT.put1(" invoke \"%s\"", funcname);
@@ -226,7 +239,10 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 		if (exp == null) return error1("func \"%s\" not found", funcname);
 		if (!WasmFunction.?(exp)) return error1("export \"%s\" is not a function", funcname);
 		var func = WasmFunction.!(exp);
-		return Execute.call(func, args);
+		if (onTest != null) onTest(func, args);
+		var result = Execute.call(func, args);
+		if (onFinish != null) onFinish(sti.instance, result);
+		return result;
 	}
 	def doGlobalGet(varname: string, globalname: string) -> Result {
 		// pop instance
@@ -295,8 +311,10 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 		var r = i.run();
 		if (i.trap_reason != TrapReason.NONE) return StModuleResult.StartTrap(i.trap_reason);
 		if (!i.error.ok()) return StModuleResult.LinkError(i.error.error_msg);
+		if (onInstantiate != null) onInstantiate(i.instance);
 		if (module.start_function >= 0) {
 			var func = r.functions[module.start_function];
+			if (onStart != null) onStart(func);
 			var result = Execute.call(func, []);
 			match (result) {
 				Value => ; // ignore result(s); should be none

--- a/test/wasm-spec/SpecTestInterpreter.v3
+++ b/test/wasm-spec/SpecTestInterpreter.v3
@@ -15,6 +15,7 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 
 	// Spectest monitor callbacks (Monitor.v3 is not compiled as a dep of this file).
 	var onMonitorsStart: void -> void;
+	var onParse: (Module, ErrorGen) -> void;
 	var onMonitorsFinish: (Module, ErrorGen) -> void;
 	var onInstantiate: Instance -> void;
 	var onStart: Function -> void;
@@ -174,6 +175,11 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 				module = mp.push(bytes, 0, bytes.length).finish();
 				if (err.error()) return StModuleResult.ParseError(err);
 				BasicTracing.instrumentModule(module);
+				if (onParse != null) {
+					var mon_err = ErrorGen.new("monitor");
+					onParse(module, mon_err);
+					if (mon_err.error()) return StModuleResult.ParseError(mon_err);
+				}
 				if (isdef) {
 					modules.register(varname, module);
 					return StModuleResult.Module(module);
@@ -224,7 +230,6 @@ class SpecTestInterpreter(engine: Engine, filename: string) {
 	def error1<T>(msg: string, p: T) -> Result.Throw {
 		return Result.Throw(Trap.new(TrapReason.ERROR, Strings.format1(msg, p), null));
 	}
-	// [rv]: monitor.onStart and monitor.onFinish
 	def doInvoke(varname: string, funcname: string, args: Array<Value>) -> Result {
 		if (Trace.spectest) {
 			OUT.put1(" invoke \"%s\"", funcname);


### PR DESCRIPTION
This PR adds monitor hooks to spectest execution. This is in preparation for adding memory inspection related probes during stack-switching spectests for more stack/continuation memory integrity coverage during testing.