### PR TITLE
Added `vsframe` GDB macro

### DIFF
--- a/gdb/.gdb_init
+++ b/gdb/.gdb_init
@@ -3,6 +3,7 @@ python
 import gdb
 import os
 
+
 class CheckProt(gdb.Command):
 
     def __init__(self):
@@ -29,8 +30,32 @@ class CheckProt(gdb.Command):
 class PrintFrame(gdb.Command):
     """Print the contents of an X86_64InterpreterFrame at the given address."""
 
+    FIELDS = [
+        (0,  "wasm_func",  "long"),
+        (8,  "mem0_base",  "long"),
+        (16, "vfp",        "long"),
+        (24, "vsp",        "long"),
+        (32, "sidetable",  "long"),
+        (40, "stp",        "long"),
+        (48, "code",       "long"),
+        (56, "ip",         "long"),
+        (64, "eip",        "long"),
+        (72, "func_decl",  "long"),
+        (80, "instance",   "long"),
+        (88, "curpc",      "int"),
+        (96, "accessor",   "long"),
+    ]
+
     def __init__(self):
         super(PrintFrame, self).__init__("printframe", gdb.COMMAND_USER)
+
+    def read_field(self, addr, offset, typ):
+        """Read a field at addr+offset with the given type."""
+        try:
+            val = gdb.Value(addr + offset).cast(gdb.lookup_type(typ).pointer()).dereference()
+            return hex(val) if typ == 'long' else val
+        except gdb.error as e:
+            return f"<error: {e}>"
 
     def invoke(self, arg, from_tty):
         try:
@@ -39,34 +64,68 @@ class PrintFrame(gdb.Command):
             print(f"Invalid address: {e}")
             return
 
-        fields = [
-            (0,  "wasm_func",  "i64"),
-            (8,  "mem0_base",  "i64"),
-            (16, "vfp",        "i64"),
-            (24, "vsp",        "i64"),
-            (32, "sidetable",  "i64"),
-            (40, "stp",        "i64"),
-            (48, "code",       "i64"),
-            (56, "ip",         "i64"),
-            (64, "eip",        "i64"),
-            (72, "func_decl",  "i64"),
-            (80, "instance",   "i64"),
-            (88, "curpc",      "int"),
-            (96, "accessor",   "i64"),
-        ]
-
-        for offset, name, typ in fields:
-            try:
-                if typ == "i64":
-                    val = hex(gdb.Value(addr + offset).cast(gdb.lookup_type("long").pointer()).dereference())
-                elif typ == "int":
-                    val = gdb.Value(addr + offset).cast(gdb.lookup_type("int").pointer()).dereference()
-            except gdb.error as e:
-                val = f"<error: {e}>"
+        for offset, name, typ in self.FIELDS:
+            val = self.read_field(addr, offset, typ)
             print(f"{name:<12} @ +{offset:>2} = {val}")
+
+
+class VSFrame(gdb.Command):
+    """Print the contents of the value stack, based on the given frame address."""
+
+    def __init__(self):
+        super(VSFrame, self).__init__("vsframe", gdb.COMMAND_USER)
+
+    def invoke(self, arg, from_tty):
+        try:
+            addr = int(gdb.parse_and_eval(arg))
+        except Exception as e:
+            print(f"Invalid address: {e}")
+            return
+
+        VFP_OFFSET = 16
+        VSP_OFFSET = 24
+
+        try:
+            VFP_ADDR = gdb.Value(addr + VFP_OFFSET).cast(gdb.lookup_type("long").pointer()).dereference()
+            VSP_ADDR = gdb.Value(addr + VSP_OFFSET).cast(gdb.lookup_type("long").pointer()).dereference()
+
+            vfp = int(VFP_ADDR)
+            vsp = int(VSP_ADDR)
+            n_elems = (vsp - vfp) // 32
+
+            print(f"VFP = {hex(vfp)}, VSP = {hex(vsp)}")
+
+            if n_elems < 0 or n_elems > 10:
+                print(f"Invalid number of elements {n_elems}, aborting")
+                return
+
+            print(f"Printing {n_elems} stack values\n")
+            # Loop from VSP_ADDR to VFP_ADDR in reverse, 32-byte value slot increments
+            # TODO: compatibility with untagged mode
+            for i in range(vsp - 32, vfp - 32, -32):
+                try:
+                    tag = gdb.Value(i).cast(gdb.lookup_type("unsigned char").pointer()).dereference()
+
+                    print(f"@ {hex(i)}:")
+                    print(f"  Tag:   {hex(tag)}")
+                    print(f"  Value: ", end="")
+
+                    val_start = i + 16
+                    for offset in range(4):
+                        at = val_start + offset * 4
+                        val = gdb.Value(at).cast(gdb.lookup_type("unsigned int").pointer()).dereference()
+                        print(f"0x{int(val):08x}", end=" ")
+                    print()
+                except gdb.error as e:
+                    print(f"Error reading at {hex(i)}: {e}")
+                    break
+        except Exception as e:
+            print(f"Invalid address: {e}")
+            return
 
 PrintFrame()
 CheckProt()
+VSFrame()
 
 end
 


### PR DESCRIPTION
This PR adds the `vsframe` GDB macro, which when called with a pointer to an interpreter frame, logs the range of its value stack and prints all stack values in a readable format.
Example: `vsframe $rsp`
```
(gdb) vsframe $rsp
VFP = 0x7ffdf7f63000, VSP = 0x7ffdf7f63040
Printing 2 stack values

@ 0x7ffdf7f63020:
  Tag:   0x63
  Value: 0x0841dd80 0x00000000 0x00000000 0x00000000
@ 0x7ffdf7f63000:
  Tag:   0x7f
  Value: 0x0000004e 0x00000000 0x00000000 0x00000000
```