### PR TITLE
[wali] Add passthroughs implementation

### DIFF
--- a/src/engine/SigCache.v3
+++ b/src/engine/SigCache.v3
@@ -10,6 +10,7 @@ component SigCache {
 	def arr_ii: Array<ValueType> = [ValueType.I32, ValueType.I32];
 	def arr_iii: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32];
 	def arr_iiii: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32];
+	def arr_iiil: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I64];
 	def arr_iiiii: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32];
 	def arr_iiiiii: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32];
 	def arr_iiiiiii: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32];
@@ -84,6 +85,8 @@ component SigCache {
 	def iii_i = S(arr_iii, arr_i);
 	def iii_v = S(arr_iii, arr_v);
 	def iiii_v = S(arr_iiii, arr_v);
+	def iiil_i = S(arr_iiil, arr_i);
+	def iiil_l = S(arr_iiil, arr_l);
 	def iiii_i = S(arr_iiii, arr_i);
 	def iiii_l = S(arr_iiii, arr_l);
 	def iiiii_i = S(arr_iiiii, arr_i);

--- a/src/modules/HostModuleBuilder.v3
+++ b/src/modules/HostModuleBuilder.v3
@@ -42,6 +42,7 @@ class HostModuleBuilderOf<C>(name: string, tnew: void -> C, tbind: (C, Instance)
 	def func_i_v(name: string, hfp: C -> int -> void) -> this				{ module.adapters[name] = fun c => HostAdapters.i_v(hfp(c)); }
 	def func_i_i(name: string, hfp: C -> int -> int) -> this				{ module.adapters[name] = fun c => HostAdapters.i_i(hfp(c)); }
 	def func_ii_i(name: string, hfp: C -> (int, int) -> int) -> this			{ module.adapters[name] = fun c => HostAdapters.ii_i(hfp(c)); }
+	def func_ii_v(name: string, hfp: C -> (int, int) -> void) -> this			{ module.adapters[name] = fun c => HostAdapters.ii_v(hfp(c)); }
 	def func_iii_i(name: string, hfp: C -> (int, int, int) -> int) -> this			{ module.adapters[name] = fun c => HostAdapters.iii_i(hfp(c)); }
 	def func_uuu_r(name: string, hfp: C -> (u32, u32, u32) -> HostResult) -> this		{ module.adapters[name] = fun c => HostAdapters.uuu_r(hfp(c)); }
 	def func_iuu_r(name: string, hfp: C -> (int, u32, u32) -> HostResult) -> this		{ module.adapters[name] = fun c => HostAdapters.iuu_r(hfp(c)); }
@@ -52,9 +53,13 @@ class HostModuleBuilderOf<C>(name: string, tnew: void -> C, tbind: (C, Instance)
 	def func_v_i(name: string, hfp: C -> void -> int) -> this				{ module.adapters[name] = fun c => HostAdapters.v_i(hfp(c)); }
 	def func_v_l(name: string, hfp: C -> void -> long) -> this				{ module.adapters[name] = fun c => HostAdapters.v_l(hfp(c)); }
 	def func_i_l(name: string, hfp: C -> (int) -> long) -> this				{ module.adapters[name] = fun c => HostAdapters.i_l(hfp(c)); }
+	def func_l_l(name: string, hfp: C -> (long) -> long) -> this				{ module.adapters[name] = fun c => HostAdapters.l_l(hfp(c)); }
 	def func_ii_l(name: string, hfp: C -> (int, int) -> long) -> this			{ module.adapters[name] = fun c => HostAdapters.ii_l(hfp(c)); }
+	def func_il_l(name: string, hfp: C -> (int, long) -> long) -> this			{ module.adapters[name] = fun c => HostAdapters.il_l(hfp(c)); }
 	def func_iii_l(name: string, hfp: C -> (int, int, int) -> long) -> this			{ module.adapters[name] = fun c => HostAdapters.iii_l(hfp(c)); }
 	def func_iiii_l(name: string, hfp: C -> (int, int, int, int) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.iiii_l(hfp(c)); }
+	def func_illi_l(name: string, hfp: C -> (int, long, long, int) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.illi_l(hfp(c)); }
+	def func_iiil_l(name: string, hfp: C -> (int, int, int, long) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.iiil_l(hfp(c)); }
 	def func_iiiii_l(name: string, hfp: C -> (int, int, int, int, int) -> long) -> this	{ module.adapters[name] = fun c => HostAdapters.iiiii_l(hfp(c)); }
 	def func_iiiiii_l(name: string, hfp: C -> (int, int, int, int, int, int) -> long) -> this	{ module.adapters[name] = fun c => HostAdapters.iiiiii_l(hfp(c)); }
 	def func_iiiiil_l(name: string, hfp: C -> (int, int, int, int, int, long) -> long) -> this	{ module.adapters[name] = fun c => HostAdapters.iiiiil_l(hfp(c)); }

--- a/src/modules/wali/x86-64-linux/WaliModule.v3
+++ b/src/modules/wali/x86-64-linux/WaliModule.v3
@@ -552,19 +552,11 @@ class WaliInstance {
 		return Linux.syscall(LinuxConst.SYS_getrlimit, (resource, Pointer.atContents(rreg.result))).0;
 	}
 	//========================================================================================
-	def mprotect(addr: int, len: int, prot: int) -> long {
-		return Linux.syscall(LinuxConst.SYS_mprotect, (u64.view(addr), len, prot)).0;
-	}
+	def mprotect(addr: int, len: int, prot: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def mremap(old_addr: int, old_size: int, new_size: int, flags: int, new_addr: int) -> long {
-		var newp = if((flags & LinuxConst.MAP_FIXED) != 0, u64.view(new_addr), 0u);
-		var ret = Linux.syscall(LinuxConst.SYS_mremap, (u64.view(old_addr), old_size, new_size, flags, newp)).0;
-		return ret;
-	}
+	def mremap(old_addr: int, old_size: int, new_size: int, flags: int, new_addr: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def munmap(addr: int, len: int) -> long {
-		return Linux.syscall(LinuxConst.SYS_munmap, (addr, len)).0;
-	}
+	def munmap(addr: int, len: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def fstat(fd: int, buf: int) -> long {
 		var sys_fd = fdmap.get(fd);
@@ -611,17 +603,11 @@ class WaliInstance {
 	//========================================================================================
 	def rt_sigprocmask(how: int, set: int, oldset: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def tkill(tid: int, sig: int) -> long {
-		return Linux.syscall(LinuxConst.SYS_tkill, (tid, sig)).0;
-	}
+	def tkill(tid: int, sig: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def rt_sigaction(sig: int, act: int, oact: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def poll(fds: int, nfds: int, timeout: int) -> long {
-		var region = getRegion(fds, nfds * /*best-effort*/ 8);
-		if (region.reason != TrapReason.NONE && fds != 0) return WaliErrno.EFAULT.code;
-		return Linux.syscall(LinuxConst.SYS_poll, (Pointer.atContents(region.result), nfds, timeout)).0;
-	}
+	def poll(fds: int, nfds: int, timeout: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def rt_sigreturn(unused: long) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -641,37 +627,19 @@ class WaliInstance {
 	//========================================================================================
 	def readv(fd: int, vec: int, vlen: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def pipe(fds_ptr: int) -> long {
-		var region = getRegion(fds_ptr, 2 * 4);
-		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
-		return Linux.syscall(LinuxConst.SYS_pipe, (Pointer.atContents(region.result))).0;
-	}
+	def pipe(fds_ptr: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def select(nfds: int, readfds: int, writefds: int, exceptfds: int, timeout: int) -> long {
-		var rreg = getRegion(readfds, (nfds + 7) / 8);
-		if (readfds != 0 && rreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
-		var wreg = getRegion(writefds, (nfds + 7) / 8);
-		if (writefds != 0 && wreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
-		var ereg = getRegion(exceptfds, (nfds + 7) / 8);
-		if (exceptfds != 0 && ereg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
-		var treg = getRegion(timeout, /*sizeof timeval*/ 16);
-		if (timeout != 0 && treg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
-		return Linux.syscall(LinuxConst.SYS_select, (nfds, Pointer.atContents(rreg.result), Pointer.atContents(wreg.result), Pointer.atContents(ereg.result), Pointer.atContents(treg.result))).0;
-	}
+	def select(nfds: int, readfds: int, writefds: int, exceptfds: int, timeout: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def sched_yield() -> long {
 		return Linux.syscall(LinuxConst.SYS_sched_yield, ()).0;
 	}
 	//========================================================================================
-	def msync(addr: int, len: int, flags: int) -> long {
-		return Linux.syscall(LinuxConst.SYS_msync, (u64.view(addr), len, flags)).0;
-	}
+	def msync(addr: int, len: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def mincore(start: int, len: int, vec: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def madvise(addr: int, len: int, advice: int) -> long {
-		return Linux.syscall(LinuxConst.SYS_madvise, (u64.view(addr), len, advice)).0;
-	}
+	def madvise(addr: int, len: int, advice: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def fadvise(fd: int, offset: long, len: long, advice: int) -> long {
 		var sys_fd = fdmap.get(fd);

--- a/src/modules/wali/x86-64-linux/WaliModule.v3
+++ b/src/modules/wali/x86-64-linux/WaliModule.v3
@@ -1,7 +1,7 @@
 // Copyright 2024 Wizard authors. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
-def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, WaliInstance.bind)
+def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, WaliInstance.mbind)
 	.func_iii_l	("SYS_read",			fun i => i.read)
 	.func_iii_l	("SYS_write",			fun i => i.write)
 	.func_iii_l	("SYS_open",			fun i => i.open)
@@ -36,9 +36,9 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_ii_l	("SYS_tkill",			fun i => i.tkill)
 	.func_iiii_l	("SYS_rt_sigaction",		fun i => i.rt_sigaction)
 	.func_iii_l	("SYS_poll",			fun i => i.poll)
-	.func_i_l	("SYS_rt_sigreturn",		fun i => i.rt_sigreturn)
-	.func_iiii_l	("SYS_pread64",			fun i => i.pread64)
-	.func_iiii_l	("SYS_pwrite64",		fun i => i.pwrite64)
+	.func_l_l	("SYS_rt_sigreturn",		fun i => i.rt_sigreturn)
+	.func_iiil_l	("SYS_pread64",			fun i => i.pread64)
+	.func_iiil_l	("SYS_pwrite64",		fun i => i.pwrite64)
 	.func_iii_l	("SYS_readv",			fun i => i.readv)
 	.func_i_l	("SYS_pipe",			fun i => i.pipe)
 	.func_iiiii_l	("SYS_select",			fun i => i.select)
@@ -46,6 +46,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iii_l	("SYS_msync",			fun i => i.msync)
 	.func_iii_l	("SYS_mincore",			fun i => i.mincore)
 	.func_iii_l	("SYS_madvise",			fun i => i.madvise)
+	.func_illi_l	("SYS_fadvise",			fun i => i.fadvise)
 	.func_iii_l	("SYS_shmget",			fun i => i.shmget)
 	.func_iii_l	("SYS_shmat",			fun i => i.shmat)
 	.func_iii_l	("SYS_shmctl",			fun i => i.shmctl)
@@ -87,7 +88,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_i_l	("SYS_fsync",			fun i => i.fsync)
 	.func_i_l	("SYS_fdatasync",		fun i => i.fdatasync)
 	.func_ii_l	("SYS_truncate",		fun i => i.truncate)
-	.func_ii_l	("SYS_ftruncate",		fun i => i.ftruncate)
+	.func_il_l	("SYS_ftruncate",		fun i => i.ftruncate)
 	.func_iii_l	("SYS_getdents",		fun i => i.getdents)
 	.func_ii_l	("SYS_getcwd",			fun i => i.getcwd)
 	.func_i_l	("SYS_chdir",			fun i => i.chdir)
@@ -237,7 +238,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iii_l	("SYS_tgkill",			fun i => i.tgkill)
 	.func_ii_l	("SYS_utimes",			fun i => i.utimes)
 	.func_v_l	("SYS_vserver",			fun i => i.vserver)
-	.func_iiiiii_l	("SYS_mbind",			fun i => i.mbind)
+	.func_iii_l	("SYS_bind",			fun i => i.bind)
 	.func_iii_l	("SYS_set_mempolicy",		fun i => i.set_mempolicy)
 	.func_iiiii_l	("SYS_get_mempolicy",		fun i => i.get_mempolicy)
 	.func_iiii_l	("SYS_mq_open",			fun i => i.mq_open)
@@ -268,8 +269,8 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iiiii_l	("SYS_linkat",			fun i => i.linkat)
 	.func_iii_l	("SYS_symlinkat",		fun i => i.symlinkat)
 	.func_iiii_l	("SYS_readlinkat",		fun i => i.readlinkat)
-	.func_iii_l	("SYS_fchmodat",		fun i => i.fchmodat)
-	.func_iii_l	("SYS_faccessat",		fun i => i.faccessat)
+	.func_iiii_l	("SYS_fchmodat",		fun i => i.fchmodat)
+	.func_iiii_l	("SYS_faccessat",		fun i => i.faccessat)
 	.func_iiiiii_l	("SYS_pselect6",		fun i => i.pselect6)
 	.func_iiiii_l	("SYS_ppoll",			fun i => i.ppoll)
 	.func_i_l	("SYS_unshare",			fun i => i.unshare)
@@ -335,6 +336,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iiii_l	("SYS_rseq",			fun i => i.rseq)
 	.func_iiii_l	("SYS_faccessat2",		fun i => i.faccessat2)
 	.func_ii_l	("__wasm_init_memory",		fun i => i.wasm_init_memory)
+	.func_ii_i	("__wasm_thread_spawn",		fun i => i.wasm_thread_spawn)
 	.func_v_i	("__cl_get_argc",		fun i => i.cl_get_argc)
 	.func_i_i	("__cl_get_argv_len",		fun i => i.cl_get_argv_len)
 	.func_ii_i	("__cl_copy_argv",		fun i => i.cl_copy_argv)
@@ -342,6 +344,8 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_v_v	("__call_dtors",		fun i => i.call_dtors)
 	.func_u_vr	("__proc_exit",			fun i => i.proc_exit)
 	.func_ii_i	("__get_init_envfile",		fun i => i.get_init_envfile)
+	.func_ii_v	("longjmp",			fun i => i.longjmp)
+	.func_i_i	("setjmp",			fun i => i.setjmp)
 	.init(WaliInstance.init)
 	.getMain(WaliInstance.getMain)
 	.register(true);
@@ -358,7 +362,7 @@ class WaliInstance {
 	private var cmdline_env: Array<string>; // global: environment, TODO
 	private var trace: bool;
 
-	def bind(instance: Instance) {
+	def mbind(instance: Instance) {
 		memory = instance.findExportOfType<Memory>(null);
 	}
 	def init(args: Array<string>, t: bool, err: ErrorGen) {
@@ -488,76 +492,191 @@ class WaliInstance {
 	//========================================================================================
 	def exit_group(code: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def sched_getaffinity(pid: int, cpusetsize: int, mask: int) => TODO_UNIMPLEMENTED;
+	def sched_getaffinity(pid: int, cpusetsize: int, mask_ptr: int) -> long {
+		var m = getRegion(mask_ptr, cpusetsize);
+		if (m.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_sched_getaffinity, (pid, cpusetsize, Pointer.atContents(m.result))).0;
+	}
 	//========================================================================================
-	def set_tid_address(tidptr: int) => TODO_UNIMPLEMENTED;
+	def set_tid_address(tidptr: int) -> long {
+		var t = getRegion(tidptr, 4);
+		if (t.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_set_tid_address, (Pointer.atContents(t.result))).0;
+	}
 	//========================================================================================
 	def mmap(addr: int, length: int, prot: int, flags: int, fd: int, offset: long) -> long {
-		def X86_PAGE_SIZE = 4096u;
-		var pages = (u64.!(length) + X86_PAGE_SIZE) / X86_PAGE_SIZE;
-		var final_addr = Pointer.NULL + long.view(memory.num_bytes);
-		if (memory.grow(pages) == -1) return WaliErrno.EFAULT.code;
-		return Linux.syscall(LinuxConst.SYS_mmap, 
-			(final_addr, length, prot, flags | LinuxConst.MAP_FIXED, fd, offset)).0;
+	    def X86_PAGE_SIZE = 4096u;
+	    def WASM_PAGE_SIZE = 65536u;
+	    def EINVAL = -22;
+
+	    if (length <= 0) return WaliErrno.EINVAL.code;
+	    if ((u64.view(offset) % X86_PAGE_SIZE) != 0u) return WaliErrno.EINVAL.code;
+
+	    var need = u64.view(length);
+	    var wasm_pages = (need + (WASM_PAGE_SIZE - 1u)) / WASM_PAGE_SIZE;
+	    var final_addr = Pointer.NULL + long.view(memory.num_bytes);
+
+	    if (wasm_pages > 0u && memory.grow(wasm_pages) == -1) return WaliErrno.ENOMEM.code;
+
+	    var host_fd = if(fd < 0, fd, fdmap.get(fd));
+	    var want_flags = if(fd == -1, flags | LinuxConst.MAP_ANONYMOUS, flags);
+	    var ret = Linux.syscall(
+		LinuxConst.SYS_mmap,
+		(u64.view(final_addr - Pointer.NULL), length, prot, want_flags | LinuxConst.MAP_FIXED, host_fd, offset)
+	    ).0;
+	    if (ret < 0) return ret;
+	    return long.view(final_addr - Pointer.NULL);
 	}
 	//========================================================================================
 	def fcntl(fd: int, cmd: int, arg: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def sysinfo(info: int) => TODO_UNIMPLEMENTED;
+	def sysinfo(info_ptr: int) -> long {
+		var ireg = getRegion(info_ptr, wali_sysinfo.size);
+		if (ireg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_sysinfo, (Pointer.atContents(ireg.result))).0;
+	}
 	//========================================================================================
 	def brk(brk: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def prlimit64(pid: int, resource: int, new_limit: int, old_limit: int) => TODO_UNIMPLEMENTED;
+	def prlimit64(pid: int, resource: int, new_limit_ptr: int, old_limit_ptr: int) -> long {
+		var n = getRegion(new_limit_ptr, wali_rlimit64.size);
+		if (new_limit_ptr != 0 && n.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var o = getRegion(old_limit_ptr, wali_rlimit64.size);
+		if (old_limit_ptr != 0 && o.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_prlimit64, (pid, resource, Pointer.atContents(n.result), Pointer.atContents(o.result))).0;
+	}
 	//========================================================================================
-	def getrlimit(resource: int, rlim: int) => TODO_UNIMPLEMENTED;
+	def getrlimit(resource: int, rlim_ptr: int) -> long {
+		var rreg = getRegion(rlim_ptr, wali_rlimit.size);
+		if (rreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getrlimit, (resource, Pointer.atContents(rreg.result))).0;
+	}
 	//========================================================================================
-	def mprotect(addr: int, len: int, prot: int) => TODO_UNIMPLEMENTED;
+	def mprotect(addr: int, len: int, prot: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_mprotect, (u64.view(addr), len, prot)).0;
+	}
 	//========================================================================================
-	def mremap(old_address: int, old_size: int, new_size: int, flags: int, new_address: int) => TODO_UNIMPLEMENTED;
+	def mremap(old_addr: int, old_size: int, new_size: int, flags: int, new_addr: int) -> long {
+		var newp = if((flags & LinuxConst.MAP_FIXED) != 0, u64.view(new_addr), 0u);
+		var ret = Linux.syscall(LinuxConst.SYS_mremap, (u64.view(old_addr), old_size, new_size, flags, newp)).0;
+		return ret;
+	}
 	//========================================================================================
 	def munmap(addr: int, len: int) -> long {
 		return Linux.syscall(LinuxConst.SYS_munmap, (addr, len)).0;
 	}
 	//========================================================================================
-	def fstat(fd: int, statbuf: int) => TODO_UNIMPLEMENTED;
+	def fstat(fd: int, buf: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var statbuf = getRegion(buf, WaliStruct_stat.size);
+		if (statbuf.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_fstat, (sys_fd, Pointer.atContents(statbuf.result))).0;
+	}
 	//========================================================================================
-	def fstatat(dfd: int, filename: int, statbuf: int, flags: int) => TODO_UNIMPLEMENTED;
+	def fstatat(dirfd: int, path: int, buf: int, flags: int) -> long {
+		var sys_dirfd = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var b = getRegion(buf, WaliStruct_stat.size);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_fstatat, (sys_dirfd, Pointer.atContents(pr.result), Pointer.atContents(b.result), flags)).0;
+	}
 	//========================================================================================
-	def lstat(pathname: int, statbuf: int) => TODO_UNIMPLEMENTED;
+	def lstat(path: int, buf: int) -> long {
+		var region = getPath(u32.view(path));
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var statbuf = getRegion(buf, WaliStruct_stat.size);
+		if (statbuf.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_lstat, (Pointer.atContents(region.result), Pointer.atContents(statbuf.result))).0;
+	}
 	//========================================================================================
 	def writev(fd: int, iov: int, iovcnt: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def ioctl(fd: int, request: int, argp: int) => TODO_UNIMPLEMENTED;
+	def ioctl(fd: int, request: int, arg: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		// arg may be pointer or integer; pass as-is
+		var argptr = u64.view(arg);
+		return Linux.syscall(LinuxConst.SYS_ioctl, (sys_fd, request, argptr)).0;
+	}
 	//========================================================================================
-	def futex(uaddr: int, futex_op: int, val: int, timeout: int, uaddr2: int, val3: int) => TODO_UNIMPLEMENTED;
+	def futex(uaddr: int, op: int, val: int, timeout_ptr: int, uaddr2: int, val3: int) -> long {
+		var a1 = getRegion(uaddr, 4);
+		if (a1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var t = getRegion(timeout_ptr, 16);
+		if (timeout_ptr != 0 && t.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var a2 = getRegion(uaddr2, 4);
+		if (uaddr2 != 0 && a2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_futex, (Pointer.atContents(a1.result), op, val, Pointer.atContents(t.result), Pointer.atContents(a2.result), val3)).0;
+	}
 	//========================================================================================
 	def rt_sigprocmask(how: int, set: int, oldset: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def tkill(tid: int, sig: int) => TODO_UNIMPLEMENTED;
+	def tkill(tid: int, sig: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_tkill, (tid, sig)).0;
+	}
 	//========================================================================================
 	def rt_sigaction(sig: int, act: int, oact: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def poll(ufds: int, nfds: int, timeout: int) => TODO_UNIMPLEMENTED;
+	def poll(fds: int, nfds: int, timeout: int) -> long {
+		var region = getRegion(fds, nfds * /*best-effort*/ 8);
+		if (region.reason != TrapReason.NONE && fds != 0) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_poll, (Pointer.atContents(region.result), nfds, timeout)).0;
+	}
 	//========================================================================================
-	def rt_sigreturn(unused: int) => TODO_UNIMPLEMENTED;
+	def rt_sigreturn(unused: long) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def pread64(fd: int, buf: int, count: int, pos: int) => TODO_UNIMPLEMENTED;
+	def pread64(fd: int, buf: int, count: int, offset: long) -> long {
+		var sys_fd = fdmap.get(fd);
+		var region = getRegion(buf, count);
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_pread64, (sys_fd, Pointer.atContents(region.result), count, offset)).0;
+	}
 	//========================================================================================
-	def pwrite64(fd: int, buf: int, count: int, pos: int) => TODO_UNIMPLEMENTED;
+	def pwrite64(fd: int, buf: int, count: int, offset: long) -> long {
+		var sys_fd = fdmap.get(fd);
+		var region = getRegion(buf, count);
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_pwrite64, (sys_fd, Pointer.atContents(region.result), count, offset)).0;
+	}
 	//========================================================================================
 	def readv(fd: int, vec: int, vlen: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def pipe(fildes: int) => TODO_UNIMPLEMENTED;
+	def pipe(fds_ptr: int) -> long {
+		var region = getRegion(fds_ptr, 2 * 4);
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_pipe, (Pointer.atContents(region.result))).0;
+	}
 	//========================================================================================
-	def select(n: int, inp: int, outp: int, exp: int, tvp: int) => TODO_UNIMPLEMENTED;
+	def select(nfds: int, readfds: int, writefds: int, exceptfds: int, timeout: int) -> long {
+		var rreg = getRegion(readfds, (nfds + 7) / 8);
+		if (readfds != 0 && rreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var wreg = getRegion(writefds, (nfds + 7) / 8);
+		if (writefds != 0 && wreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var ereg = getRegion(exceptfds, (nfds + 7) / 8);
+		if (exceptfds != 0 && ereg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var treg = getRegion(timeout, /*sizeof timeval*/ 16);
+		if (timeout != 0 && treg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_select, (nfds, Pointer.atContents(rreg.result), Pointer.atContents(wreg.result), Pointer.atContents(ereg.result), Pointer.atContents(treg.result))).0;
+	}
 	//========================================================================================
-	def sched_yield() => TODO_UNIMPLEMENTED;
+	def sched_yield() -> long {
+		return Linux.syscall(LinuxConst.SYS_sched_yield, ()).0;
+	}
 	//========================================================================================
-	def msync(start: int, len: int, flags: int) => TODO_UNIMPLEMENTED;
+	def msync(addr: int, len: int, flags: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_msync, (u64.view(addr), len, flags)).0;
+	}
 	//========================================================================================
 	def mincore(start: int, len: int, vec: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def madvise(start: int, len: int, behavior: int) => TODO_UNIMPLEMENTED;
+	def madvise(addr: int, len: int, advice: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_madvise, (u64.view(addr), len, advice)).0;
+	}
+	//========================================================================================
+	def fadvise(fd: int, offset: long, len: long, advice: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_fadvise64, (sys_fd, offset, len, advice)).0;
+	}
 	//========================================================================================
 	def shmget(key: int, size: int, flag: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -567,55 +686,157 @@ class WaliInstance {
 	//========================================================================================
 	def pause() => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def nanosleep(rqtp: int, rmtp: int) => TODO_UNIMPLEMENTED;
+	def nanosleep(req_ptr: int, rem_ptr: int) -> long {
+		var rreg = getRegion(req_ptr, /*timespec*/ 16);
+		if (req_ptr != 0 && rreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var mreg = getRegion(rem_ptr, /*timespec*/ 16);
+		if (rem_ptr != 0 && mreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_nanosleep, (Pointer.atContents(rreg.result), Pointer.atContents(mreg.result))).0;
+	}
 	//========================================================================================
 	def getitimer(which: int, value: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def alarm(seconds: int) => TODO_UNIMPLEMENTED;
+	def alarm(seconds: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_alarm, (seconds)).0;
+	}
 	//========================================================================================
-	def setitimer(which: int, value: int, ovalue: int) => TODO_UNIMPLEMENTED;
+	def setitimer(which: int, newptr: int, oldptr: int) -> long {
+		var n = getRegion(newptr, /*itimerval*/ 32);
+		if (newptr != 0 && n.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var o = getRegion(oldptr, /*itimerval*/ 32);
+		if (oldptr != 0 && o.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_setitimer, (which, Pointer.atContents(n.result), Pointer.atContents(o.result))).0;
+	}
 	//========================================================================================
-	def getpid() => TODO_UNIMPLEMENTED;
+	def getpid() -> long {
+		return Linux.syscall(LinuxConst.SYS_getpid, ()).0;
+	}
 	//========================================================================================
 	def sendfile(out_fd: int, in_fd: int, offset: int, count: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def socket(domain: int, type_: int, protocol: int) => TODO_UNIMPLEMENTED;
+	def socket(domain: int, stype: int, protocol: int) -> long {
+		var r = Linux.syscall(LinuxConst.SYS_socket, (domain, stype, protocol)).0;
+		if (r < 0) return r;
+		var fd = fdmap.alloc();
+		fdmap.set(fd, int.!(r));
+		return fd;
+	}
 	//========================================================================================
-	def connect(fd: int, addr: int, addrlen: int) => TODO_UNIMPLEMENTED;
+	def connect(fd: int, addr_ptr: int, addrlen: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var areg = getRegion(addr_ptr, addrlen);
+		if (addr_ptr != 0 && areg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_connect, (sys_fd, Pointer.atContents(areg.result), addrlen)).0;
+	}
 	//========================================================================================
-	def accept(fd: int, addr: int, addrlen: int) => TODO_UNIMPLEMENTED;
+	def accept(fd: int, addr_ptr: int, addrlen_ptr: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var areg = getRegion(addr_ptr, /*max addr len*/ 128);
+		if (addr_ptr != 0 && areg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var alenreg = getRegion(addrlen_ptr, 4);
+		if (addrlen_ptr != 0 && alenreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r = Linux.syscall(LinuxConst.SYS_accept, (sys_fd, Pointer.atContents(areg.result), Pointer.atContents(alenreg.result))).0;
+		if (r < 0) return r;
+		var guestfd = fdmap.alloc();
+		fdmap.set(guestfd, int.!(r));
+		return guestfd;
+	}
 	//========================================================================================
-	def sendto(fd: int, buf: int, len: int, flags: int, dest_addr: int, addrlen: int) => TODO_UNIMPLEMENTED;
+	def sendto(fd: int, buf: int, len: int, flags: int, dest: int, addrlen: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var region = getRegion(buf, len);
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var dreg = getRegion(dest, addrlen);
+		if (dest != 0 && dreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_sendto, (sys_fd, Pointer.atContents(region.result), len, flags, Pointer.atContents(dreg.result), addrlen)).0;
+	}
 	//========================================================================================
-	def recvfrom(fd: int, buf: int, len: int, flags: int, src_addr: int, addrlen: int) => TODO_UNIMPLEMENTED;
+	def recvfrom(fd: int, buf: int, len: int, flags: int, src: int, addrlen_ptr: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var region = getRegion(buf, len);
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var sreg = getRegion(src, /*addrlen*/ 128);
+		if (src != 0 && sreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var alenreg = getRegion(addrlen_ptr, 4);
+		if (addrlen_ptr != 0 && alenreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_recvfrom, (sys_fd, Pointer.atContents(region.result), len, flags, Pointer.atContents(sreg.result), Pointer.atContents(alenreg.result))).0;
+	}
 	//========================================================================================
 	def sendmsg(fd: int, msg: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def recvmsg(fd: int, msg: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def shutdown(fd: int, how: int) => TODO_UNIMPLEMENTED;
+	def shutdown(fd: int, how: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_shutdown, (sys_fd, how)).0;
+	}
 	//========================================================================================
-	def listen(fd: int, backlog: int) => TODO_UNIMPLEMENTED;
+	def listen(fd: int, backlog: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_listen, (sys_fd, backlog)).0;
+	}
 	//========================================================================================
-	def getsockname(fd: int, addr: int, addrlen: int) => TODO_UNIMPLEMENTED;
+	def getsockname(fd: int, addr_ptr: int, addrlen_ptr: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var areg = getRegion(addr_ptr, /*space*/ 128);
+		if (addr_ptr != 0 && areg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var alenreg = getRegion(addrlen_ptr, 4);
+		if (addrlen_ptr != 0 && alenreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getsockname, (sys_fd, Pointer.atContents(areg.result), Pointer.atContents(alenreg.result))).0;
+	}
 	//========================================================================================
-	def getpeername(fd: int, addr: int, addrlen: int) => TODO_UNIMPLEMENTED;
+	def getpeername(fd: int, addr_ptr: int, addrlen_ptr: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var areg = getRegion(addr_ptr, /*space*/ 128);
+		if (addr_ptr != 0 && areg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var alenreg = getRegion(addrlen_ptr, 4);
+		if (addrlen_ptr != 0 && alenreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getpeername, (sys_fd, Pointer.atContents(areg.result), Pointer.atContents(alenreg.result))).0;
+	}
 	//========================================================================================
-	def socketpair(domain: int, type_: int, protocolint: int, buf: int) => TODO_UNIMPLEMENTED;
+	def socketpair(domain: int, stype: int, protocol: int, sv_ptr: int) -> long {
+		var sreg = getRegion(sv_ptr, 2 * 4);
+		if (sreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_socketpair, (domain, stype, protocol, Pointer.atContents(sreg.result))).0;
+	}
 	//========================================================================================
-	def setsockopt(fd: int, level: int, optname: int, optval: int, optlen: int) => TODO_UNIMPLEMENTED;
+	def setsockopt(fd: int, level: int, optname: int, optval: int, optlen: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var oreg = getRegion(optval, optlen);
+		if (optval != 0 && oreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_setsockopt, (sys_fd, level, optname, Pointer.atContents(oreg.result), optlen)).0;
+	}
 	//========================================================================================
-	def getsockopt(fd: int, level: int, optname: int, optval: int, optlen: int) => TODO_UNIMPLEMENTED;
+	def getsockopt(fd: int, level: int, optname: int, optval_ptr: int, optlen_ptr: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var oreg = getRegion(optval_ptr, /*optlen*/ 64);
+		if (optval_ptr != 0 && oreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var plen = getRegion(optlen_ptr, 4);
+		if (optlen_ptr != 0 && plen.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getsockopt, (sys_fd, level, optname, Pointer.atContents(oreg.result), Pointer.atContents(plen.result))).0;
+	}
 	//========================================================================================
 	def vfork() => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def execve(filename: int, argv: int, envp: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def wait4(pid: int, stat_addr: int, options: int, ru: int) => TODO_UNIMPLEMENTED;
+	def wait4(pid: int, status_ptr: int, options: int, rusage_ptr: int) -> long {
+		var sreg = getRegion(status_ptr, 4);
+		if (status_ptr != 0 && sreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var rreg = getRegion(rusage_ptr, /*rusage*/ 128);
+		if (rusage_ptr != 0 && rreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_wait4, (pid, Pointer.atContents(sreg.result), options, Pointer.atContents(rreg.result))).0;
+	}
 	//========================================================================================
-	def kill(pid: int, sig: int) => TODO_UNIMPLEMENTED;
+	def kill(pid: int, sig: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_kill, (pid, sig)).0;
+	}
 	//========================================================================================
-	def uname(buf: int) => TODO_UNIMPLEMENTED;
+	def uname(buf: int) -> long {
+		var breg = getRegion(buf, utsname.size);
+		if (breg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_uname, (Pointer.atContents(breg.result))).0;
+	}
 	//========================================================================================
 	def semget(key: int, nsems: int, semflg: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -633,117 +854,245 @@ class WaliInstance {
 	//========================================================================================
 	def msgctl(msqid: int, cmd: int, buf: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def flock(fd: int, cmd: int) => TODO_UNIMPLEMENTED;
+	def flock(fd: int, operation: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_flock, (sys_fd, operation)).0;
+	}
 	//========================================================================================
-	def fsync(fd: int) => TODO_UNIMPLEMENTED;
+	def fsync(fd: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_fsync, (sys_fd)).0;
+	}
 	//========================================================================================
-	def fdatasync(fd: int) => TODO_UNIMPLEMENTED;
+	def fdatasync(fd: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_fdatasync, (sys_fd)).0;
+	}
 	//========================================================================================
 	def truncate(path: int, length: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def ftruncate(fd: int, length: int) => TODO_UNIMPLEMENTED;
+	def ftruncate(fd: int, length: long) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_ftruncate, (sys_fd, length)).0;
+	}
 	//========================================================================================
-	def getdents(fd: int, dirent: int, count: int) => TODO_UNIMPLEMENTED;
+	def getdents(fd: int, dirp: int, count: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var dreg = getRegion(dirp, count);
+		if (dirp != 0 && dreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getdents, (sys_fd, Pointer.atContents(dreg.result), count)).0;
+	}
 	//========================================================================================
-	def getcwd(buf: int, size: int) => TODO_UNIMPLEMENTED;
+	def getcwd(buf: int, size: int) -> long {
+		var breg = getRegion(buf, size);
+		if (breg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getcwd, (Pointer.atContents(breg.result), size)).0;
+	}
 	//========================================================================================
-	def chdir(filename: int) => TODO_UNIMPLEMENTED;
+	def chdir(path: int) -> long {
+		var region = getPath(u32.view(path));
+		if (region.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_chdir, (Pointer.atContents(region.result))).0;
+	}
 	//========================================================================================
-	def fchdir(fd: int) => TODO_UNIMPLEMENTED;
+	def fchdir(fd: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_fchdir, (sys_fd)).0;
+	}
 	//========================================================================================
-	def rename(oldname: int, newname: int) => TODO_UNIMPLEMENTED;
+	def rename(oldpath: int, newpath: int) -> long {
+		var r1 = getPath(u32.view(oldpath));
+		if (r1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r2 = getPath(u32.view(newpath));
+		if (r2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_rename, (Pointer.atContents(r1.result), Pointer.atContents(r2.result))).0;
+	}
 	//========================================================================================
-	def mkdir(pathname: int, mode: int) => TODO_UNIMPLEMENTED;
+	def mkdir(path: int, mode: int) -> long {
+		var r = getPath(u32.view(path));
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_mkdir, (Pointer.atContents(r.result), mode)).0;
+	}
 	//========================================================================================
-	def rmdir(pathname: int) => TODO_UNIMPLEMENTED;
+	def rmdir(path: int) -> long {
+		var r = getPath(u32.view(path));
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_rmdir, (Pointer.atContents(r.result))).0;
+	}
 	//========================================================================================
 	def creat(pathname: int, mode: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def link(oldname: int, newname: int) => TODO_UNIMPLEMENTED;
+	def link(oldpath: int, newpath: int) -> long {
+		var r1 = getPath(u32.view(oldpath));
+		if (r1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r2 = getPath(u32.view(newpath));
+		if (r2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_link, (Pointer.atContents(r1.result), Pointer.atContents(r2.result))).0;
+	}
 	//========================================================================================
-	def unlink(pathname: int) => TODO_UNIMPLEMENTED;
+	def unlink(path: int) -> long {
+		var r = getPath(u32.view(path));
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_unlink, (Pointer.atContents(r.result))).0;
+	}
 	//========================================================================================
-	def symlink(old: int, new_: int) => TODO_UNIMPLEMENTED;
+	def symlink(target: int, linkpath: int) -> long {
+		var r1 = getPath(u32.view(target));
+		if (r1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r2 = getPath(u32.view(linkpath));
+		if (r2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_symlink, (Pointer.atContents(r1.result), Pointer.atContents(r2.result))).0;
+	}
 	//========================================================================================
-	def readlink(path: int, buf: int, bufsiz: int) => TODO_UNIMPLEMENTED;
+	def readlink(path: int, buf: int, bufsiz: int) -> long {
+		var r = getPath(u32.view(path));
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var b = getRegion(buf, bufsiz);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_readlink, (Pointer.atContents(r.result), Pointer.atContents(b.result), bufsiz)).0;
+	}
 	//========================================================================================
-	def chmod(filename: int, mode: int) => TODO_UNIMPLEMENTED;
+	def chmod(path: int, mode: int) -> long {
+		var r = getPath(u32.view(path));
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_chmod, (Pointer.atContents(r.result), mode)).0;
+	}
 	//========================================================================================
-	def fchmod(fd: int, mode: int) => TODO_UNIMPLEMENTED;
+	def fchmod(fd: int, mode: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_fchmod, (sys_fd, mode)).0;
+	}
 	//========================================================================================
-	def chown(filename: int, user: int, group: int) => TODO_UNIMPLEMENTED;
+	def chown(path: int, owner: int, group: int) -> long {
+		var r = getPath(u32.view(path));
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_chown, (Pointer.atContents(r.result), owner, group)).0;
+	}
 	//========================================================================================
-	def fchown(fd: int, user: int, group: int) => TODO_UNIMPLEMENTED;
+	def fchown(fd: int, owner: int, group: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		return Linux.syscall(LinuxConst.SYS_fchown, (sys_fd, owner, group)).0;
+	}
 	//========================================================================================
 	def lchown(filename: int, user: int, group: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def umask(mask: int) => TODO_UNIMPLEMENTED;
+	def umask(mask: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_umask, (mask)).0;
+	}
 	//========================================================================================
 	def gettimeofday(tv: int, tz: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getrusage(who: int, ru: int) => TODO_UNIMPLEMENTED;
+	def getrusage(who: int, usage_ptr: int) -> long {
+		var ureg = getRegion(usage_ptr, wali_rusage.size);
+		if (ureg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getrusage, (who, Pointer.atContents(ureg.result))).0;
+	}
 	//========================================================================================
 	def times(tbuf: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def ptrace(request: int, pid: int, addr: int, data: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getuid() => TODO_UNIMPLEMENTED;
+	def getuid() -> long {
+		return Linux.syscall(LinuxConst.SYS_getuid, ()).0;
+	}
 	//========================================================================================
 	def syslog(type_: int, buf: int, len: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getgid() => TODO_UNIMPLEMENTED;
+	def getgid() -> long {
+		return Linux.syscall(LinuxConst.SYS_getgid, ()).0;
+	}
 	//========================================================================================
 	def setuid(uid: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def setgid(gid: int) => TODO_UNIMPLEMENTED;
+	def setgid(gid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_setgid, (gid)).0;
+	}
 	//========================================================================================
-	def geteuid() => TODO_UNIMPLEMENTED;
+	def geteuid() -> long {
+		return Linux.syscall(LinuxConst.SYS_geteuid, ()).0;
+	}
 	//========================================================================================
-	def getegid() => TODO_UNIMPLEMENTED;
+	def getegid() -> long {
+		return Linux.syscall(LinuxConst.SYS_getegid, ()).0;
+	}
 	//========================================================================================
-	def setpgid(pid: int, pgid: int) => TODO_UNIMPLEMENTED;
+	def setpgid(pid: int, pgid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_setpgid, (pid, pgid)).0;
+	}
 	//========================================================================================
-	def getppid() => TODO_UNIMPLEMENTED;
+	def getppid() -> long {
+		return Linux.syscall(LinuxConst.SYS_getppid, ()).0;
+	}
 	//========================================================================================
 	def getpgrp() => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def setsid() => TODO_UNIMPLEMENTED;
+	def setsid() -> long {
+		return Linux.syscall(LinuxConst.SYS_setsid, ()).0;
+	}
 	//========================================================================================
-	def setreuid(ruid: int, euid: int) => TODO_UNIMPLEMENTED;
+	def setreuid(ruid: int, euid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_setreuid, (ruid, euid)).0;
+	}
 	//========================================================================================
-	def setregid(rgid: int, egid: int) => TODO_UNIMPLEMENTED;
+	def setregid(rgid: int, egid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_setregid, (rgid, egid)).0;
+	}
 	//========================================================================================
-	def getgroups(gidsetsize: int, grouplist: int) => TODO_UNIMPLEMENTED;
+	def getgroups(size: int, list_ptr: int) -> long {
+		var lreg = getRegion(list_ptr, if(size > 0, size * 4, 0));
+		if (size > 0 && lreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getgroups, (size, Pointer.atContents(lreg.result))).0;
+	}
 	//========================================================================================
-	def setgroups(gidsetsize: int, grouplist: int) => TODO_UNIMPLEMENTED;
+	def setgroups(size: int, list_ptr: int) -> long {
+		var lreg = getRegion(list_ptr, size * 4);
+		if (lreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_setgroups, (size, Pointer.atContents(lreg.result))).0;
+	}
 	//========================================================================================
-	def setresuid(ruid: int, euid: int, suid: int) => TODO_UNIMPLEMENTED;
+	def setresuid(ruid: int, euid: int, suid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_setresuid, (ruid, euid, suid)).0;
+	}
 	//========================================================================================
 	def getresuid(ruid: int, euid: int, suid: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def setresgid(rgid: int, egid: int, sgid: int) => TODO_UNIMPLEMENTED;
+	def setresgid(rgid: int, egid: int, sgid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_setresgid, (rgid, egid, sgid)).0;
+	}
 	//========================================================================================
 	def getresgid(rgid: int, egid: int, sgid: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getpgid(pid: int) => TODO_UNIMPLEMENTED;
+	def getpgid(pid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_getpgid, (pid)).0;
+	}
 	//========================================================================================
 	def setfsuid(uid: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def setfsgid(gid: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getsid(pid: int) => TODO_UNIMPLEMENTED;
+	def getsid(pid: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_getsid, (pid)).0;
+	}
 	//========================================================================================
 	def capget(header: int, dataptr: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def capset(header: int, data: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def rt_sigpending(set: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
+	def rt_sigpending(set_ptr: int, sigsetsize: int) -> long {
+		var sreg = getRegion(set_ptr, sigsetsize);
+		if (sreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_rt_sigpending, (Pointer.atContents(sreg.result), sigsetsize)).0;
+	}
 	//========================================================================================
 	def rt_sigtimedwait(uthese: int, uinfo: int, uts: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def rt_sigqueueinfo(pid: int, sig: int, uinfo: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def rt_sigsuspend(unewset: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
+	def rt_sigsuspend(mask_ptr: int, sigsetsize: int) -> long {
+		var mreg = getRegion(mask_ptr, sigsetsize);
+		if (mreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_rt_sigsuspend, (Pointer.atContents(mreg.result), sigsetsize)).0;
+	}
 	//========================================================================================
 	def sigaltstack(uss: int, uoss: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -757,9 +1106,20 @@ class WaliInstance {
 	//========================================================================================
 	def ustat(dev: int, ubuf: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def statfs(path: int, buf: int) => TODO_UNIMPLEMENTED;
+	def statfs(path: int, buf: int) -> long {
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var b = getRegion(buf, wali_statfs.size);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_statfs, (Pointer.atContents(pr.result), Pointer.atContents(b.result))).0;
+	}
 	//========================================================================================
-	def fstatfs(fd: int, buf: int) => TODO_UNIMPLEMENTED;
+	def fstatfs(fd: int, buf: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var b = getRegion(buf, wali_statfs.size);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_fstatfs, (sys_fd, Pointer.atContents(b.result))).0;
+	}
 	//========================================================================================
 	def sysfs(option: int, arg1: int, arg2: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -795,15 +1155,25 @@ class WaliInstance {
 	//========================================================================================
 	def pivot_root(new_root: int, put_old: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def prctl(option: int, arg2: int, arg3: int, arg4: int, arg5: int) => TODO_UNIMPLEMENTED;
+	def prctl(option: int, arg2: int, arg3: int, arg4: int, arg5: int) -> long {
+		return Linux.syscall(LinuxConst.SYS_prctl, (option, arg2, arg3, arg4, arg5)).0;
+	}
 	//========================================================================================
 	def arch_prctl() => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def adjtimex(txc_p: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def setrlimit(resource: int, rlim: int) => TODO_UNIMPLEMENTED;
+	def setrlimit(resource: int, rlim_ptr: int) -> long {
+		var r = getRegion(rlim_ptr, wali_rlimit.size);
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_setrlimit, (resource, Pointer.atContents(r.result))).0;
+	}
 	//========================================================================================
-	def chroot(filename: int) => TODO_UNIMPLEMENTED;
+	def chroot(path: int) -> long {
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_chroot, (Pointer.atContents(pr.result))).0;
+	}
 	//========================================================================================
 	def sync() => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -853,7 +1223,9 @@ class WaliInstance {
 	//========================================================================================
 	def security() => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def gettid() => TODO_UNIMPLEMENTED;
+	def gettid() -> long {
+		return Linux.syscall(LinuxConst.SYS_gettid, ()).0;
+	}
 	//========================================================================================
 	def readahead(fd: int, offset: int, count: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -907,7 +1279,12 @@ class WaliInstance {
 	//========================================================================================
 	def remap_file_pages(start: int, size: int, prot: int, pgoff: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getdents64(fd: int, dirent: int, count: int) => TODO_UNIMPLEMENTED;
+	def getdents64(fd: int, dirp: int, count: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var d = getRegion(dirp, count);
+		if (d.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getdents64, (sys_fd, Pointer.atContents(d.result), count)).0;
+	}
 	//========================================================================================
 	def restart_syscall() => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -929,7 +1306,13 @@ class WaliInstance {
 	//========================================================================================
 	def clock_getres(which_clock: int, tp: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def clock_nanosleep(which_clock: int, flags: int, rqtp: int, rmtp: int) => TODO_UNIMPLEMENTED;
+	def clock_nanosleep(clockid: int, flags: int, req_ptr: int, rem_ptr: int) -> long {
+		var r = getRegion(req_ptr, 16);
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var m = getRegion(rem_ptr, 16);
+		if (rem_ptr != 0 && m.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_clock_nanosleep, (clockid, flags, Pointer.atContents(r.result), Pointer.atContents(m.result))).0;
+	}
 	//========================================================================================
 	def epoll_wait(epfd: int, events: int, maxevents: int, timeout: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -941,7 +1324,12 @@ class WaliInstance {
 	//========================================================================================
 	def vserver() => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def mbind(start: int, len: int, mode: int, nmask: int, maxnode: int, flags: int) => TODO_UNIMPLEMENTED;
+	def bind(fd: int, addr_ptr: int, addrlen: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var areg = getRegion(addr_ptr, addrlen);
+		if (areg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_bind, (sys_fd, Pointer.atContents(areg.result), addrlen)).0;
+	}
 	//========================================================================================
 	def set_mempolicy(mode: int, nmask: int, maxnode: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -981,31 +1369,87 @@ class WaliInstance {
 	//========================================================================================
 	def migrate_pages(pid: int, maxnode: int, from: int, to: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def openat(dfd: int, filename: int, flags: int, mode: int) => TODO_UNIMPLEMENTED;
+	def openat(dirfd: int, path: int, flags: int, mode: int) -> long {
+		var sys_dirfd = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r = Linux.syscall(LinuxConst.SYS_openat, (sys_dirfd, Pointer.atContents(pr.result), flags, mode)).0;
+		if (r < 0) return r;
+		var guestfd = fdmap.alloc();
+		fdmap.set(guestfd, int.!(r));
+		return guestfd;
+	}
 	//========================================================================================
-	def mkdirat(dfd: int, pathname: int, mode: int) => TODO_UNIMPLEMENTED;
+	def mkdirat(dirfd: int, path: int, mode: int) -> long {
+		var sys_dirfd = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_mkdirat, (sys_dirfd, Pointer.atContents(pr.result), mode)).0;
+	}
 	//========================================================================================
 	def mknodat(dfd: int, filename: int, mode: int, dev: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def fchownat(dfd: int, filename: int, user: int, group: int, flag: int) => TODO_UNIMPLEMENTED;
+	def fchownat(dirfd: int, path: int, owner: int, group: int, flags: int) -> long {
+		var sys_dirfd = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_fchownat, (sys_dirfd, Pointer.atContents(pr.result), owner, group, flags)).0;
+	}
 	//========================================================================================
 	def futimesat(dfd: int, filename: int, utimes: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def newfstatat(dfd: int, filename: int, statbuf: int, flag: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def unlinkat(dfd: int, pathname: int, flag: int) => TODO_UNIMPLEMENTED;
+	def unlinkat(dirfd: int, path: int, flags: int) -> long {
+		var sys_dirfd = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_unlinkat, (sys_dirfd, Pointer.atContents(pr.result), flags)).0;
+	}
 	//========================================================================================
 	def renameat(olddfd: int, oldname: int, newdfd: int, newname: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def linkat(olddfd: int, oldname: int, newdfd: int, newname: int, flags: int) => TODO_UNIMPLEMENTED;
+	def linkat(olddirfd: int, oldpath: int, newdirfd: int, newpath: int, flags: int) -> long {
+		var s_old = fdmap.get(olddirfd);
+		var s_new = fdmap.get(newdirfd);
+		var r1 = getPath(u32.view(oldpath));
+		if (r1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r2 = getPath(u32.view(newpath));
+		if (r2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_linkat, (s_old, Pointer.atContents(r1.result), s_new, Pointer.atContents(r2.result), flags)).0;
+	}
 	//========================================================================================
-	def symlinkat(oldname: int, newdfd: int, newname: int) => TODO_UNIMPLEMENTED;
+	def symlinkat(target: int, newdirfd: int, linkpath: int) -> long {
+		var s_new = fdmap.get(newdirfd);
+		var r1 = getPath(u32.view(target));
+		if (r1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r2 = getPath(u32.view(linkpath));
+		if (r2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_symlinkat, (Pointer.atContents(r1.result), s_new, Pointer.atContents(r2.result))).0;
+	}
 	//========================================================================================
-	def readlinkat(dfd: int, path: int, buf: int, bufsiz: int) => TODO_UNIMPLEMENTED;
+	def readlinkat(dirfd: int, path: int, buf: int, bufsiz: int) -> long {
+		var s = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var b = getRegion(buf, bufsiz);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_readlinkat, (s, Pointer.atContents(pr.result), Pointer.atContents(b.result), bufsiz)).0;
+	}
 	//========================================================================================
-	def fchmodat(dfd: int, filename: int, mode: int) => TODO_UNIMPLEMENTED;
+	def fchmodat(dirfd: int, path: int, mode: int, flags: int) -> long {
+		var s = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_fchmodat, (s, Pointer.atContents(pr.result), mode, flags)).0;
+	}
 	//========================================================================================
-	def faccessat(dfd: int, filename: int, mode: int) => TODO_UNIMPLEMENTED;
+	def faccessat(dirfd: int, path: int, mode: int, flags: int) -> long {
+		var s = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_faccessat, (s, Pointer.atContents(pr.result), mode, flags)).0;
+	}
 	//========================================================================================
 	def pselect6(nfds: int, readfds: int, writefds: int, exceptfds: int, timeout: int, sigmask: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1027,7 +1471,14 @@ class WaliInstance {
 	//========================================================================================
 	def move_pages(pid: int, nr_pages: int, pages: int, nodes: int, status: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def utimensat(dfd: int, filename: int, utimes: int, flags: int) => TODO_UNIMPLEMENTED;
+	def utimensat(dirfd: int, path: int, times_ptr: int, flags: int) -> long {
+		var s = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var treg = getRegion(times_ptr, 32);
+		if (times_ptr != 0 && treg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_utimensat, (s, Pointer.atContents(pr.result), Pointer.atContents(treg.result), flags)).0;
+	}
 	//========================================================================================
 	def epoll_pwait(epfd: int, events: int, maxevents: int, timeout: int, sigmask: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1035,7 +1486,13 @@ class WaliInstance {
 	//========================================================================================
 	def timerfd_create(clockid: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def eventfd(count: int) => TODO_UNIMPLEMENTED;
+	def eventfd(initval: int) -> long {
+		var r = Linux.syscall(LinuxConst.SYS_eventfd, (initval)).0;
+		if (r < 0) return r;
+		var guestfd = fdmap.alloc();
+		fdmap.set(guestfd, int.!(r));
+		return guestfd;
+	}
 	//========================================================================================
 	def fallocate(fd: int, mode: int, offset: int, len: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1043,15 +1500,36 @@ class WaliInstance {
 	//========================================================================================
 	def timerfd_gettime(ufd: int, otmr: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def accept4(fd: int, addr: int, addrlen: int, flags: int) => TODO_UNIMPLEMENTED;
+	def accept4(fd: int, addr_ptr: int, addrlen_ptr: int, flags: int) -> long {
+		var sys_fd = fdmap.get(fd);
+		var areg = getRegion(addr_ptr, 128);
+		if (addr_ptr != 0 && areg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var alenreg = getRegion(addrlen_ptr, 4);
+		if (addrlen_ptr != 0 && alenreg.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r = Linux.syscall(LinuxConst.SYS_accept4, (sys_fd, Pointer.atContents(areg.result), Pointer.atContents(alenreg.result), flags)).0;
+		if (r < 0) return r;
+		var guestfd = fdmap.alloc();
+		fdmap.set(guestfd, int.!(r));
+		return guestfd;
+	}
 	//========================================================================================
 	def signalfd4(ufd: int, user_mask: int, sizemask: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def eventfd2(count: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def epoll_create1(flags: int) => TODO_UNIMPLEMENTED;
+	def epoll_create1(flags: int) -> long {
+		var r = Linux.syscall(LinuxConst.SYS_epoll_create1, (flags)).0;
+		if (r < 0) return r;
+		var guestfd = fdmap.alloc();
+		fdmap.set(guestfd, int.!(r));
+		return guestfd;
+	}
 	//========================================================================================
-	def pipe2(fildes: int, flags: int) => TODO_UNIMPLEMENTED;
+	def pipe2(fds_ptr: int, flags: int) -> long {
+		var r = getRegion(fds_ptr, 8);
+		if (r.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_pipe2, (Pointer.atContents(r.result), flags)).0;
+	}
 	//========================================================================================
 	def inotify_init1(flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1095,11 +1573,23 @@ class WaliInstance {
 	//========================================================================================
 	def sched_getattr(pid: int, attr: int, size: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def renameat2(olddfd: int, oldname: int, newdfd: int, newname: int, flags: int) => TODO_UNIMPLEMENTED;
+	def renameat2(olddirfd: int, oldpath: int, newdirfd: int, newpath: int, flags: int) -> long {
+		var s_old = fdmap.get(olddirfd);
+		var s_new = fdmap.get(newdirfd);
+		var r1 = getPath(u32.view(oldpath));
+		if (r1.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var r2 = getPath(u32.view(newpath));
+		if (r2.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_renameat2, (s_old, Pointer.atContents(r1.result), s_new, Pointer.atContents(r2.result), flags)).0;
+	}
 	//========================================================================================
 	def seccomp(op: int, flags: int, uargs: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def getrandom(buf: int, count: int, flags: int) => TODO_UNIMPLEMENTED;
+	def getrandom(buf: int, buflen: int, flags: int) -> long {
+		var b = getRegion(buf, buflen);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_getrandom, (Pointer.atContents(b.result), buflen, flags)).0;
+	}
 	//========================================================================================
 	def memfd_create(uname_ptr: int, flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1127,15 +1617,39 @@ class WaliInstance {
 	//========================================================================================
 	def pkey_free(pkey: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def statx(dfd: int, path: int, flags: int, mask: int, buffer: int) => TODO_UNIMPLEMENTED;
+	def statx(dirfd: int, path: int, flags: int, mask: int, buf: int) -> long {
+		var s = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		var b = getRegion(buf, wali_statx.size);
+		if (b.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_statx, (s, Pointer.atContents(pr.result), flags, mask, Pointer.atContents(b.result))).0;
+	}
 	//========================================================================================
 	def io_pgetevents(ctx_id: int, min_nr: int, nr: int, events: int, timeout: int, sig: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def rseq(rseq: int, rseq_len: int, flags: int, sig: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def faccessat2(dfd: int, filename: int, mode: int, flags: int) => TODO_UNIMPLEMENTED;
+	def faccessat2(dirfd: int, path: int, mode: int, flags: int) -> long {
+		var s = fdmap.get(dirfd);
+		var pr = getPath(u32.view(path));
+		if (pr.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_faccessat2, (s, Pointer.atContents(pr.result), mode, flags)).0;
+	}
+	//========================================================================================
+	def longjmp(x: int, y: int) {
+		//TODO: implement
+	}
+	//========================================================================================
+	def setjmp(x: int) -> int {
+		return TODO_ZERO;
+	}
 	//========================================================================================
 	def wasm_init_memory(x: int, y: int) -> long {
+		return TODO_ZERO;
+	}
+	//========================================================================================
+	def wasm_thread_spawn(x: int, y: int) -> int {
 		return TODO_ZERO;
 	}
 	//========================================================================================

--- a/src/util/HostAdapters.v3
+++ b/src/util/HostAdapters.v3
@@ -13,15 +13,18 @@ def rv() => 		HostResult.Value0;
 
 // Utility methods that adapt host (V3) functions to be called from Wasm.
 component HostAdapters {
-	def v_v(func:		void -> void) =>						HostFunc(SigCache.v_i,		fun a => (func(), HostResult.Value0).last);
+	def v_v(func:		void -> void) =>						HostFunc(SigCache.v_v,		fun a => (func(), HostResult.Value0).last);
 	def i_i(func:		(int) -> int) =>						HostFunc(SigCache.i_i,		fun a => ri(func(ui(a[0]))));
 	def i_r(func:		(int) -> HostResult) =>						HostFunc(SigCache.i_v,		fun a => func(ui(a[0])));
 	
 	def ii_i(func:		(int, int) -> int) =>						HostFunc(SigCache.ii_i,		fun a => ri(func(ui(a[0]), ui(a[1]))));
+	def ii_v(func:		(int, int) -> void) =>						HostFunc(SigCache.ii_v,		fun a => rv(func(ui(a[0]), ui(a[1]))));
 	def ii_r(func:		(int, int) -> HostResult) =>					HostFunc(SigCache.ii_i,		fun a => func(ui(a[0]), ui(a[1])));
 	def iii_i(func:		(int, int, int) -> int) =>					HostFunc(SigCache.iii_i,	fun a => ri(func(ui(a[0]), ui(a[1]), ui(a[2]))));
 	def iii_r(func:		(int, int, int) -> HostResult) =>				HostFunc(SigCache.iii_i,	fun a => func(ui(a[0]), ui(a[1]), ui(a[2])));
 	def iiii_i(func:	(int, int, int, int) -> int) =>					HostFunc(SigCache.iiii_i,	fun a => ri(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]))));
+	def iiil_i(func:	(int, int, int, long) -> int) =>				HostFunc(SigCache.iiil_i,	fun a => ri(func(ui(a[0]), ui(a[1]), ui(a[2]), ul(a[3]))));
+	def iiil_l(func:	(int, int, int, long) -> long) =>				HostFunc(SigCache.iiil_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ul(a[3]))));
 	def iiii_r(func:	(int, int, int, int) -> HostResult) =>				HostFunc(SigCache.iiii_i,	fun a => func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3])));
 	def iiiii_i(func:	(int, int, int, int, int) -> int) =>				HostFunc(SigCache.iiiii_i,	fun a => ri(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]))));
 	def iiiiii_i(func:	(int, int, int, int, int, int) -> int) =>			HostFunc(SigCache.iiiiii_i,	fun a => ri(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]), ui(a[5]))));
@@ -46,9 +49,12 @@ component HostAdapters {
 
 	def v_l(func:		void -> long) =>						HostFunc(SigCache.v_l,		fun a => rl(func()));
 	def i_l(func:		(int) -> long) =>						HostFunc(SigCache.i_l,		fun a => rl(func(ui(a[0]))));
+	def l_l(func:		(long) -> long) =>						HostFunc(SigCache.l_l,		fun a => rl(func(ui(a[0]))));
 	def ii_l(func:		(int, int) -> long) =>						HostFunc(SigCache.ii_l,		fun a => rl(func(ui(a[0]), ui(a[1]))));
+	def il_l(func:		(int, long) -> long) =>						HostFunc(SigCache.il_l,		fun a => rl(func(ui(a[0]), ul(a[1]))));
 	def iii_l(func:		(int, int, int) -> long) =>					HostFunc(SigCache.iii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]))));
 	def iiii_l(func:	(int, int, int, int) -> long) =>				HostFunc(SigCache.iiii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]))));
+	def illi_l(func:	(int, long, long, int) -> long) =>				HostFunc(SigCache.illi_l,	fun a => rl(func(ui(a[0]), ul(a[1]), ul(a[2]), ui(a[3]))));
 	def iiiii_l(func:	(int, int, int, int, int) -> long) =>				HostFunc(SigCache.iiiii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]))));
 	def iiiiii_l(func:	(int, int, int, int, int, int) -> long) =>			HostFunc(SigCache.iiiiii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]), ui(a[5]))));
 	def iiiiil_l(func:	(int, int, int, int, int, long) -> long) =>			HostFunc(SigCache.iiiiil_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]), ul(a[5]))));


### PR DESCRIPTION
With this PR wizard should have all WALI passthroughs implementation similar to WAMR:

```
- read
- write
- close
- stat
- fstat
- lstat
- poll
- lseek
- mprotect
- ioctl
- pread64
- pwrite64
- access
- pipe
- select
- msync
- madvise
- dup
- dup2
- nanosleep
- alarm
- setitimer
- getpid
- socket
- connect
- accept
- sendto
- recvfrom
- shutdown
- bind
- listen
- getsockname
- getpeername
- socketpair
- setsockopt
- getsockopt
- fork
- wait4
- kill
- uname
- flock
- fsync
- fdatasync
- ftruncate
- getdents
- getcwd
- chdir
- fchdir
- rename
- mkdir
- rmdir
- link
- unlink
- symlink
- readlink
- chmod
- fchmod
- chown
- fchown
- umask
- getrlimit
- getrusage
- sysinfo
- getuid
- getgid
- setgid
- geteuid
- getegid
- setpgid
- getppid
- setsid
- setreuid
- setregid
- getgroups
- setgroups
- setresuid
- setresgid
- getpgid
- getsid
- rt_sigpending
- rt_sigsuspend
- statfs
- fstatfs
- prctl
- setrlimit
- chroot
- gettid
- tkill
- futex
- sched_getaffinity
- getdents64
- set_tid_address
- fadvise
- clock_nanosleep
- openat
- mkdirat
- fchownat
- fstatat
- unlinkat
- linkat
- symlinkat
- readlinkat
- fchmodat
- faccessat
- utimensat
- eventfd
- accept4
- epoll_create1
- dup3
- pipe2
- prlimit64
- renameat2
- getrandom
- statx
- faccessat2
```