### PR TITLE
[virgil] Fixed constructor type parameter issue

### DIFF
--- a/src/engine/compiler/CompilerOptions.v3
+++ b/src/engine/compiler/CompilerOptions.v3
@@ -3,7 +3,7 @@
 
 // Parses command-line options that configure an engine.
 component CompilerOptions {
-	def JIT_FILTER = Option.new<DeclFilter>("jit-filter", null, DeclFilters.parseString);
+	def JIT_FILTER = Option<DeclFilter>.new("jit-filter", null, DeclFilters.parseString);
 	var group: OptionGroup;
 
 	new() {

--- a/src/util/OptionsRegistry.v3
+++ b/src/util/OptionsRegistry.v3
@@ -52,7 +52,7 @@ class OptionGroup(name: string, o: BasicOptions) {
 	var list: List<OptionGroupEntry>;
 
 	def newDeclFilterOption(name: string, help: string) -> Option<DeclFilter> {
-		var r = Option.new<DeclFilter>(name, null, DeclFilters.parseString);
+		var r = Option<DeclFilter>.new(name, null, DeclFilters.parseString);
 		return add(o.add(r), "=<function patterns>", help);
 	}
 	def newIntOption(name: string, defval: int, help: string) -> Option<int> {


### PR DESCRIPTION
This PR changes the syntax for calling a constructor with type parameters, in response to the relevant changes to Virgil earlier today.