### PR TITLE
[wali] Fix argument types for fcntl, poll, ppoll, prctl syscall imports

### DIFF
--- a/src/engine/SigCache.v3
+++ b/src/engine/SigCache.v3
@@ -25,6 +25,8 @@ component SigCache {
 	def arr_liilli: Array<ValueType> = [ValueType.I64, ValueType.I32, ValueType.I32, ValueType.I64, ValueType.I64, ValueType.I32];
 	def arr_li: Array<ValueType> = [ValueType.I64, ValueType.I32];
 	def arr_illl: Array<ValueType> = [ValueType.I32, ValueType.I64, ValueType.I64, ValueType.I64];
+	def arr_illll: Array<ValueType> = [ValueType.I32, ValueType.I64, ValueType.I64, ValueType.I64, ValueType.I64];
+	def arr_iliii: Array<ValueType> = [ValueType.I32, ValueType.I64, ValueType.I32, ValueType.I32, ValueType.I32];
 	def arr_iiili: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I64, ValueType.I32];
 	def arr_iiiilli: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I64, ValueType.I64, ValueType.I32];
 	def arr_iiiiillii: Array<ValueType> = [ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I64, ValueType.I64, ValueType.I32, ValueType.I32];
@@ -114,6 +116,8 @@ component SigCache {
 	def liilli_l = S(arr_liilli, arr_l);
 	def li_l = S(arr_li, arr_l);
 	def illl_l = S(arr_illl, arr_l);
+	def illll_l = S(arr_illll, arr_l);
+	def iliii_l = S(arr_iliii, arr_l);
 	def iill_l = S(arr_iill, arr_l);
 	def ill_i = S(arr_ill, arr_i);
 	def ili_l = S(arr_ili, arr_l);

--- a/src/modules/HostModuleBuilder.v3
+++ b/src/modules/HostModuleBuilder.v3
@@ -57,6 +57,7 @@ class HostModuleBuilderOf<C>(name: string, tnew: void -> C, tbind: (C, Instance)
 	def func_ii_l(name: string, hfp: C -> (int, int) -> long) -> this			{ module.adapters[name] = fun c => HostAdapters.ii_l(hfp(c)); }
 	def func_il_l(name: string, hfp: C -> (int, long) -> long) -> this			{ module.adapters[name] = fun c => HostAdapters.il_l(hfp(c)); }
 	def func_iii_l(name: string, hfp: C -> (int, int, int) -> long) -> this			{ module.adapters[name] = fun c => HostAdapters.iii_l(hfp(c)); }
+	def func_iil_l(name: string, hfp: C -> (int, int, long) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.iil_l(hfp(c)); }
 	def func_iiii_l(name: string, hfp: C -> (int, int, int, int) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.iiii_l(hfp(c)); }
 	def func_illi_l(name: string, hfp: C -> (int, long, long, int) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.illi_l(hfp(c)); }
 	def func_iiil_l(name: string, hfp: C -> (int, int, int, long) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.iiil_l(hfp(c)); }
@@ -65,6 +66,8 @@ class HostModuleBuilderOf<C>(name: string, tnew: void -> C, tbind: (C, Instance)
 	def func_iiiiil_l(name: string, hfp: C -> (int, int, int, int, int, long) -> long) -> this	{ module.adapters[name] = fun c => HostAdapters.iiiiil_l(hfp(c)); }
 	def func_iiiiiiii_l(name: string, hfp: C -> (int, int, int, int, int, int, int, int) -> long) { module.adapters[name] = fun c => HostAdapters.iiiiiiii_l(hfp(c)); }
 	def func_ili_l(name: string, hfp: C -> (int, long, int) -> long) -> this		{ module.adapters[name] = fun c => HostAdapters.ili_l(hfp(c)); }
+	def func_iliii_l(name: string, hfp: C -> (int, long, int, int, int) -> long) -> this	{ module.adapters[name] = fun c => HostAdapters.iliii_l(hfp(c)); }
+	def func_illll_l(name: string, hfp: C -> (int, long, long, long, long) -> long) -> this	{ module.adapters[name] = fun c => HostAdapters.illll_l(hfp(c)); }
 	
 	// Adds a post-processing function for an instance, e.g. to examine its exports.
 	def postprocess(f: (C, ErrorGen, Instance) -> void) -> this {

--- a/src/modules/wali/x86-64-linux/WaliModule.v3
+++ b/src/modules/wali/x86-64-linux/WaliModule.v3
@@ -18,7 +18,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iii_l	("SYS_sched_getaffinity",	fun i => i.sched_getaffinity)
 	.func_i_l	("SYS_set_tid_address",		fun i => i.set_tid_address)
 	.func_iiiiil_l	("SYS_mmap",			fun i => i.mmap)
-	.func_iii_l	("SYS_fcntl",			fun i => i.fcntl)
+	.func_iil_l	("SYS_fcntl",			fun i => i.fcntl)
 	.func_i_l	("SYS_sysinfo",			fun i => i.sysinfo)
 	.func_i_l	("SYS_brk",			fun i => i.brk)
 	.func_iiii_l	("SYS_prlimit64",		fun i => i.prlimit64)
@@ -35,7 +35,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iiii_l	("SYS_rt_sigprocmask",		fun i => i.rt_sigprocmask)
 	.func_ii_l	("SYS_tkill",			fun i => i.tkill)
 	.func_iiii_l	("SYS_rt_sigaction",		fun i => i.rt_sigaction)
-	.func_iii_l	("SYS_poll",			fun i => i.poll)
+	.func_ili_l	("SYS_poll",			fun i => i.poll)
 	.func_l_l	("SYS_rt_sigreturn",		fun i => i.rt_sigreturn)
 	.func_iiil_l	("SYS_pread64",			fun i => i.pread64)
 	.func_iiil_l	("SYS_pwrite64",		fun i => i.pwrite64)
@@ -165,7 +165,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_v_l	("SYS_vhangup",			fun i => i.vhangup)
 	.func_v_l	("SYS_modify_ldt",		fun i => i.modify_ldt)
 	.func_ii_l	("SYS_pivot_root",		fun i => i.pivot_root)
-	.func_iiiii_l	("SYS_prctl",			fun i => i.prctl)
+	.func_illll_l	("SYS_prctl",			fun i => i.prctl)
 	.func_v_l	("SYS_arch_prctl",		fun i => i.arch_prctl)
 	.func_i_l	("SYS_adjtimex",		fun i => i.adjtimex)
 	.func_ii_l	("SYS_setrlimit",		fun i => i.setrlimit)
@@ -272,7 +272,7 @@ def unused_ = HostModuleBuilderOf<WaliInstance>.new("wali", WaliInstance.new, Wa
 	.func_iiii_l	("SYS_fchmodat",		fun i => i.fchmodat)
 	.func_iiii_l	("SYS_faccessat",		fun i => i.faccessat)
 	.func_iiiiii_l	("SYS_pselect6",		fun i => i.pselect6)
-	.func_iiiii_l	("SYS_ppoll",			fun i => i.ppoll)
+	.func_iliii_l	("SYS_ppoll",			fun i => i.ppoll)
 	.func_i_l	("SYS_unshare",			fun i => i.unshare)
 	.func_ii_l	("SYS_set_robust_list",		fun i => i.set_robust_list)
 	.func_iii_l	("SYS_get_robust_list",		fun i => i.get_robust_list)
@@ -528,7 +528,7 @@ class WaliInstance {
 	    return long.view(final_addr - Pointer.NULL);
 	}
 	//========================================================================================
-	def fcntl(fd: int, cmd: int, arg: int) => TODO_UNIMPLEMENTED;
+	def fcntl(fd: int, cmd: int, arg: long) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def sysinfo(info_ptr: int) -> long {
 		var ireg = getRegion(info_ptr, wali_sysinfo.size);
@@ -611,7 +611,7 @@ class WaliInstance {
 	//========================================================================================
 	def rt_sigaction(sig: int, act: int, oact: int, sigsetsize: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def poll(fds: int, nfds: int, timeout: int) => TODO_UNIMPLEMENTED;
+	def poll(fds: int, nfds: long, timeout: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def rt_sigreturn(unused: long) => TODO_UNIMPLEMENTED;
 	//========================================================================================
@@ -1127,7 +1127,7 @@ class WaliInstance {
 	//========================================================================================
 	def pivot_root(new_root: int, put_old: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def prctl(option: int, arg2: int, arg3: int, arg4: int, arg5: int) -> long {
+	def prctl(option: int, arg2: long, arg3: long, arg4: long, arg5: long) -> long {
 		return Linux.syscall(LinuxConst.SYS_prctl, (option, arg2, arg3, arg4, arg5)).0;
 	}
 	//========================================================================================
@@ -1429,7 +1429,7 @@ class WaliInstance {
 	//========================================================================================
 	def pselect6(nfds: int, readfds: int, writefds: int, exceptfds: int, timeout: int, sigmask: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
-	def ppoll(buf: int, a2: int, timeout: int, sigmask: int, len: int) => TODO_UNIMPLEMENTED;
+	def ppoll(buf: int, a2: long, timeout: int, sigmask: int, len: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================
 	def unshare(unshare_flags: int) => TODO_UNIMPLEMENTED;
 	//========================================================================================

--- a/src/util/HostAdapters.v3
+++ b/src/util/HostAdapters.v3
@@ -53,6 +53,7 @@ component HostAdapters {
 	def ii_l(func:		(int, int) -> long) =>						HostFunc(SigCache.ii_l,		fun a => rl(func(ui(a[0]), ui(a[1]))));
 	def il_l(func:		(int, long) -> long) =>						HostFunc(SigCache.il_l,		fun a => rl(func(ui(a[0]), ul(a[1]))));
 	def iii_l(func:		(int, int, int) -> long) =>					HostFunc(SigCache.iii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]))));
+	def iil_l(func:		(int, int, long) -> long) =>					HostFunc(SigCache.iil_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ul(a[2]))));
 	def iiii_l(func:	(int, int, int, int) -> long) =>				HostFunc(SigCache.iiii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]))));
 	def illi_l(func:	(int, long, long, int) -> long) =>				HostFunc(SigCache.illi_l,	fun a => rl(func(ui(a[0]), ul(a[1]), ul(a[2]), ui(a[3]))));
 	def iiiii_l(func:	(int, int, int, int, int) -> long) =>				HostFunc(SigCache.iiiii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]))));
@@ -60,6 +61,8 @@ component HostAdapters {
 	def iiiiil_l(func:	(int, int, int, int, int, long) -> long) =>			HostFunc(SigCache.iiiiil_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]), ul(a[5]))));
 	def iiiiiiii_l(func:	(int, int, int, int, int, int, int, int) -> long) =>		HostFunc(SigCache.iiiiiiii_l,	fun a => rl(func(ui(a[0]), ui(a[1]), ui(a[2]), ui(a[3]), ui(a[4]), ui(a[5]), ui(a[6]), ui(a[7]))));
 	def ili_l(func:		(int, long, int) -> long) =>					HostFunc(SigCache.ili_l,	fun a => rl(func(ui(a[0]), ul(a[1]), ui(a[2]))));
