### PR TITLE
Add a debugger feature to print 64-bit words in memory.

### DIFF
--- a/src/monitors/DebugMonitor.v3
+++ b/src/monitors/DebugMonitor.v3
@@ -39,6 +39,7 @@ type DbgCommand {
 	case Continue;
 	case List;
 	case Set(local_idx: int, value: Value);
+	case Print(index: int);
 	case Unknown(cmd: string);
 }
 
@@ -112,12 +113,14 @@ class DebuggerParser {
 			return DbgCommand.Info(parseInfo(args));
 		} else if (Strings.equal(name, "disable")) {
 			return DbgCommand.DisableBreakpoint(Ints.parseDecimal(args, 0).1);
-		} else if (Strings.equal(name, "enable")) { 
+		} else if (Strings.equal(name, "enable")) {
 			return DbgCommand.EnableBreakpoint(Ints.parseDecimal(args, 0).1);
 		} else if (Strings.equal(name, "backtrace") || Strings.equal(name, "bt")) {
 			return DbgCommand.Backtrace;
 		} else if (Strings.equal(name, "set")) {
 			return parseSet(args);
+		} else if (Strings.equal(name, "print") || Strings.equal(name, "p")) {
+			return DbgCommand.Print(Ints.parseDecimal(args, 0).1);
 		}
 		return DbgCommand.Unknown(command);
 	}
@@ -342,6 +345,22 @@ component Debugger {
 					}
 					OUT.ln();
 					depth++;
+				}
+				return true;
+			}
+			Print(index) => {
+				var val = instance.memories[0].range_ol_64(u64.!(index), 8);
+				if (val.ok()) {
+					OUT.put1("memory[0][%d] (u64) = ", index)
+						.put1("%x", val.result[0])
+						.put1("%x", val.result[1])
+						.put1("%x", val.result[2])
+						.put1("%x", val.result[3])
+						.put1("%x", val.result[4])
+						.put1("%x", val.result[5])
+						.put1("%x", val.result[6])
+						.put1("%x", val.result[7])
+						.ln();
 				}
 				return true;
 			}


### PR DESCRIPTION
This one is a little underbaked as yet, but I wanted to share the idea already.

It should have:
* The ability to print from other memories
* The ability to print i32, i64, u32, u64 types at least. (Reading little-endian int data out of hex digits is 🤡 )

But maybe you have some ideas what the interface should be for selecting those? I was thinking maybe `p [<memory>] [<type>] <address>` where <memory> is the index of the memory object, and would default to 0. And <type> could be e.g. `i32`, etc, or it could be `raw` or `hex` or something to indicate you want the raw bytes in hex. It would default to raw.

I must say, these two debugger features I'm PRing were _crucial_ to pinning down my vexing bug in the Go compiler today. I was finally able to inspect the shadow stack at each point and see where I was going wrong. :pray: