### PR TITLE
[stack-switching] x86-64 frame clean-up

### DIFF
--- a/src/engine/x86-64/X86_64Frames.v3
+++ b/src/engine/x86-64/X86_64Frames.v3
@@ -112,6 +112,15 @@ type X86_64FrameHandle #unboxed {
 	def set_accessor(val: X86_64FrameAccessor) {
 		(sfp() + X86_64InterpreterFrame.accessor.offset).store<X86_64FrameAccessor>(val);
 	}
+	def set_vfp(val: Pointer) {
+		(sfp() + X86_64InterpreterFrame.vfp.offset).store<Pointer>(val);
+	}
+	def set_instance(val: Instance) {
+		(sfp() + X86_64InterpreterFrame.instance.offset).store<Instance>(val);
+	}
+	def set_mem0_base(val: Pointer) {
+		(sfp() + X86_64InterpreterFrame.mem0_base.offset).store<Pointer>(val);
+	}
 
 	// Compound operations.
 
@@ -266,6 +275,12 @@ class X86_64FrameAccessor(stack: X86_64Stack, handle: X86_64FrameHandle, decl: F
 	def getLocal(i: int) -> Value {
 		checkNotUnwound();
 		checkLocalBounds(i);
+		return stack.readValue(handle.vfp(), i);
+	}
+	// Get the value at {vfp + i} without a bounds check.
+	// XXX: refactor — used by stack compression; overlaps with {getLocal}.
+	def getValue(i: int) -> Value {
+		checkNotUnwound();
 		return stack.readValue(handle.vfp(), i);
 	}
 	// Get the value of frame variable {i}.

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -123,7 +123,7 @@ class X86_64Stack extends WasmStack {
 	// stop the stackwalk. Otherwise stop at the return-parent stub. In any case, return the last
 	// valid stack pointer, and a boolean indicating if the walk stopped early (due to {f} returning {false}).
 	// (XXX: takes a function {f} with an additional parameter, and the parameter, to avoid a closure).
-	private def walk<P>(f: (Pointer, RiUserCode, StackFramePos, P) -> bool, param: P, start_srp: Pointer, continue_to_parent: bool) -> (bool, StackFramePos) {
+	def walk<P>(f: (Pointer, RiUserCode, StackFramePos, P) -> bool, param: P, start_srp: Pointer, continue_to_parent: bool) -> (bool, StackFramePos) {
 		var stack = this;
 		var srp = start_srp;
 		if (Trace.stack && Debug.stack) {
@@ -597,7 +597,7 @@ def G = X86_64MasmRegs.toGpr, X = X86_64MasmRegs.toXmmr;
 component X86_64Stacks {
 	var RESUME_STUB_POINTER: Pointer;
 
-	def getFrameAccessor(sfp: Pointer) -> X86_64FrameAccessor {
+	def getFrameAccessorOfStack(sfp: Pointer, stack: X86_64Stack) -> X86_64FrameAccessor {
 		var retip = (sfp + -RETADDR_SIZE).load<Pointer>();
 		var code = RiRuntime.findUserCode(retip);
 		match (code) {
@@ -607,7 +607,7 @@ component X86_64Stacks {
 				if (prev != null) return prev;
 				// Interpreter frames store the {WasmFunction} _and_ {FuncDecl}.
 				var decl = h.func_decl();
-				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, h, decl);
+				var n = X86_64FrameAccessor.new(stack, h, decl);
 				h.set_accessor(n);
 				return n;
 			}
@@ -618,12 +618,16 @@ component X86_64Stacks {
 				// SPC frames only store the {WasmFunction}.
 				// TODO: assert wf.decl == x.decl()
 				var decl = h.wasm_func().decl;
-				var n = X86_64FrameAccessor.new(X86_64Runtime.curStack, h, decl);
+				var n = X86_64FrameAccessor.new(stack, h, decl);
 				h.set_accessor(n);
 				return n;
 			}
 			_ => return null;
 		}
+	}
+	// TODO[cleanup]: defaulting to {curStack} should be deprecated with stack-switching
+	def getFrameAccessor(sfp: Pointer) -> X86_64FrameAccessor {
+		return getFrameAccessorOfStack(sfp, X86_64Runtime.curStack);
 	}
 	def traceIpAndSp(ip: Pointer, sfp: Pointer, out: Range<byte> -> void) {
 		var buf = X86_64Runtime.globalFrameDescriptionBuf;

--- a/src/engine/x86-64/X86_64Target.v3
+++ b/src/engine/x86-64/X86_64Target.v3
@@ -172,6 +172,10 @@ type TargetFrame(sfp: Pointer) #unboxed {
 	def getFrameAccessor() -> X86_64FrameAccessor {
 		return X86_64Stacks.getFrameAccessor(sfp);
 	}
+	// TODO[cleanup]: a frame accessor should be able to obtain its corresponding stack
+	def getFrameAccessorOfStack(stack: X86_64Stack) -> X86_64FrameAccessor {
+		return X86_64Stacks.getFrameAccessorOfStack(sfp, stack);
+	}
 }
 type SpcResultForStub(wf: WasmFunction, entrypoint: Pointer, thrown: Throwable) #unboxed { }
 class TargetHandlerDest(is_dummy: bool) {


### PR DESCRIPTION
This PR adds a stack-dependent version of `getFrameAccessorOfStack`, which should be used instead of the one that defaults to using the `curStack` after stack-switching has been implemented.