+	def iliii_l(func:	(int, long, int, int, int) -> long) =>				HostFunc(SigCache.iliii_l,	fun a => rl(func(ui(a[0]), ul(a[1]), ui(a[2]), ui(a[3]), ui(a[4]))));
+	def illll_l(func:	(int, long, long, long, long) -> long) =>			HostFunc(SigCache.illll_l,	fun a => rl(func(ui(a[0]), ul(a[1]), ul(a[2]), ul(a[3]), ul(a[4]))));
 
 	def uuu_r(func: (u32, u32, u32) -> HostResult) => 					HostFunc(SigCache.iii_i,		fun a => func(uu(a[0]), uu(a[1]), uu(a[2])));
 	def iuu_r(func: (int, u32, u32) -> HostResult) => 					HostFunc(SigCache.iii_i,		fun a => func(ui(a[0]), uu(a[1]), uu(a[2])));


### PR DESCRIPTION
WALI musl declares several syscall args as `unsigned long`, which is i64 on 64-bit Linux. Wizard had them as `int` (i32), causing import signature mismatches at link time for any module that uses these syscalls.

- SYS_fcntl: 3rd arg int -> long
- SYS_poll:  2nd arg int -> long (nfds_t)
- SYS_ppoll: 2nd arg int -> long
- SYS_prctl: args 2-5 int -> long

Adds three new helpers (func_iil_l, func_iliii_l, func_illll_l) to HostModuleBuilder/HostAdapters/SigCache to support these signatures.

These signature changes were identified with Claude's help while debugging WALI test failures.