### PR TITLE
Codex wrote: A monitor stack-depth @ suspend stats

### DIFF
--- a/doc/Monitors.md
+++ b/doc/Monitors.md
@@ -48,8 +48,17 @@ The available monitors and their options are as follows:
 | `memstats` |                                            | Monitors memory accesses and reports statistics per page of memory.                                 |
 | `opcodes`  |                                            | Reports the static and dynamic count of instructions, broken down by opcode.                        |
 | [`profile`](ProfileMonitor.md)  | `{depth=<num>\|calls=<function pattern*>}` | Collects performance profiling data, with options for depth or function pattern.                    |
+| `stackdepth` |                                          | Reports the distribution of Wasm stack depths observed at `suspend` instructions.                   |
 | `timeout`  | `{<num>}`                                  | Terminates program execution after a given number of instructions.                                  |
 | `tracepoints` | `{<func-filter>:min_pc..max_pc}`        | Traces a function's value stack at given locations.                                                 |
+
+### Stack depth at suspension
+
+The `stackdepth` monitor records the number of active Wasm frames immediately before each
+`suspend` instruction executes. Depth is one-based and local to the current stack segment;
+host frames and parent continuation segments are not included. Its text report includes a
+histogram, mean, mode, p50, p90, p99, and maximum. The global `-csv` option emits the histogram
+as comma-separated values.
 
 ## Debugger
 

--- a/src/monitors/StackDepthMonitor.v3
+++ b/src/monitors/StackDepthMonitor.v3
@@ -1,0 +1,128 @@
+// Copyright 2026 Wizard Authors. All rights reserved.
+// See LICENSE for details of Apache 2.0 license.
+
+// Records the Wasm stack depth whenever a suspend instruction is executed.
+def monitor_ = MonitorRegistry.add(
+	"stackdepth", "Reports Wasm stack depth at suspend instructions.",
+	StackDepthMonitor.new());
+
+class StackDepthMonitor extends Monitor {
+	def stats = StackDepthStats.new();
+	def probe = SuspendDepthProbe.new(stats);
+
+	def onParse(module: Module, err: ErrorGen) {
+		SuspendDepthInstrumenter.new(module, probe).run();
+	}
+
+	def onFinish(i: Instance, r: Result) {
+		if (MonitorOptions.CSV.val) reportStackDepthCSV(out, stats);
+		else reportStackDepthText(out, stats);
+	}
+}
+
+// Inserts the shared depth probe only at suspend instructions.
+class SuspendDepthInstrumenter extends BytecodeInstrumenter {
+	def probe: Probe;
+
+	new(module: Module, probe: Probe) super(module) { }
+
+	def visit_SUSPEND(tag: u31) {
+		insertProbeHere(probe);
+	}
+}
+
+class SuspendDepthProbe(stats: StackDepthStats) extends Probe {
+	def fire(dynamicLoc: DynamicLoc) -> ProbeAction {
+		// FrameAccessor.depth() is zero-based within the current stack segment.
+		stats.record(dynamicLoc.frame.getFrameAccessor().depth() + 1);
+		return ProbeAction.Continue;
+	}
+}
+
+class StackDepthStats {
+	var counts = Array<u64>.new(1);
+	var total: u64;
+	var sum: u64;
+	var max: int;
+
+	def record(depth: int) {
+		if (depth >= counts.length) counts = Arrays.grow(counts, depth + 1);
+		counts[depth]++;
+		total++;
+		sum += u64.view(depth);
+		if (depth > max) max = depth;
+	}
+
+	def mode() -> int {
+		var result = 0;
+		var highest = 0uL;
+		for (depth < counts.length) {
+			if (counts[depth] > highest) {
+				highest = counts[depth];
+				result = depth;
+			}
+		}
+		return result;
+	}
+
+	// Returns the nearest-rank percentile, where {percent} is in [1, 100].
+	def percentile(percent: u64) -> int {
+		if (total == 0) return 0;
+		// Split the calculation so {total * percent} cannot overflow.
+		var target = (total / 100uL) * percent;
+		target += ((total % 100uL) * percent + 99uL) / 100uL;
+		var cumulative = 0uL;
+		for (depth < counts.length) {
+			cumulative += counts[depth];
+			if (cumulative >= target) return depth;
+		}
+		return max;
+	}
+}
+
+def stackDepthTable = initStackDepthTable();
+def initStackDepthTable() -> TraceTable {
+	var t = TraceTable.new(["Depth", "Suspends", "Percent"]);
+	t.cells[0].set(8, Justification.RIGHT, Color.NONE);
+	t.cells[1].set(12, Justification.RIGHT, Color.COUNT);
+	t.cells[2].set(10, Justification.RIGHT, Color.COUNT);
+	return t;
+}
+
+def fillStackDepthRow(stats: StackDepthStats, depth: int) {
+	var count = stats.counts[depth];
+	stackDepthTable.cells[0].putd(depth);
+	stackDepthTable.cells[1].putd(count);
+	TraceUtil.renderPercent(stackDepthTable.cells[2], long.view(count), long.view(stats.total), 2);
+}
+
+def reportStackDepthText(out: TraceBuilder, stats: StackDepthStats) {
+	out.beginColor(Color.UNDERLINE).puts("stackdepth: Wasm stack depth at suspend").endColors().ln();
+	if (stats.total == 0) {
+		out.puts("  (no suspend instructions were executed)").ln();
+		return;
+	}
+	out.puts("suspends: ").putd(stats.total).puts(", mean: ");
+	TraceUtil.renderFraction(out, long.view(stats.sum), long.view(stats.total), 2);
+	out.puts(", mode: ").putd(stats.mode());
+	out.puts(", p50: ").putd(stats.percentile(50));
+	out.puts(", p90: ").putd(stats.percentile(90));
+	out.puts(", p99: ").putd(stats.percentile(99));
+	out.puts(", max: ").putd(stats.max).ln();
+	stackDepthTable.putTableHeader(out);
+	for (depth = 1; depth < stats.counts.length; depth++) {
+		if (stats.counts[depth] == 0) continue;
+		fillStackDepthRow(stats, depth);
+		stackDepthTable.putTableRow(out);
+	}
+	out.ln();
+}
+
+def reportStackDepthCSV(out: TraceBuilder, stats: StackDepthStats) {
+	stackDepthTable.putCsvHeader(out);
+	for (depth = 1; depth < stats.counts.length; depth++) {
+		if (stats.counts[depth] == 0) continue;
+		fillStackDepthRow(stats, depth);
+		stackDepthTable.putCsvRow(out);
+	}
+}

