### PR TITLE
[exception-handling] Fixed sidetable reading of `try_table`

### DIFF
--- a/src/engine/Sidetable.v3
+++ b/src/engine/Sidetable.v3
@@ -82,7 +82,11 @@ component Sidetables {
 			BR => 			size = Sidetable_BrEntry.size;
 			BR_IF => 		size = Sidetable_BrEntry.size;
 			BR_TABLE =>		{ var count = immptr.skip_labels(); size = (1 + count) * Sidetable_BrEntry.size; }
-			TRY_TABLE =>		{ var count = immptr.skip_catches(); size = count * Sidetable_CatchEntry.size; }
+			TRY_TABLE =>		{
+				immptr.read_BlockTypeCode();
+				var count = immptr.skip_catches();
+				size = count * Sidetable_CatchEntry.size;
+			}
 			BR_ON_NULL =>		size = Sidetable_BrEntry.size;
 			BR_ON_NON_NULL =>	size = Sidetable_BrEntry.size;
 			BR_ON_CAST =>		size = Sidetable_BrEntry.size;

--- a/test/unittest/SidetableTest.v3
+++ b/test/unittest/SidetableTest.v3
@@ -11,6 +11,7 @@ def X_ = void(
 	T("if0", test_if0),
 	T("relative", test_relative),
 	T("br_table0", test_br_table0),
+	T("try_table0", test_try_table0),
 	T("br_loop_val", test_br_loop_val),
 	()
 );
@@ -96,6 +97,7 @@ def BLOCK = u8.!(Opcode.BLOCK.code);
 def LOOP = u8.!(Opcode.LOOP.code);
 def IF = u8.!(Opcode.IF.code);
 def ELSE = u8.!(Opcode.ELSE.code);
+def TT = u8.!(Opcode.TRY_TABLE.code);
 def N = BpTypeCode.EmptyBlock.code;
 def I = BpTypeCode.I32.code;
 
@@ -248,6 +250,14 @@ def test_br_table0(t: SidetableTester) {
 		(3, BRE(3, 0, 0, 8)),
 		(3, BRE(2, 0, 0, 4))
 	], t.func.sidetable);
+}
+
+def test_try_table0(t: SidetableTester) {
+	t.extensions |= Extension.EXCEPTION_HANDLING;
+	t.sig(SigCache.v_v);
+	// try_table (empty block type) with 0 catches; br to try_table label.
+	t.codev([TT, N, 0, BR, 0, END]);
+	t.assert(4, 2, 0, 0, 4);
 }
 
 def test_br_loop_val(t: SidetableTester) {


### PR DESCRIPTION
This PR fixed a bug in `computeEntrySize` when called on `try_table`; old implementation does not consume the block type.