### PR TITLE
More specific names for `sp`

### DIFF
--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -93,27 +93,27 @@ class X86_64Stack extends WasmStack {
 	def throw(thrown: Throwable) -> ThrowResult {
 		if (Trace.stack) traceFrames(Strings.format1("stack.throw(%q)", thrown.render), rsp + RETADDR_SIZE);
 		// Perform a stackwalk, starting from the RSP stored in this object, gathering frames.
-		var prev_sp = this.rsp;
+		var prev_srp = this.rsp;
 		if (Exception.?(thrown)) {
 			var ex = Exception.!(thrown);
-			var result = walk(findExHandler, ex, prev_sp, true);
+			var result = walk(findExHandler, ex, prev_srp, true);
 			var pos = result.1;
-			var new_sp = pos.frame.sp + -RETADDR_SIZE;
+			var new_srp = pos.frame.srp();
 			if (Trace.stack) {
-				if (result.0) Trace.OUT.put1("walk found handler at frame[sp=0x%x]", pos.frame.sp - Pointer.NULL).ln();
+				if (result.0) Trace.OUT.put1("walk found handler at frame[sfp=0x%x]", pos.frame.sfp - Pointer.NULL).ln();
 				else Trace.OUT.puts("walk found no handler").ln();
 			}
-			if (new_sp != prev_sp) unwind(prev_sp, new_sp);
+			if (new_srp != prev_srp) unwind(prev_srp, new_srp);
 			return if(result.0, ThrowResult.Handled(pos.stack), ThrowResult.Unhandled(ex));
 		}
 
 		var gatherTrace = !FeatureDisable.stacktraces;
 		var trace = if (gatherTrace, Vector<(WasmFunction, int)>.new());
-		var result = walk(if(gatherTrace, addFrameToTrace), trace, prev_sp, true);
-		var new_sp = result.1.frame.sp + -RETADDR_SIZE;
+		var result = walk(if(gatherTrace, addFrameToTrace), trace, prev_srp, true);
+		var new_srp = result.1.frame.srp();
 		// Unwind this stack to the return parent stub and overwrite the caller's return IP.
 		this.vsp = mapping.range.start; // clear value stack
-		if (new_sp != prev_sp) unwind(prev_sp, new_sp);
+		if (new_srp != prev_srp) unwind(prev_srp, new_srp);
 
 		// Append the (reversed) stacktrace to the throwable.
 		if (trace != null) thrown.prependFrames(ArrayUtil.copyReverse(trace));
@@ -123,26 +123,26 @@ class X86_64Stack extends WasmStack {
 	// stop the stackwalk. Otherwise stop at the return-parent stub. In any case, return the last
 	// valid stack pointer, and a boolean indicating if the walk stopped early (due to {f} returning {false}).
 	// (XXX: takes a function {f} with an additional parameter, and the parameter, to avoid a closure).
-	private def walk<P>(f: (Pointer, RiUserCode, StackFramePos, P) -> bool, param: P, start_sp: Pointer, continue_to_parent: bool) -> (bool, StackFramePos) {
+	private def walk<P>(f: (Pointer, RiUserCode, StackFramePos, P) -> bool, param: P, start_srp: Pointer, continue_to_parent: bool) -> (bool, StackFramePos) {
 		var stack = this;
-		var sp = start_sp;
+		var srp = start_srp;
 		if (Trace.stack && Debug.stack) {
 			Trace.OUT.put1("walk started on stack[rsp=0x%x] (", this.rsp - Pointer.NULL);
-			Trace.OUT.put3("start=0x%x, sp=0x%x, end=0x%x, ", stack.mapping.range.start - Pointer.NULL, start_sp - Pointer.NULL, stack.mapping.range.end - Pointer.NULL);
+			Trace.OUT.put3("start=0x%x, srp=0x%x, end=0x%x, ", stack.mapping.range.start - Pointer.NULL, start_srp - Pointer.NULL, stack.mapping.range.end - Pointer.NULL);
 			Trace.OUT.put1("continue_to_parent=%s)", if(continue_to_parent, "true", "false")).ln();
 		}
-		while (sp < stack.mapping.range.end) {
-			var retip = sp.load<Pointer>();
+		while (srp < stack.mapping.range.end) {
+			var retip = srp.load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
+			var sfp = srp + RETADDR_SIZE;
 			var accessor: FrameAccessor;
 			if (Trace.stack && Debug.stack) {
 				Trace.OUT.put1("\tretip=0x%x", retip - Pointer.NULL);
-				// TODO: unify {sp} convention
- 				if (code != null) code.describeFrame(retip, sp + RETADDR_SIZE, Trace.OUT.putr_void);
+				if (code != null) code.describeFrame(retip, sfp, Trace.OUT.putr_void);
 				else Trace.OUT.ln();
 				Trace.OUT.flush();
 			}
-			var pos = StackFramePos(stack, TargetFrame(sp + RETADDR_SIZE));
+			var pos = StackFramePos(stack, TargetFrame(sfp));
 			match (code) {
 				null => break;
 				x: X86_64InterpreterCode => if (f != null && !f(retip, code, pos, param)) return (true, pos);
@@ -156,28 +156,28 @@ class X86_64Stack extends WasmStack {
 					} else {
 						stack = X86_64Stack.!(stack.parent);
 						if (Trace.stack && Debug.stack) Trace.OUT.put1("walk to parent[rsp=0x%x]", stack.rsp - Pointer.NULL).ln();
-						sp = stack.rsp;
+						srp = stack.rsp;
 						continue;
 					}
 				}
 			}
-			var t = code.nextFrame(retip, sp);
-			sp = t.1;
+			var t = code.nextFrame(retip, srp);
+			srp = t.1;
 		}
 //TODO		fatal(Strings.format1("invalid stack state: rsp=0x%x", this.rsp - Pointer.NULL));
 		return (false, StackFramePos(this, TargetFrame(Pointer.NULL)));
 	}
-	def traceFrames(when: string, sp: Pointer) {
+	def traceFrames(when: string, sfp: Pointer) {
 		Trace.OUT.puts(when);
 		if (Debug.stack) Trace.OUT.put1(" rsp=0x%x", rsp - Pointer.NULL);
 		Trace.OUT.ln();
-		while (sp >= mapping.range.start && sp < mapping.range.end) {
-			var retip = (sp + -RETADDR_SIZE).load<Pointer>();
+		while (sfp >= mapping.range.start && sfp < mapping.range.end) {
+			var retip = (sfp + -RETADDR_SIZE).load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
 			if (code == null) break;
-			code.describeFrame(retip, sp, Trace.STDOUT_void);
-			var t = code.nextFrame(retip, sp);
-			sp = t.1;
+			code.describeFrame(retip, sfp, Trace.STDOUT_void);
+			var t = code.nextFrame(retip, sfp);
+			sfp = t.1;
 		}
 	}
 	def setRsp(ptr: Pointer) -> this {
@@ -287,15 +287,14 @@ class X86_64Stack extends WasmStack {
 			if (p_retaddr != Pointer.NULL) p_retaddr.store<Pointer>(STACK_UNWIND_STUB.getEntry() + NOP_ENTRY);
 		}
 	}
-	def handleOverflow(ip: Pointer, sp: Pointer) -> Pointer {
-		if (Trace.stack) traceFrames("stack.overflow (before)", sp);
+	def handleOverflow(ip: Pointer, sfp: Pointer) -> Pointer {
+		if (Trace.stack) traceFrames("stack.overflow (before)", sfp);
 		// Unwind the stack, skipping the top frame (which might have triggered the overflow)
-		// XXX: change the %sp convention from the caller instead of doing {+ -RETADDR_SIZE}
-		var result = walk<void>(null, (), sp + -RETADDR_SIZE, true);
-		var new_sp = result.1.frame.sp + -RETADDR_SIZE;
+		var result = walk<void>(null, (), sfp + -RETADDR_SIZE, true);
+		var new_srp = result.1.frame.srp();
 		// Unwind without updating any return addresses.
 		this.vsp = mapping.range.start; // clear value stack
-		if (new_sp != this.rsp) unwind(Pointer.NULL, new_sp);
+		if (new_srp != this.rsp) unwind(Pointer.NULL, new_srp);
 		// Instead, return from the signal to the stack overflow stub, which will unwind with a Trap.STACK_OVERFLOW throwable.
 		if (Trace.stack) traceFrames("stack.overflow (after)", this.rsp + RETADDR_SIZE);
 		return STACK_OVERFLOW_STUB.getEntry() + NOP_ENTRY;
@@ -470,7 +469,7 @@ class X86_64Stack extends WasmStack {
 		walk<void>(scanFrame, (), rsp, false);
 	}
 	private def scanFrame(ip: Pointer, code: RiUserCode, pos: StackFramePos, v: void) -> bool {
-		code.scanFrame(ip, pos.frame.sp);
+		code.scanFrame(ip, pos.frame.sfp);
 		return true;
 	}
 	def readValue(base: Pointer, offset: int) -> Value {
@@ -593,35 +592,35 @@ def G = X86_64MasmRegs.toGpr, X = X86_64MasmRegs.toXmmr;
 component X86_64Stacks {
 	var RESUME_STUB_POINTER: Pointer;
 
-	def getFrameAccessor(sp: Pointer) -> X86_64FrameAccessor {
-		var retip = (sp + -RETADDR_SIZE).load<Pointer>();
+	def getFrameAccessor(sfp: Pointer) -> X86_64FrameAccessor {
+		var retip = (sfp + -RETADDR_SIZE).load<Pointer>();
 		var code = RiRuntime.findUserCode(retip);
 		match (code) {
 			x: X86_64InterpreterCode => {
-				var prev = (sp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+				var prev = (sfp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 				if (prev != null) return prev;
 				// Interpreter frames store the {WasmFunction} _and_ {FuncDecl}.
-				var decl = (sp + X86_64InterpreterFrame.func_decl.offset).load<FuncDecl>();
-				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sp, decl);
-				(sp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
+				var decl = (sfp + X86_64InterpreterFrame.func_decl.offset).load<FuncDecl>();
+				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sfp, decl);
+				(sfp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
 				return n;
 			}
 			x: X86_64SpcCode => {
-				var prev = (sp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+				var prev = (sfp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 				if (prev != null) return prev;
 				// SPC frames only store the {WasmFunction}.
-				var wf = (sp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
+				var wf = (sfp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
 				// TODO: assert wf.decl == x.decl()
-				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sp, wf.decl);
-				(sp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
+				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, sfp, wf.decl);
+				(sfp + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(n);
 				return n;
 			}
 		}
 		return null;
 	}
-	def traceIpAndSp(ip: Pointer, sp: Pointer, out: Range<byte> -> void) {
+	def traceIpAndSp(ip: Pointer, sfp: Pointer, out: Range<byte> -> void) {
 		var buf = X86_64Runtime.globalFrameDescriptionBuf;
-		buf.put2("\t@[ip=0x%x, sp=0x%x] ", ip - Pointer.NULL, sp - Pointer.NULL).send(out);
+		buf.put2("\t@[ip=0x%x, sfp=0x%x] ", ip - Pointer.NULL, sfp - Pointer.NULL).send(out);
 		buf.reset();
 	}
 }
@@ -666,23 +665,23 @@ class X86_64ReturnParentStub extends RiUserCode {
 	new() super(Pointer.NULL, Pointer.NULL) { }
 
 	// Called from V3 runtime upon fatal errors to describe a frame for a stacktrace.
-	def describeFrame(ip: Pointer, sp: Pointer, out: Range<byte> -> void) {
-		if (Debug.stack) X86_64Stacks.traceIpAndSp(ip, sp, out);
+	def describeFrame(ip: Pointer, sfp: Pointer, out: Range<byte> -> void) {
+		if (Debug.stack) X86_64Stacks.traceIpAndSp(ip, sfp, out);
 		var buf = X86_64Runtime.globalFrameDescriptionBuf;
 		buf.puts("\tin [return-parent-stub]");
 		if (Debug.stack) {
-			var parent_rsp = sp.load<Pointer>();
+			var parent_rsp = sfp.load<Pointer>();
 			buf.put1(" parent_rsp=0x%x", parent_rsp - Pointer.NULL);
 		}
 		buf.ln().send(out);
 		buf.reset();
 	}
 	// Called from V3 runtime to get to the next frame.
-	def nextFrame(ip: Pointer, sp: Pointer) -> (Pointer, Pointer) {
-		sp = sp.load<Pointer>(); // parent_rsp on stack
-		if (sp == Pointer.NULL) return (Pointer.NULL, Pointer.NULL); // not initialized
-		ip = sp.load<Pointer>();
-		return (ip + -1, sp + RETADDR_SIZE); // XXX: V3 quirk with -1 (use RiOs?)
+	def nextFrame(ip: Pointer, sfp: Pointer) -> (Pointer, Pointer) {
+		var srp = sfp.load<Pointer>(); // parent srp on stack
+		if (srp == Pointer.NULL) return (Pointer.NULL, Pointer.NULL); // not initialized
+		ip = srp.load<Pointer>();
+		return (ip + -1, srp + RETADDR_SIZE); // XXX: V3 quirk with -1 (use RiOs?)
 	}
 }
 
@@ -697,8 +696,8 @@ class X86_64UnwindStub extends RiUserCode {
 	new(name) super(Pointer.NULL, Pointer.NULL) { }
 
 	// Called from V3 runtime upon fatal errors to describe a frame for a stacktrace.
-	def describeFrame(ip: Pointer, sp: Pointer, out: Range<byte> -> void) {
-		if (Debug.stack) X86_64Stacks.traceIpAndSp(ip, sp, out);
+	def describeFrame(ip: Pointer, sfp: Pointer, out: Range<byte> -> void) {
+		if (Debug.stack) X86_64Stacks.traceIpAndSp(ip, sfp, out);
 		var buf = X86_64Runtime.globalFrameDescriptionBuf;
 		buf.puts("\tin [").puts(name).puts("-stub]");
 		if (Debug.stack) {
@@ -709,11 +708,11 @@ class X86_64UnwindStub extends RiUserCode {
 		buf.reset();
 	}
 	// Called from V3 runtime to get to the next frame.
-	def nextFrame(ip: Pointer, sp: Pointer) -> (Pointer, Pointer) {
-		sp = X86_64Runtime.curStack.rsp;
-		if (sp == Pointer.NULL) return (Pointer.NULL, Pointer.NULL); // not initialized
-		ip = sp.load<Pointer>();
-		return (ip + -1, sp + RETADDR_SIZE); // XXX: V3 quirk with -1 (use RiOs?)
+	def nextFrame(ip: Pointer, sfp: Pointer) -> (Pointer, Pointer) {
+		var srp = X86_64Runtime.curStack.rsp;
+		if (srp == Pointer.NULL) return (Pointer.NULL, Pointer.NULL); // not initialized
+		ip = srp.load<Pointer>();
+		return (ip + -1, srp + RETADDR_SIZE); // XXX: V3 quirk with -1 (use RiOs?)
 	}
 }
 
@@ -916,9 +915,9 @@ def genStackUnwind(ic: X86_64InterpreterCode, w: DataWriter, thrown: Throwable) 
 //                                                              [ virgil frame  ]
 
 component X86_64Frames {
-	// Convert a machine stack pointer into a reference to the frame.
-	def fromSp(sp: Pointer) -> Ref<X86_64InterpreterFrame> {
-		return Ref<X86_64InterpreterFrame>.of(CiRuntime.forgeRange<byte>(sp, X86_64InterpreterFrame.size));
+	// Convert a machine stack frame pointer into a reference to the frame.
+	def fromSfp(sfp: Pointer) -> Ref<X86_64InterpreterFrame> {
+		return Ref<X86_64InterpreterFrame>.of(CiRuntime.forgeRange<byte>(sfp, X86_64InterpreterFrame.size));
 	}
 }
 
@@ -947,7 +946,7 @@ enum X86_64FrameState {
 }
 // Implements access to interpreter and SPC frames.
 // TODO: (stack) parent method
-class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) extends FrameAccessor {
+class X86_64FrameAccessor(stack: X86_64Stack, sfp: Pointer, decl: FuncDecl) extends FrameAccessor {
 	var writer: X86_64FrameWriter; // non-null if any writes have been made
 	var cached_depth = -1;
 	var cached_pc: int;
@@ -955,12 +954,12 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	// Returns {true} if this frame has been unwound, either due to returning, a trap, or exception.
 	def isUnwound() -> bool {
 		if (FeatureDisable.frameAccess) return false; // TODO: proper is-frame-unwound check
-		return this != (sp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
+		return this != (sfp + X86_64InterpreterFrame.accessor.offset).load<X86_64FrameAccessor>();
 	}
 	// Returns the Wasm function in this frame.
 	def func() -> WasmFunction {
 		checkNotUnwound();
-		return (sp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
+		return (sfp + X86_64InterpreterFrame.wasm_func.offset).load<WasmFunction>();
 	}
 	// Returns the current program counter.
 	def pc() -> int {
@@ -969,9 +968,9 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var code = RiRuntime.findUserCode(ip);
 		match (code) {
 			x: X86_64SpcModuleCode => cached_pc = x.lookupTopPc(ip, true);
-			x: X86_64SpcInlinedFrame => cached_pc = (sp + X86_64InterpreterFrame.curpc.offset).load<int>();
-			x: X86_64InterpreterCode => cached_pc = X86_64Interpreter.computePCFromFrame(sp);
-			x: X86_64SpcTrapsStub => cached_pc = (sp + X86_64InterpreterFrame.curpc.offset).load<int>();
+			x: X86_64SpcInlinedFrame => cached_pc = (sfp + X86_64InterpreterFrame.curpc.offset).load<int>();
+			x: X86_64InterpreterCode => cached_pc = X86_64Interpreter.computePCFromFrame(sfp);
+			x: X86_64SpcTrapsStub => cached_pc = (sfp + X86_64InterpreterFrame.curpc.offset).load<int>();
 			_ => cached_pc = -1;
 		}
 		return cached_pc;
@@ -989,10 +988,10 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	}
 	private def computeDepth() -> int {
 		var depth = 0;
-		var next_sp = sp;
+		var next_sfp = sfp;
 		while (true) {
-			next_sp = next_sp + X86_64InterpreterFrame.size + RETADDR_SIZE;
-			var retip = (next_sp + -RETADDR_SIZE).load<Pointer>();
+			next_sfp = next_sfp + X86_64InterpreterFrame.size + RETADDR_SIZE;
+			var retip = (next_sfp + -RETADDR_SIZE).load<Pointer>();
 			var code = RiRuntime.findUserCode(retip);
 			match (code) {
 				x: X86_64InterpreterCode => ;
@@ -1006,7 +1005,7 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	}
 	def caller() -> FrameLoc {
 		checkNotUnwound();
-		var frame = TargetFrame(callerSp());
+		var frame = TargetFrame(callerSfp());
 		var accessor = frame.getFrameAccessor();
 		if (accessor == null) return FrameLoc.None;
 		return FrameLoc.Wasm(accessor.func(), accessor.pc(), frame);
@@ -1017,7 +1016,7 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 		var code = RiRuntime.findUserCode(ip);
 		match (code) {
 			x: X86_64InterpreterCode => {
-				var stp = (sp + X86_64InterpreterFrame.stp.offset).load<Pointer>();
+				var stp = (sfp + X86_64InterpreterFrame.stp.offset).load<Pointer>();
 				var stp0 = Pointer.atContents(func().decl.sidetable.entries);
 				return int.!((stp - stp0) / 4);
 			}
@@ -1038,28 +1037,28 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	def getLocal(i: int) -> Value {
 		checkNotUnwound();
 		checkLocalBounds(i);
-		var vfp = (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (sfp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		return stack.readValue(vfp, i);
 	}
 	// Get the value of frame variable {i}.
 	def getFrameVar(i: int) -> Value {
 		checkNotUnwound();
 		checkFrameVarBounds(i);
-		var vfp = (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (sfp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		return stack.readValue(vfp, i + decl.num_locals);
 	}
 	// Get the number of operand stack elements.
 	def numOperands() -> int {
 		checkNotUnwound();
-		var vfp = (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
-		var vsp = (sp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
+		var vfp = (sfp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vsp = (sfp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
 		var diff = int.!((vsp - vfp) / Target.tagging.slot_size);
 		return diff - decl.num_locals;
 	}
 	// Get operand at depth {i}, with 0 being the top of the stack, -1 being one lower, etc.
 	def getOperand(i: int) -> Value {
 		checkNotUnwound();
-		var vsp = (sp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
+		var vsp = (sfp + X86_64InterpreterFrame.vsp.offset).load<Pointer>();
 		return stack.readValue(vsp, i - 1);
 	}
 	// Get the frame writer.
@@ -1069,15 +1068,15 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 
 	// Read the return address from the frame.
 	def readRetAddr() -> Pointer {
-		return (sp + X86_64InterpreterFrame.size).load<Pointer>();
+		return (sfp + X86_64InterpreterFrame.size).load<Pointer>();
 	}
 	// Read the instruction pointer from the frame.
 	def readIp() -> Pointer {
-		return (sp + -RETADDR_SIZE).load<Pointer>();
+		return (sfp + -RETADDR_SIZE).load<Pointer>();
 	}
-	// Compute the caller frame's stack pointer.
-	def callerSp() -> Pointer {
-		return sp + X86_64InterpreterFrame.size + RETADDR_SIZE;
+	// Compute the caller frame's stack frame pointer.
+	def callerSfp() -> Pointer {
+		return sfp + X86_64InterpreterFrame.size + RETADDR_SIZE;
 	}
 	def isSpc() -> bool {
 		var ip = readIp();
@@ -1107,7 +1106,7 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 			Trace.OUT.put1("  ret_addr=0x%x ", spc_entry + offset);
 			Trace.OUT.put2("[spc_entry=0x%x, offset=%d]", spc_entry, offset).ln();
 		}
-		(sp + -RETADDR_SIZE).store<Pointer>(func.target_code.spc_entry + offset);
+		(sfp + -RETADDR_SIZE).store<Pointer>(func.target_code.spc_entry + offset);
 	}
 	private def deoptToInterpreter() {
 		var wf = func(), func = wf.decl;
@@ -1119,24 +1118,24 @@ class X86_64FrameAccessor(stack: X86_64Stack, sp: Pointer, decl: FuncDecl) exten
 	private def deoptToInterpreter0(func: FuncDecl, pc: int, stp: int) {
 		var ic = X86_64PreGenStubs.getInterpreterCode();
 		setNewProgramLocation(func, pc, stp);
-		(sp + -RETADDR_SIZE).store<Pointer>(ic.start + ic.header.deoptReentryOffset);
+		(sfp + -RETADDR_SIZE).store<Pointer>(ic.start + ic.header.deoptReentryOffset);
 	}
 	def setNewProgramLocation(func: FuncDecl, pc: int, stp: int) {
 		var code = func.cur_bytecode;
-		(sp + X86_64InterpreterFrame.func_decl.offset)	.store<FuncDecl>(func);
-		(sp + X86_64InterpreterFrame.curpc.offset)	.store<int>(pc);
-		(sp + X86_64InterpreterFrame.code.offset)	.store<Array<byte>>(code);
-		(sp + X86_64InterpreterFrame.ip.offset)		.store<Pointer>(Pointer.atElement(code, pc));
-		(sp + X86_64InterpreterFrame.eip.offset)	.store<Pointer>(Pointer.atContents(code) + code.length);
+		(sfp + X86_64InterpreterFrame.func_decl.offset)	.store<FuncDecl>(func);
+		(sfp + X86_64InterpreterFrame.curpc.offset)	.store<int>(pc);
+		(sfp + X86_64InterpreterFrame.code.offset)	.store<Array<byte>>(code);
+		(sfp + X86_64InterpreterFrame.ip.offset)	.store<Pointer>(Pointer.atElement(code, pc));
+		(sfp + X86_64InterpreterFrame.eip.offset)	.store<Pointer>(Pointer.atContents(code) + code.length);
 		var st_entries = func.sidetable.entries;
 		var st_ptr = if(stp == st_entries.length, Pointer.atContents(st_entries), Pointer.atElement(func.sidetable.entries, stp));
-		(sp + X86_64InterpreterFrame.stp.offset)	.store<Pointer>(st_ptr);
+		(sfp + X86_64InterpreterFrame.stp.offset)	.store<Pointer>(st_ptr);
 	}
 	private def vfp() -> Pointer {
-		return (sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		return (sfp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 	}
 	private def set_vsp(p: Pointer) {
-		(sp + X86_64InterpreterFrame.vsp.offset).store<Pointer>(p);
+		(sfp + X86_64InterpreterFrame.vsp.offset).store<Pointer>(p);
 	}
 }
 private class X86_64FrameWriter extends FrameWriter {
@@ -1148,7 +1147,7 @@ private class X86_64FrameWriter extends FrameWriter {
 	def setLocal(i: int, v: Value) {
 		accessor.checkNotUnwound();
 		accessor.checkLocalBounds(i);
-		var vfp = (accessor.sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (accessor.sfp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		accessor.stack.overwriteValue(vfp, i, v);
 		if (accessor.isSpc()) accessor.deoptToInterpreter();
 	}
@@ -1156,7 +1155,7 @@ private class X86_64FrameWriter extends FrameWriter {
 	def setFrameVar(i: int, v: Value) {
 		accessor.checkNotUnwound();
 		accessor.checkFrameVarBounds(i);
-		var vfp = (accessor.sp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
+		var vfp = (accessor.sfp + X86_64InterpreterFrame.vfp.offset).load<Pointer>();
 		accessor.stack.overwriteValue(vfp, i + accessor.decl.num_locals, v);
 		if (accessor.isSpc()) accessor.deoptToInterpreter();
 	}

--- a/src/engine/x86-64/X86_64Target.v3
+++ b/src/engine/x86-64/X86_64Target.v3
@@ -167,9 +167,10 @@ type TargetOsrInfo(spc_entry: Pointer, osr_entries: List<(int, int)>) #unboxed {
 type TargetCode(spc_entry: Pointer) #unboxed { }
 type TargetModule(spc_code: X86_64SpcModuleCode) #unboxed { }
 // TODO: immutable cache for frame accessor
-type TargetFrame(sp: Pointer) #unboxed {
+type TargetFrame(sfp: Pointer) #unboxed {
+	def srp() -> Pointer { return sfp + -Pointer.SIZE; }
 	def getFrameAccessor() -> X86_64FrameAccessor {
-		return X86_64Stacks.getFrameAccessor(sp);
+		return X86_64Stacks.getFrameAccessor(sfp);
 	}
 }
 type SpcResultForStub(wf: WasmFunction, entrypoint: Pointer, thrown: Throwable) #unboxed { }


### PR DESCRIPTION
Currently `sp` have two ambiguous meanings: it's either a pointer to a frame on the execution stack, or a pointer to the return address into a frame (the two differs by a `RETADDR_SIZE`). This PR disambiguates the two by replacing `sp` with the following names, depending on where it points to:
- `sfp`: stack frame pointer. These point to execution stack frames.
- `srp`: stack return-address pointer. These point to return addresses into stack frames.

`srp + RETADDR_SIZE == sfp` when they are referring to the same stack frame.