--- a/test/monitors/stackdepth.wat
+++ b/test/monitors/stackdepth.wat
@@ -1,0 +1,48 @@
+;; Stack-switching opcodes aren't accepted by `wat2wasm`; rebuild with the stack-switching spec interpreter:
+;;
+;; stack-switching/interpreter/wasm test/monitors/stackdepth.wat -o test/monitors/stackdepth.wasm
+(module
+  (type $f (func))
+  (type $c (cont $f))
+  (tag $yield)
+
+  ;; Suspends at depth 1 within its continuation stack segment.
+  (func $shallow
+    (suspend $yield)
+  )
+
+  ;; Suspends at depth 3 within its continuation stack segment.
+  (func $deep
+    (call $level1)
+  )
+  (func $level1
+    (call $level2)
+  )
+  (func $level2
+    (suspend $yield)
+  )
+
+  (elem declare func $shallow $deep)
+
+  (func (export "main") (result i32)
+    (block (result (ref null $c))
+      (resume $c (on $yield 0) (cont.new $c (ref.func $shallow)))
+      (ref.null $c)
+    )
+    (drop)
+
+    (block (result (ref null $c))
+      (resume $c (on $yield 0) (cont.new $c (ref.func $deep)))
+      (ref.null $c)
+    )
+    (drop)
+
+    (block (result (ref null $c))
+      (resume $c (on $yield 0) (cont.new $c (ref.func $deep)))
+      (ref.null $c)
+    )
+    (drop)
+
+    (i32.const 0)
+  )
+)

--- a/test/monitors/test.sh
+++ b/test/monitors/test.sh
@@ -33,6 +33,7 @@ else
         "profile_bytecode{switch_size=7,abstract_interpreter=true}"
         "alloc"
         "opcodes"
+        "stackdepth"
         "ssevent")
 fi
 

--- a/test/monitors/update-expected.sh
+++ b/test/monitors/update-expected.sh
@@ -26,6 +26,7 @@ else
         "globals"
         "memstats"
 	    "profile_bytecode{switch_size=16}"
+	    "stackdepth"
 	    "ssevent")
 fi
 


### PR DESCRIPTION
Take this with a grain of salt—but it seems pretty cool!

This monitor keeps a histogram of stack depths as they are when we suspend. This has been pretty useful for looking at stack depth as a parameter that affects the speed of suspend/resume cycles.