### PR TITLE
[wali] Change ctors and dtors signature, and mprotect implementation

### DIFF
--- a/src/modules/wali/x86-64-linux/WaliModule.v3
+++ b/src/modules/wali/x86-64-linux/WaliModule.v3
@@ -340,8 +340,8 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_v_i	("__cl_get_argc",		fun i => i.cl_get_argc)
 	.func_i_i	("__cl_get_argv_len",		fun i => i.cl_get_argv_len)
 	.func_ii_i	("__cl_copy_argv",		fun i => i.cl_copy_argv)
-	.func_v_v	("__call_ctors",		fun i => i.call_ctors)
-	.func_v_v	("__call_dtors",		fun i => i.call_dtors)
+	.func_v_v	("__init",			fun i => i.wali_init)
+	.func_v_v	("__deinit",			fun i => i.wali_deinit)
 	.func_u_vr	("__proc_exit",			fun i => i.proc_exit)
 	.func_ii_i	("__get_init_envfile",		fun i => i.get_init_envfile)
 	.func_ii_v	("longjmp",			fun i => i.longjmp)
@@ -552,7 +552,11 @@ class WaliInstance {
 		return Linux.syscall(LinuxConst.SYS_getrlimit, (resource, Pointer.atContents(rreg.result))).0;
 	}
 	//========================================================================================
-	def mprotect(addr: int, len: int, prot: int) => TODO_UNIMPLEMENTED;
+	def mprotect(addr: int, len: int, prot: int) -> long {
+		var n = getRegion(addr, len);
+		if (addr != 0 && n.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_mprotect, (Pointer.atContents(n.result), n.result.length, prot)).0;
+	}
 	//========================================================================================
 	def mremap(old_addr: int, old_size: int, new_size: int, flags: int, new_addr: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1270,7 +1274,11 @@ class WaliInstance {
 	//========================================================================================
 	def clock_settime(which_clock: int, tp: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def clock_gettime(which_clock: int, tp: int) => TODO_UNIMPLEMENTED;
+	def clock_gettime(which_clock: int, tp: int) -> long {
+		var t = getRegion(tp, timespec.size);
+		if (t.reason != TrapReason.NONE) return WaliErrno.EFAULT.code;
+		return Linux.syscall(LinuxConst.SYS_clock_gettime, (which_clock, Pointer.atContents(t.result))).0;
+	}
 	//========================================================================================
 	def clock_getres(which_clock: int, tp: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1638,11 +1646,11 @@ class WaliInstance {
 		return str.length;
 	}
 	//========================================================================================
-	def call_ctors() {
+	def wali_init() {
 		return TODO_EMPTY;
 	}
 	//========================================================================================
-	def call_dtors() {
+	def wali_deinit() {
 		return TODO_EMPTY;
 	}
 	//========================================================================================


### PR DESCRIPTION
Add `mprotect` and `clock_gettime` implementation (passthroughs), and change ctors and dtors signature to match current WALI version.