### PR TITLE
[CBD] br table intrinsic

### DIFF
--- a/src/bytecode/CanonicalDefs.v3
+++ b/src/bytecode/CanonicalDefs.v3
@@ -9,6 +9,7 @@ class Object { }
 type TypeVar;
 type FieldOffset;
 type BlockType;
+type Labels;
 class Signature { }
 class Function { }
 
@@ -23,6 +24,7 @@ def imm_readULEB32() -> u32;
 def imm_readULEB64() -> u64;
 def imm_readU8() -> u8;
 def imm_readBlockType() -> BlockType;
+def imm_readLabels() -> Labels;
 
 // Value stack.
 def pop_u32() -> u32;
@@ -146,6 +148,7 @@ def doEnd();
 def doCall(sig: Signature, target: Function);
 def doReturnCall(sig: Signature, target: Function);
 def doBranch(label: Label);
+def doSwitch(labels: Labels, key: u32);
 
 
 //===================================================================================================
@@ -388,6 +391,11 @@ def BR_IF() {
 	var cond = pop_u32();
 	if (u32.!=(cond, 0)) return doBranch(label);
 	else return doFallthru();
+}
+def BR_TABLE() {
+    var labels #sidetable = imm_readLabels();
+    var key = pop_u32();
+    doSwitch(labels, key);
 }
 def BLOCK() {
 	var bt = imm_readBlockType();

--- a/src/bytecode/Intrinsics.v3
+++ b/src/bytecode/Intrinsics.v3
@@ -5,6 +5,7 @@ def imm_readULEB32() -> u32.V : read;
 def imm_readULEB64() -> u64.V : read;
 def imm_readU8() -> u8.V : read;
 def imm_readBlockType() -> BlockType.V : read;
+def imm_readLabels() -> Labels.V : read;
 
 // Value stack.
 def pop_u32() -> u32.I : pop;
@@ -109,6 +110,7 @@ def doEnd() : ctl;
 def doCall(sig: Signature.V, target: Function.V) : ctl;
 def doReturnCall(sig: Signature.V, target: Function.V) : ctl;
 def doBranch(label: Label.V) : ctl;
+def doSwitch(labels: Labels.V, key: u32.I) : ctl;
 
 def u32.==(lhs: u32.V, rhs: u32.V) -> u32.V;
 def u32.!=(lhs: u32.V, rhs: u32.V) -> u32.V;


### PR DESCRIPTION
I decided it's okay to skip the imm_readLabel intrinsic in the interpreter since the pc update doesn't matter; this way works pretty well for sidetable generation