### PR TITLE
Fix two crashes in the R3 monitor

### DIFF
--- a/src/monitors/R3Monitor.v3
+++ b/src/monitors/R3Monitor.v3
@@ -224,8 +224,6 @@ private class EventHandler {
 					}
 					if (index_match_found) break;
 				}
-				if (!index_match_found)
-					System.error("R3MonitorError", "external call with table_get failed");
 			}
 			checkMemGrow(instance);
 			checkTableGrow(instance);
@@ -383,17 +381,17 @@ private class EventHandler {
 
 	private def alignShadowMemRange(mem: Memory, addr: u64, size: u64) {
 		var scanned_size: u64 = 0;
-		while (scanned_size <= size - 16) {
+		while (scanned_size + 16 <= size) {
 			alignShadowMemFixedRange(mem, addr, 16);
 			scanned_size += 16;
 			addr += 16;
 		}
-		if (scanned_size <= size - 8) {
+		if (scanned_size + 8 <= size) {
 			alignShadowMemFixedRange(mem, addr, 8);
 			scanned_size += 8;
 			addr += 8;
 		}
-		if (scanned_size <= size - 4) {
+		if (scanned_size + 4 <= size) {
 			alignShadowMemFixedRange(mem, addr, 4);
 			scanned_size += 4;
 			addr += 4;


### PR DESCRIPTION
- alignShadowMemRange: unsigned size - N underflows for size < N (any memory.copy shorter than 16 bytes), driving out-of-bounds shadow reads.
- onFuncEntry: don't error when the entered function is neither exported nor table-reachable (start functions; direct calls from excluded code).