### PR TITLE
[stack-switching] Stricter value type reads

### DIFF
--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -214,7 +214,7 @@ component X86_64Runtime {
 		return null;
 	}
 	def runtime_doCast(stack: X86_64Stack, instance: Instance, nullable: byte, ht_val: int) -> bool {
-		var val = stack.peekRef();
+		var val = stack.peekValueRef();
 		return Runtime.cast(instance, (nullable & 2) != 0, ht_val, val);
 	}
 	def runtime_checkFuncSigSubtyping(instance: Instance, sig_index: u31, func: Function) -> Function {

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -401,7 +401,7 @@ class X86_64Stack extends WasmStack {
 			Ref(nullable, heap) => match(heap) { // TODO: tighter checking of ref value tags
 				ANY, EXTERN, EQ, I31 => return popRef();
 				Func => return Value.Ref(popFunction());
-				Cont => return Value.Cont(popContinuation());
+				Cont, NOCONT => return Value.Cont(popContinuation());
 				_ => return Value.Ref(popObject());
 			}
 			_ => fatal(Strings.format1("unexpected type: %s", t.name));

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -537,7 +537,7 @@ class X86_64Stack extends WasmStack {
 			BpTypeCode.F32.code => return Value.F32(vp.load<u32>());
 			BpTypeCode.F64.code => return Value.F64(vp.load<u64>());
 			BpTypeCode.V128.code => return Value.V128(vp.load<u64>(), (vp + 8).load<u64>());
-			BpTypeCode.CONTREF.code => { // == Continuations.valueTag
+			BpTypeCode.CONTREF.code => {
 				if (FeatureDisable.unboxedConts) { // boxed: 8-byte Continuation ref
 					return Value.Cont(vp.load<Continuation>());
 				} else { // unboxed: (stack, version) pair

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -398,7 +398,7 @@ class X86_64Stack extends WasmStack {
 				return Value.V128(low, high);
 			}
 			Host => return Value.Ref(popObject());
-			Ref(nullable, heap) => match(heap) { // TODO: tighter checking of ref value tags
+			Ref(nullable, heap) => match(heap) {
 				ANY, EXTERN, EQ, I31 => return popRef();
 				Func => return Value.Ref(popFunction());
 				Cont, NOCONT => return Value.Cont(popContinuation());

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -399,7 +399,11 @@ class X86_64Stack extends WasmStack {
 			}
 			Host => return Value.Ref(popObject());
 			Ref(nullable, heap) => match(heap) {
-				ANY, EXTERN, EQ, I31 => return popRef();
+				ANY, EXTERN, EQ, I31 => {
+					var val = peekRef();
+					vsp += -(valuerep.slot_size);
+					return val;
+				}
 				Func => return Value.Ref(popFunction());
 				Cont, NOCONT => return Value.Cont(popContinuation());
 				_ => return Value.Ref(popObject());
@@ -421,11 +425,6 @@ class X86_64Stack extends WasmStack {
 			vsp += -(valuerep.slot_size);
 			return Continuations.continuationWithVersion(stack, version);
 		}
-	}
-	def popRef() -> Value {
-		var val = peekRef();
-		vsp += -(valuerep.slot_size);
-		return val;
 	}
 	def peekRef() -> Value {
 		if (valuerep.tagged) {

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -400,7 +400,7 @@ class X86_64Stack extends WasmStack {
 			Host => return Value.Ref(popObject());
 			Ref(nullable, heap) => match(heap) {
 				ANY, EXTERN, EQ, I31 => {
-					var val = peekRef();
+					var val = peekValueRef();
 					vsp += -(valuerep.slot_size);
 					return val;
 				}
@@ -426,7 +426,8 @@ class X86_64Stack extends WasmStack {
 			return Continuations.continuationWithVersion(stack, version);
 		}
 	}
-	def peekRef() -> Value {
+	// Peek a {Value.Ref} on the value stack. Does not work on continuations.
+	def peekValueRef() -> Value {
 		if (valuerep.tagged) {
 			var got = peekTag();
 			if (!valuerep.maybeRefTag(got)) fatal(Strings.format1("value stack tag mismatch, expected ref, got %x", got));

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -428,10 +428,12 @@ class X86_64Stack extends WasmStack {
 		return val;
 	}
 	def peekRef() -> Value {
-		// TODO[ss]: filter out a Value.Cont after giving it its own BpTypeCode in storage
 		if (valuerep.tagged) {
 			var got = peekTag();
 			if (!valuerep.maybeRefTag(got)) fatal(Strings.format1("value stack tag mismatch, expected ref, got %x", got));
+			if (got == Continuations.valueTag || got == BpTypeCode.NULLCONTREF.code) {
+				fatal(Strings.format1("value stack tag mismatch, expected ref, got cont tag %x", got));
+			}
 		}
 		return readI31OrObject(vsp + (valuerep.tag_size - valuerep.slot_size));
 	}
@@ -461,6 +463,9 @@ class X86_64Stack extends WasmStack {
 		if (valuerep.tagged) {
 			var got = peekTag();
 			if (!valuerep.maybeRefTag(got)) fatal(Strings.format1("value stack tag mismatch, expected ref, got %x", got));
+			if (got == Continuations.valueTag || got == BpTypeCode.NULLCONTREF.code) {
+				fatal(Strings.format1("value stack tag mismatch, expected ref, got cont tag %x", got));
+			}
 		}
 		vsp += -(valuerep.slot_size);
 		var val = (vsp + valuerep.tag_size).load<u64>();
@@ -532,7 +537,7 @@ class X86_64Stack extends WasmStack {
 			BpTypeCode.F32.code => return Value.F32(vp.load<u32>());
 			BpTypeCode.F64.code => return Value.F64(vp.load<u64>());
 			BpTypeCode.V128.code => return Value.V128(vp.load<u64>(), (vp + 8).load<u64>());
-			BpTypeCode.CONTREF.code => {
+			BpTypeCode.CONTREF.code => { // == Continuations.valueTag
 				if (FeatureDisable.unboxedConts) { // boxed: 8-byte Continuation ref
 					return Value.Cont(vp.load<Continuation>());
 				} else { // unboxed: (stack, version) pair


### PR DESCRIPTION
This PR makes sure the read paths of `REF` in `X86_64Stack` reject continuation type due to it being specialized.