### PR TITLE
Call `unrefReg` at the end of stack reconstruction

### DIFF
--- a/src/engine/compiler/SinglePassCompiler.v3
+++ b/src/engine/compiler/SinglePassCompiler.v3
@@ -2162,6 +2162,8 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 		def real_frame = frames[0];
 		masm.emit_mov_m_i(xenv.pc_slot, real_frame.pc);
 
+		unrefRegs();
+
 		// load instance
 		var inst_reg = allocTmp(ValueKind.REF);
 		masm.emit_mov_r_m(ValueKind.REF, inst_reg, frame.instance_slot);
@@ -2197,6 +2199,7 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 			prev_base_sp = cur_base_sp;
 		}
 
+		unrefRegs();
 		return total_space;
 	}
 	def emitReconstructStackFrame(spcFrame: SpcFrame, offset: int, vfp_delta: int,
@@ -2259,7 +2262,6 @@ class SinglePassCompiler(xenv: SpcExecEnv, masm: MacroAssembler, regAlloc: RegAl
 				emit();
 				return;
 			}
-			unrefRegs();
 			frames_reconstructed = true;
 			def space = emitReconstructStackFrames(snapshotFrames());
 			emit();


### PR DESCRIPTION
and move the `unrefReg` before to be inside the method