### PR TITLE
Runtime cast refactor

### DIFF
--- a/src/engine/Runtime.v3
+++ b/src/engine/Runtime.v3
@@ -392,6 +392,7 @@ component Runtime {
 	}
 	def castI31(instance: Instance, ht_val: int) -> bool {
 		match (ht_val) {
+			BpHeapTypeCode.EXTERN.val,
 			BpHeapTypeCode.ANY.val,
 			BpHeapTypeCode.EQ.val,
 			BpHeapTypeCode.I31.val => return true;

--- a/src/engine/Runtime.v3
+++ b/src/engine/Runtime.v3
@@ -377,12 +377,7 @@ component Runtime {
 	}
 	def cast(instance: Instance, nullable: bool, ht_val: int, val: Value) -> bool {
 		match (val) {
-			Ref(obj) => {
-				match (obj) {
-					null => return nullable;
-					_ => return castObject(instance, ht_val, obj);
-				}
-			}
+			Ref(obj) => return if(obj == null, nullable, castObject(instance, ht_val, obj));
 			I31(val) => {
 				match (ht_val) {
 					BpHeapTypeCode.EXTERN.val,
@@ -395,6 +390,15 @@ component Runtime {
 			_ => return false;
 		}
 	}
+	def castI31(instance: Instance, ht_val: int) -> bool {
+		match (ht_val) {
+			BpHeapTypeCode.ANY.val,
+			BpHeapTypeCode.EQ.val,
+			BpHeapTypeCode.I31.val => return true;
+			_ => return false;
+		}
+	}
+	// caller do nullable
 	def castObject(instance: Instance, ht_val: int, obj: Object) -> bool {
 		match (ht_val) {
 			BpHeapTypeCode.FUNC.val => return Function.?(obj);

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -2053,7 +2053,7 @@ class V3Interpreter extends WasmStack {
 	private def doRuntimeCast(instance: Instance, nullable: bool, ht_val: int, val: Value) -> bool {
 		match (val) {
 			Ref(obj) => return if(obj == null, nullable, Runtime.castObject(instance, ht_val, obj));
-			I31(val) => return Runtime.castI31(instance, ht_val);
+			I31 => return Runtime.castI31(instance, ht_val);
 			_ => return false;
 		}
 	}

--- a/src/engine/v3/V3Interpreter.v3
+++ b/src/engine/v3/V3Interpreter.v3
@@ -892,7 +892,7 @@ class V3Interpreter extends WasmStack {
 			REF_TEST_NULL => {
 				var nullable = (opcode == Opcode.REF_TEST_NULL);
 				var ht_val = codeptr.read_sleb32();
-				var result = Runtime.cast(frame.func.instance, nullable, ht_val, pop());
+				var result = doRuntimeCast(frame.func.instance, nullable, ht_val, pop());
 				pushz(result);
 			}
 			REF_CAST,
@@ -900,14 +900,14 @@ class V3Interpreter extends WasmStack {
 				var nullable = (opcode == Opcode.REF_CAST_NULL);
 				var ht_val = codeptr.read_sleb32();
 				var val = pop();
-				var result = Runtime.cast(frame.func.instance, nullable, ht_val, val);
+				var result = doRuntimeCast(frame.func.instance, nullable, ht_val, val);
 				if (!result) trap(TrapReason.FAILED_CAST);
 				else push(val);
 			}
 			BR_ON_CAST => {
 				var imm = codeptr.read_BrOnCastImm();
 				var val = pop();
-				var result = Runtime.cast(frame.func.instance, imm.null2(), imm.ht2, val);
+				var result = doRuntimeCast(frame.func.instance, imm.null2(), imm.ht2, val);
 				push(val);
 				if (result) codeptr.at(doGoto(pc));
 				else doFallthru();
@@ -915,7 +915,7 @@ class V3Interpreter extends WasmStack {
 			BR_ON_CAST_FAIL => {
 				var imm = codeptr.read_BrOnCastImm();
 				var val = pop();
-				var result = Runtime.cast(frame.func.instance, imm.null2(), imm.ht2, val);
+				var result = doRuntimeCast(frame.func.instance, imm.null2(), imm.ht2, val);
 				push(val);
 				if (!result) codeptr.at(doGoto(pc));
 				else doFallthru();
@@ -2048,6 +2048,13 @@ class V3Interpreter extends WasmStack {
 			}
 			out.ln();
 			last_fp = f.fp;
+		}
+	}
+	private def doRuntimeCast(instance: Instance, nullable: bool, ht_val: int, val: Value) -> bool {
+		match (val) {
+			Ref(obj) => return if(obj == null, nullable, Runtime.castObject(instance, ht_val, obj));
+			I31(val) => return Runtime.castI31(instance, ht_val);
+			_ => return false;
 		}
 	}
 }

--- a/src/engine/x86-64/X86_64Runtime.v3
+++ b/src/engine/x86-64/X86_64Runtime.v3
@@ -214,8 +214,12 @@ component X86_64Runtime {
 		return null;
 	}
 	def runtime_doCast(stack: X86_64Stack, instance: Instance, nullable: byte, ht_val: int) -> bool {
-		var val = stack.peekValueRef();
-		return Runtime.cast(instance, (nullable & 2) != 0, ht_val, val);
+		var isI31 = stack.topObjectIsI31();
+		if (isI31) return Runtime.castI31(instance, ht_val);
+		else {
+			var obj = stack.peekObject();
+			return if(obj == null, (nullable & 2) != 0, Runtime.castObject(instance, ht_val, obj));
+		}
 	}
 	def runtime_checkFuncSigSubtyping(instance: Instance, sig_index: u31, func: Function) -> Function {
 		var expected = SigDecl.!(instance.heaptypes[sig_index]);	// cast not strictly necessary; for debugging

--- a/src/engine/x86-64/X86_64Stack.v3
+++ b/src/engine/x86-64/X86_64Stack.v3
@@ -459,7 +459,7 @@ class X86_64Stack extends WasmStack {
 		vsp += -(valuerep.slot_size);
 		return (vsp + valuerep.tag_size).load<u64>();
 	}
-	def popObject() -> Object {
+	def peekObject() -> Object {
 		if (valuerep.tagged) {
 			var got = peekTag();
 			if (!valuerep.maybeRefTag(got)) fatal(Strings.format1("value stack tag mismatch, expected ref, got %x", got));
@@ -467,10 +467,15 @@ class X86_64Stack extends WasmStack {
 				fatal(Strings.format1("value stack tag mismatch, expected ref, got cont tag %x", got));
 			}
 		}
-		vsp += -(valuerep.slot_size);
-		var val = (vsp + valuerep.tag_size).load<u64>();
+		var slot_ptr = vsp + -(valuerep.slot_size);
+		var val = (slot_ptr + valuerep.tag_size).load<u64>();
 		if ((val & 1) == 1) fatal("expected ref, got i31");
-		return (vsp + valuerep.tag_size).load<Object>();
+		return (slot_ptr + valuerep.tag_size).load<Object>();
+	}
+	def popObject() -> Object {
+		var result = peekObject();
+		vsp += -(valuerep.slot_size);
+		return result;
 	}
 	def checkTopTag(tag: byte) -> byte {
 		if (!valuerep.tagged) return tag;
@@ -623,6 +628,12 @@ class X86_64Stack extends WasmStack {
 		if ((bits & 1) == 1) return Value.I31(u31.view(bits >> 1));
 		var obj = vp.load<Object>();
 		return Value.Ref(obj);
+	}
+	// Assuming the top object is a non-continuation reference, test for if it is a {Value.I31}.
+	def topObjectIsI31() -> bool {
+		var vp = vsp + (valuerep.tag_size - valuerep.slot_size);
+		var bits = vp.load<u64>();
+		return (bits & 1) == 1;
 	}
 	def popResult(rt: Array<ValueType>) -> Result {
 		var r = Array<Value>.new(rt.length);

--- a/src/monitors/ControlInstrumenter.v3
+++ b/src/monitors/ControlInstrumenter.v3
@@ -136,7 +136,12 @@ private class CiBrOnCastProbe(nullable: bool, ht_val: int, success_taken: bool) 
 	def fire(loc: DynamicLoc) -> ProbeAction {
 		var accessor = loc.frame.getFrameAccessor();
 		var instance = accessor.func().instance;
-		var result = Runtime.cast(instance, nullable, ht_val, accessor.getOperand(0));
+		var result: bool;
+		match (accessor.getOperand(0)) {
+			Ref(obj) => result = if(obj == null, nullable, Runtime.castObject(instance, ht_val, obj));
+			I31 => result = Runtime.castI31(instance, ht_val);
+			_ => result = false;
+		}
 		taken[if(result == success_taken, 0, 1)]++;
 		return ProbeAction.Continue;
 	}

--- a/src/monitors/LoopTraceMonitor.v3
+++ b/src/monitors/LoopTraceMonitor.v3
@@ -239,7 +239,12 @@ private class TraceBrOnCastProbe(trace: TraceBuffer, nullable: bool, ht_val: int
 		// XXX: introduce a utility for taken/not taken branches
 		var accessor = loc.frame.getFrameAccessor();
 		var instance = accessor.func().instance;
-		var result = Runtime.cast(instance, nullable, ht_val, accessor.getOperand(0));
+		var result: bool;
+		match (accessor.getOperand(0)) {
+			Ref(obj) => result = if(obj == null, nullable, Runtime.castObject(instance, ht_val, obj));
+			I31 => result = Runtime.castI31(instance, ht_val);
+			_ => result = false;
+		}
 		if (result == success_taken) trace.pushNotTaken();
 		else trace.pushTaken();
 		return ProbeAction.Continue;


### PR DESCRIPTION
This PR refactors `Runtime.cast` so that the `x86-64` paths performs runtime casting without allocating a `Value`.